### PR TITLE
docs(Research): 持久化全链路调研报告与工程方案

### DIFF
--- a/.agents/issue.md
+++ b/.agents/issue.md
@@ -21,3 +21,20 @@
 - **处理方式**：删除 package.json 的 `pnpm` 字段；在 `pnpm-workspace.yaml` 写入 `allowBuilds: { esbuild: true, '@vscode/vsce-sign': true, keytar: true }` 后重新 `pnpm install`，三个 postinstall 正常执行。
 - **后续防范**：pnpm 项目一律在 `pnpm-workspace.yaml` 管理构建脚本审批；新增含原生二进制的依赖时，需在此文件追加放行；CI 首次 `pnpm install` 后确认无 `ERR_PNPM_IGNORED_BUILDS`。
 - **同类问题影响**：所有 pnpm 11 工程；凡依赖 esbuild / keytar / @vscode/vsce-sign / prebuild-install 类原生模块的扩展。
+
+## #3 pnpm 11.9 要求 Node ≥ 22.13（CI 用 Node 20 崩溃）
+
+- **表因**：CI `Lint & Build` job 10s 内失败，日志 `Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite`，并告警 `This version of pnpm requires at least Node.js v22.13`。本地不暴露（本地用 Node 24）。
+- **根因**：pnpm 11.9 内部使用 Node 22.13+ 才有的 `node:sqlite` 内置模块；CI 工作流配置 `node-version: 20`，pnpm 启动即崩。
+- **处理方式**：CI 所有 job 的 `setup-node` 由 `node-version: 20` 升至 `node-version: 22`。
+- **后续防范**：pnpm ≥ 11 工程的 Node 基线须 ≥ 22.13；`engines.node`/CI/本地三者对齐（建议 22 LTS 或 24）；升级 pnpm 前查其 Node 版本要求（https://r.pnpm.io/comp）。
+- **同类问题影响**：所有 pnpm 11+ 的 CI/本地环境；node:sqlite 依赖的其他工具链。
+
+## #4 CI 集成测试 job 缺失扩展构建步骤
+
+- **表因**：CI `Test` job 集成测试报 `Activating extension 'threefish-ai.hyper-git' failed: Cannot find module '.../dist/extension.js'`；本地却通过。
+- **根因**：`test` job 仅跑 `test:unit` + `test:integration`，未执行 `node esbuild.js` 构建 `dist/extension.js`；test-electron 启动真实 VS Code 加载扩展（`main: ./dist/extension.js`）时找不到入口。本地因先前 `pnpm run package` 残留 dist/ 而误判通过。
+- **处理方式**：`test` job 在 `pnpm install` 后、测试前增加 `node esbuild.js`（或 `pnpm run compile`）构建 dist/。
+- **后续防范**：凡含 `@vscode/test-electron` 集成测试的 CI job，必须在测试前显式构建扩展产物；本地验证集成测试后清理 dist/ 以暴露该依赖；`.gitignore` 排除 dist/ 时注意 CI 需重建。
+- **同类问题影响**：所有 VS Code 扩展的 test-electron CI job；本地"能跑"但 CI 失败的构建产物缺失类问题。
+

--- a/.agents/knowledge-map.md
+++ b/.agents/knowledge-map.md
@@ -14,6 +14,12 @@
 - [引用规范 IEEE](./reference-specifications.md) — 文献引用格式与上标锚定。
 - [浏览器验证协议](./browser-validation.md) — OAuth/SSO 红线与 E2E 验证协议。
 
+## 项目文档（docs/）
+- [文档中心](../docs/README.md) — 文档与调研资产总索引。
+- [工程实施方案](../docs/architecture/engineering-plan.md) — 路径 B 架构 + M0-M5 里程碑（**开发蓝图**）。
+- [IDEA 功能复刻矩阵](../docs/requirements/idea-feature-matrix.md) — 56 功能点 / 8 组（**验收基线**）。
+- [调研报告](../docs/research/README.md) — SCM 集成 / 工程蓝图 / 发布 CI / AI 接缝四路循证报告。
+
 ## 架构分层（src/）
 > 依赖方向单向：`UI → Adapter → Engine`；`Agent` 以接口注入 `Engine`/`CommitPipeline`，不反向依赖 UI。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# Hyper Git 文档中心
+
+> 项目文档与调研资产索引。所有决策均循证（附 GitHub 源码路径 / 官方文档 URL）。
+
+## 工程方案与需求基线（高频引用）
+- [工程实施方案](./architecture/engineering-plan.md) — 全链路调研结论 + 路径 B 架构 + M0-M5 里程碑路线图 + 风险与验证（**开发蓝图**）。
+- [IDEA 功能复刻矩阵](./requirements/idea-feature-matrix.md) — 56 个原子功能点 / 8 组 + CheckinHandler 生命周期（**验收基线**）。
+
+## 调研报告（循证依据）
+- [02 · VS Code SCM API 与 vscode.git 集成路径](./research/02-vscode-scm-integration.md) — 路径 B 决策依据、SCM 稳定/proposed API 边界、changelist 模型映射。
+- [03 · VS Code 扩展工程蓝图](./research/03-extension-blueprint.md) — 技术栈决策、工程骨架、IDEA→VS Code UI 表面映射表。
+- [04 · 发布策略 + CI/CD](./research/04-publishing-cicd.md) — 双市场（Marketplace + OpenVSX）、CI 矩阵、版本治理、安全。
+- [05 · AI Agent 架构预留](./research/05-ai-agent-seams.md) — AI 接缝（ILlmProvider 等）+ IDEA CheckinHandler 对齐 + 渐进式引入路线。
+
+## 协作与规范
+- [AGENTS.md](../AGENTS.md) — 协作协议与工程行为准则。
+- [知识索引](../.agents/knowledge-map.md) · [Issue 记录](../.agents/issue.md) · [引用规范 IEEE](../.agents/reference-specifications.md)。

--- a/docs/architecture/engineering-plan.md
+++ b/docs/architecture/engineering-plan.md
@@ -1,0 +1,292 @@
+# Hyper Git — VS Code 扩展工程实施方案
+
+> 复刻 IntelliJ IDEA 社区版「Git 工具窗口 + Commit 提交窗口」全功能，并为未来 AI Agent 自主代理预留架构接缝。
+> 决策已与用户确认：**路径 B**（消费 `vscode.git` API + 自建 changelist registry + 独立视图容器）、扩展命名 **Hyper Git**、**双市场发布**、**AI 现仅预留接缝 + Null 实现、延后至 M5**。
+
+---
+
+## 0. Context（背景与目标）
+
+**为什么做**：IntelliJ IDEA 的统一 Git 工具窗口（顶部 `Commit/Shelf/Stash` 标签页 + Changes 变更树 + Commit Message 编辑区 + 提交前 Inspection）是 Java/全栈开发者高频依赖的工作流，但迁移到 VS Code 后只能用原生 Source Control 视图（无多 changelist、无忠实 Commit 窗口、无提交前检查流水线）。本项目目标是**在 VS Code 上 1:1 复刻该体验**，并在未来为 git 管理引入 AI Agent（提交信息生成 / 提交前代码审查 / 变更语义分组 / 冲突解决）。
+
+**当前状态**：仓库为全新 greenfield 工程（仅有 `.agents/` 文档脚手架与 AGENTS.md 协议，无源码 / 无 package.json / 无 README）。本方案从零搭建。
+
+**循证基线**（已读源码 / 官方文档交叉验证）：
+- IDEA 侧：56 个原子功能点 / 8 组 + `CheckinHandler` 11 个 hook 生命周期（`git4idea` + `vcs-api/vcs-impl` 源码）。
+- VS Code 侧：`vscode.git` 导出的稳定 `Repository` API（`extensions/git/src/api/git.d.ts` 已逐行复核）；`scmHistoryProvider`/`scmMultiDiffSource` 仍是 proposed API（上架禁用）；`SourceControlInputBoxValueProvider` 已删除。
+- IDEA 多 changelist 模型（active 概念 + 跨列表行级归属 `PartialLocalLineStatusTracker`）**无法**用原生 SCM group 1:1 表达 → 必须自建 changelist registry。
+
+---
+
+## 1. 核心架构决策（路径 B）
+
+| 决策项 | 结论 | 循证依据 |
+|---|---|---|
+| **git 操作底座** | 消费内置 `vscode.git` 扩展导出的 `API`（`getAPI(1)` → `Repository`），**不自调 git CLI、不重造状态机** | `git.d.ts` 已暴露 commit/add/revert/diff/blame/log/stash/branch/merge/rebase 全套；GitHub PR 扩展即此模式 |
+| **changelist 表达** | **自建 changelist registry**（仿 IDEA `ChangeListManager`），以 TreeView 渲染；**不**注册竞争性 SCM Provider | Track1：IDEA active 列表 + 跨列表行级归属，原生 SCM group 无法表达 |
+| **视图容器** | 活动栏新建独立视图容器 `hyper-git`，承载 Changes/Commit/Log/Branches/Shelf/Stash；**不接管/不替代原生 Source Control 视图**（避免双胞胎冲突） | Track2：注册独立 SCM 会与原生 git 视图并列混淆 |
+| **Commit 编辑器** | WebviewView 自绘（多行 / 模板 / Conventional Commits 校验 / Amend / Author / sign-off） | 原生 `SourceControlInputBox` 仅 `value` 字段，Provider 已删除 |
+| **Log 提交图** | Webview 自绘 SVG graph + 消费 `Repository.log()` | `scmHistoryProvider` 为 proposed，上架不可用 |
+| **Diff 预览** | 复用 `vscode.diff` + `api.toGitUri(uri,'HEAD')`（零成本） | Track2 §5.5 |
+| **发布** | 双市场（Marketplace + OpenVSX） | Cursor/Windsurf 走 OpenVSX；AI 受众主战场 |
+| **AI** | 现仅定义接缝 + Null 实现，实现延后 M5 | YAGNI + 复用 IDEA `CheckinHandler` 语义 |
+
+**架构总览（Mermaid，深色模式高对比）**：
+
+```mermaid
+flowchart TB
+    subgraph UI["UI 层 (自绘, adapter/ui)"]
+        direction LR
+        V1["Changes<br/>TreeView"]
+        V2["Commit<br/>WebviewView"]
+        V3["Log<br/>Webview graph"]
+        V4["Branches/Shelf/Stash<br/>TreeView"]
+    end
+    subgraph Adapter["Adapter 层 (唯一接触 vscode API)"]
+        GA["GitRepositoryAdapter<br/>封装 vscode.git Repository"]
+        CR["ChangelistRegistry<br/>(active/分组/持久化)"]
+        WV["WebviewHost<br/>postMessage 协议"]
+        DI["DiffContentProvider<br/>自定义 scheme"]
+    end
+    subgraph Engine["Engine 层 (纯逻辑, 零 vscode 依赖, 可单测)"]
+        M["领域模型<br/>FileChange/Changelist/Commit/Branch/Stash"]
+        DF["Diff/行级 patch<br/>(partial commit 基础)"]
+        CK["CommitPipeline<br/>(Checkin hook 责任链)"]
+        SM["Status 色映射<br/>M/A/D/U/R/C"]
+    end
+    subgraph Agent["Agent 层 (AI 接缝, 预留)"]
+        LLM["ILlmProvider"]
+        AI1["ICommitMessageProvider"]
+        AI2["IPreCommitInspector"]
+        AI3["IChangelistGrouper"]
+        AI4["IConflictResolver"]
+    end
+    VSCodeGIT[("vscode.git<br/>内置 Repository API")]
+    NATIVE[("原生 Source Control 视图<br/>不动, 共存")]
+
+    UI --> Adapter
+    Adapter --> Engine
+    Agent -. 读领域模型 / 注入 hook .-> Engine
+    Agent -. 读 .-> Adapter
+    Adapter --> VSCodeGIT
+    NATIVE -. 平行存在 .-> VSCodeGIT
+
+    classDef ui fill:#1f6feb,stroke:#4dabf7,stroke-width:2px,color:#fff
+    classDef ad fill:#7c3aed,stroke:#c4b5fd,stroke-width:2px,color:#fff
+    classDef eg fill:#0f766e,stroke:#5eead4,stroke-width:2px,color:#fff
+    classDef ag fill:#b45309,stroke:#fcd34d,stroke-width:2px,color:#fff
+    classDef ext fill:#444654,stroke:#8b8fa3,stroke-width:2px,color:#fff
+    class V1,V2,V3,V4 ui
+    class GA,CR,WV,DI ad
+    class M,DF,CK,SM eg
+    class LLM,AI1,AI2,AI3,AI4 ag
+    class VSCodeGIT,NATIVE ext
+```
+
+**依赖方向（单向，正交）**：`UI → Adapter → Engine`；`Agent` 以接口注入 `Engine`/`CommitPipeline`，不反向依赖 UI；`Engine` 零依赖 `vscode`（可被 Vitest 与未来 CLI 双复用，是项目核心 IP）。
+
+---
+
+## 2. 模块正交分解（工程骨架）
+
+```
+hyper-git/
+├── package.json              # Manifest + contributes（viewsContainers/views/commands/menus/configuration/keybindings）
+├── esbuild.js                # 沿用官方 esbuild-sample（CJS, external:['vscode']）
+├── tsconfig.json             # strict; @types/vscode 与 engines.vscode 最低版本对齐
+├── eslint.config.mjs         # flat config + typescript-eslint
+├── .prettierrc
+├── .npmrc                    # node-linker=hoisted（规避 vsce/pnpm hoisting）
+├── .vscodeignore             # 排除 src/tests/*.config
+├── .github/workflows/ci.yml  # lint→build→test 矩阵→package→publish
+├── media/                    # 图标 SVG + webview 前端产物（commit-view/log-graph）
+└── src/
+    ├── extension.ts          # 唯一入口：activate/deactivate，仅装配（DI 注册）
+    ├── engine/               # 【引擎层】纯领域逻辑，零 vscode 依赖
+    │   ├── model/            #   FileChange / Changelist / Commit / Branch / StashEntry / ConflictHunk
+    │   ├── diff/             #   diff 解析 + 行级 patch（partial commit 基础）
+    │   ├── commit/           #   CommitPipeline（Checkin hook 责任链，仿 IDEA CheckinHandler）
+    │   └── scm-mapping/      #   Status(M/A/D/U/R/C) → decorations 映射（纯函数）
+    ├── adapter/              # 【适配层】唯一接触 vscode API
+    │   ├── git-repository.ts #   GitRepositoryAdapter：封装 vscode.git Repository（add/commit/diff/log/stash/branch…）
+    │   ├── changelist-registry.ts # ChangelistRegistry：active 列表/分组/移动/持久化(workspaceState)
+    │   ├── tree/             #   TreeDataProvider：Changes / Branches / Shelf / Stash
+    │   ├── webview/          #   WebviewView 宿主：Commit 窗口 + Log 图（postMessage 协议）
+    │   ├── diff/             #   TextDocumentContentProvider：自定义 scheme 提供任意 ref 版本
+    │   ├── commands/         #   command 注册分发 + menu when-clause 上下文键
+    │   └── storage/          #   globalState/workspaceState/SecretStorage 封装
+    ├── agent/                # 【代理层】AI 接缝（预留，Null 实现）
+    │   ├── llm-provider.ts   #   ILlmProvider（模型来源抽象：vscodeLM/byok/openaiCompatible）
+    │   ├── commit-message.ts #   ICommitMessageProvider（生成 + Conventional Commits 校验）
+    │   ├── pre-commit.ts     #   IPreCommitInspector（对齐 IDEA beforeCheckin/CommitCheck）
+    │   ├── grouper.ts        #   IChangelistGrouper（语义分组）
+    │   ├── conflict.ts       #   IConflictResolver（三方合并建议）
+    │   └── chat-tools.ts     #   IChatToolRegistrar（M5 暴露 git 能力给 Agent）
+    ├── ui/                   # 【UI 层】webview 前端（独立 esbuild iife bundle → media/）
+    │   ├── commit-view/      #   Commit 窗口前端（多行编辑器 + 模板/校验/Amend/Author）
+    │   ├── log-graph/        #   Log 图渲染（SVG graph + 过滤）
+    │   └── shared/           #   共享组件
+    ├── shared/
+    │   └── protocol.ts       # 【单一事实源】webview↔host 消息类型契约（前后端共引）
+    └── infra/                # 日志（OutputChannel）/ 错误处理 / 事件总线 / 配置读取
+└── tests/
+    ├── unit/                 # Vitest：engine/* 与 diff/scm-mapping 纯逻辑（无 vscode 依赖）
+    ├── integration/          # @vscode/test-electron + Mocha：adapter/* 适配层
+    └── fixtures/             # 最小化 git 仓库 fixture
+```
+
+**职责边界**：`engine/` 零依赖 `vscode`（Vitest 可测、未来 CLI 可复用）；`adapter/` 是唯一接触 `vscode` API 的层；`agent/` 依赖 `engine/` 但不依赖 `adapter/`；`shared/protocol.ts` 是 webview↔host 消息类型唯一来源，杜绝 Split-Brain。
+
+---
+
+## 3. 关键复用点（Reuse-Driven，拒绝重复造轮子）
+
+| 复用对象 | 用途 | 来源 |
+|---|---|---|
+| `vscode.git` → `Repository` | 所有 git 操作（commit/add/revert/clean/restore/diff*/blame/log/createBranch/merge/rebase/createStash/applyStash/popStash/dropStash/fetch/pull/push/checkout） | `extensions/git/src/api/git.d.ts`（已逐行复核） |
+| `Repository.state.{indexChanges,workingTreeChanges,untrackedChanges,mergeChanges}` + `Status` 枚举 | 变更数据单一事实源 | 同上 |
+| `api.toGitUri(uri, ref)` | 构造任意 ref 版本的资源 Uri（diff 原始端） | 同上 |
+| `vscode.commands.executeCommand('vscode.diff', left, right, title)` | 文件 diff 预览（零成本，不自绘 diff） | VS Code 稳定 API |
+| `ThemeColor('gitDecoration.modifiedResourceForeground')` 等 | 文件状态色（深色模式一致） | 复用原生 token |
+| `@vscode/vsce` / `ovsx` | 打包 / 发布 | 官方工具 |
+| `@vscode/test-electron` | 集成测试 | 官方唯一推荐 |
+| `esbuild-sample` 模板 | 工程骨架零点（`esbuild.js` + scripts） | microsoft/vscode-extension-samples |
+| `HaaLeo/publish-vs-code-extension` Action | 一键双市场发布 | GitHub Marketplace |
+
+**消费 `vscode.git` API 的声明**：`package.json` 加 `"extensionDependencies": ["vscode.git"]`；TS 类型复制 `git.d.ts` 入仓；运行时 `getExtension<GitExtension>('vscode.git').activate().getAPI(1)`。
+
+---
+
+## 4. IDEA 功能复刻优先级矩阵
+
+> 基于 Track1 的 56 功能点，按价值×依赖×难度分入 P0(MVP)/P1(核心对齐)/P2(高级对齐)/P3(AI 增强)。完整 56 项明细见 [IDEA 功能复刻矩阵](../requirements/idea-feature-matrix.md)（后续验收的需求基线）。
+
+| 优先级 | 功能域 | 代表功能（来源 Track1 编号） |
+|---|---|---|
+| **P0 MVP** | Commit 窗口核心 | 统一窗口容器(#1)、Commit Message 多行编辑(#2 模板/#3 历史)、Commit / Commit and Push(#7)、Amend(#5)、Author/sign-off/skip-hooks(#6/#8/#9)、选择性勾选文件提交(#22)、本地 vs HEAD diff(#35)、Rollback/Discard(#51)、文件状态色 |
+| **P0 MVP** | Local Changes | 多 changelist(#15)、active changelist(#16)、新建/删除/重命名(#17-19)、Move changes(#20) |
+| **P1 核心** | Commit 检查流水线 | 提交前 Inspection 框架(#10，对接 VS Code Diagnostics)、Commit Checks 顺序闸门(#11)、CRLF/大文件预检(#12)、Conventional Commits 校验(#4，IDEA 无内置需自建 linter) |
+| **P1 核心** | Branches | 创建/检出/删除/重命名(#45/#46)、Merge/Rebase/Pull/Push/Fetch(#48)、Compare(#47) |
+| **P1 核心** | Stash + Diff | Stash apply/pop/drop(#29/#30)、Annotate(blame)(#37)、Show History(#38) |
+| **P2 高级** | Partial / 行级提交 | 按代码块提交(#23)、按行提交(#24)、Move Lines to Changelist(#25)——最难，仿 `PartialChangesUtil` |
+| **P2 高级** | Log 提交图 | graph 自绘(#39)、filter(#40)、cherry-pick/revert from log(#41/#42)、Undo Commit(#43) |
+| **P2 高级** | Shelf | 忠实 shelve/unshelve with conflict(#27/#28，patch 存储+三方合并)；MVP 先用 stash 近似 |
+| **P3 AI 增强** | （M5，接缝现已埋） | AI 提交信息生成、AI 提交前审查、AI 语义分组、AI 冲突解决、AI release notes、Chat Tools 暴露 git 能力 |
+
+---
+
+## 5. 里程碑路线图
+
+> 每个 M：交付物 / 验收标准 / 依赖。版本号遵循 Marketplace 偶数 minor=release、奇数 minor=pre-release 约定（如 `0.2.x` release / `0.3.x` pre-release）。
+
+**M0 — 脚手架 + CI（0.1.0 pre-release）**
+- 交付：pnpm 工程、esbuild、tsconfig、ESLint9、Vitest、`@vscode/test-electron`、`.github/workflows/ci.yml`（lint→build→test 矩阵 ubuntu/mac/win + xvfb→package vsix→artifact）、`.vscodeignore`、README 骨架、`shared/protocol.ts`。
+- 验收：`pnpm test`（单测+集成）< 3min 全绿；CI 三平台通过；`vsce package` 产 vsix。
+- 依赖：无。
+
+**M1 — Git Adapter + Changes TreeView（0.2.0）**
+- 交付：`GitRepositoryAdapter`（封装 `vscode.git` API）、`ChangelistRegistry`（active/分组/移动/`workspaceState` 持久化）、Changes TreeView（changelist 一级节点 + 文件叶子 + 状态色 `gitDecoration.*`）、文件单击触发 `vscode.diff` + `toGitUri('HEAD')`。
+- 验收：能读取真实仓库 `workingTreeChanges` 并渲染 changelist 树；新建/移动/删除 changelist 持久化重启仍在；单击文件弹出原生 diff。
+- 依赖：M0。
+
+**M2 — Commit 提交窗口（0.3.x pre-release）**
+- 交付：Commit WebviewView（多行编辑器 + 模板注入 + 历史选填 + Conventional Commits 实时校验 linter + Amend + Author + sign-off + skip-hooks 开关）、底部 Commit / Commit and Push 按钮、`CommitPipeline`（Checkin hook 责任链骨架，Null hooks）、AI 接缝 5 个接口 + Null 实现（`ILlmProvider`/`ICommitMessageProvider`/`IPreCommitInspector`/`IChangelistGrouper`/`IConflictResolver`）、`includedChangesChanged` 等价事件。
+- 验收：勾选文件→填 message→Commit 落库（调 `Repository.commit`）；Commit and Push 成功；Amend 修正上一提交；CC 不合规时有提示；hook 链可注入并阻断（用内置非 AI 检查如 TODO 验证）。
+- 依赖：M1。
+
+**M3 — Log 图 + Branches + Diff/Blame（0.4.0）**
+- 交付：Log Webview（SVG graph + 按作者/路径/日期过滤，消费 `Repository.log`）、cherry-pick/revert from log、Branches TreeView（create/checkout/delete/rename/compare/merge/rebase）、Annotate(blame)、Show History、Reset 对话框（soft/mixed/hard/keep）。
+- 验收：Log 图正确渲染拓扑；分支操作经真实 git 验证；blame 行级显示作者。
+- 依赖：M1、M2。
+
+**M4 — Shelf + Partial/行级提交 + Stash UI（Parity 收口，0.6.0）**
+- 交付：忠实 Shelf（patch 存储 + unshelve 三方合并）、行级 partial commit（仿 `PartialChangesUtil` + 行级 hunk staging）、Stash 完整 UI（apply/pop/drop/clear/keep-index）、Git Staging Area 模式开关。
+- 验收：shelve/unshelve with conflict 可解；单文件部分行可单独提交。
+- 依赖：M2、M3。
+
+**M5 — AI Agent（实现接缝，0.7.x pre-release）**
+- 交付：`ILlmProvider` 三实现（vscodeLM / byok-Ollama / openaiCompatible，配置驱动）、AI 提交信息生成（流式 + CC 校验）、AI 提交前代码审查（挂 `IPreCommitInspector`，可阻断）、AI 语义分组、AI 冲突解决（用户逐块确认）、`@hyper-git` Chat Participant + `languageModelTools`（`hyper_get_staged_diff`/`hyper_git_blame` 等暴露给任意 Agent）。
+- 验收：opt-in 开关启用后 ✨ 按钮出现；AI 审查能阻断不良提交；Chat 工具可被 Copilot Agent 调用。
+- 依赖：M2-M4。注：M5 起需 `engines.vscode` 评估上调（LM/Chat API 稳定版本要求）。
+
+---
+
+## 6. AI 集成架构预留点（现建接缝，M5 实现）
+
+> 对齐 IDEA `CheckinHandler` 生命周期（Track1 D 节：`beforeCheckin`/`CommitCheck.runCheck`/`includedChangesChanged`/`checkinSuccessful`/`checkinFailed`）。**只定义契约 + Null 实现，不引入 Copilot 依赖**（未启用 AI 用户零负担）。
+
+| 接缝（Agent 层） | 对齐 IDEA | 为何现在抽 |
+|---|---|---|
+| `ILlmProvider`（模型来源抽象） | — | **最关键**：未来切换 vscodeLM/byok/自带 key 的命脉；晚抽则所有 AI 调用散落、迁移成本爆炸 |
+| `ICommitMessageProvider` | （IDEA 无内置，插件有） | 提交信息是 commit 流水线核心产物，留接缝让"无 AI→LM→自带 key"平滑切换 |
+| `IPreCommitInspector` | `beforeCheckin`/`CommitCheck.runCheck`（返回 COMMIT/CANCEL/DEFER，对齐 `ReturnResult`） | 复用 IDEA 20+ 年验证的 hook 闸门机制；AI 审查最佳挂载点 |
+| `IChangelistGrouper` | （IDEA 无内置） | 写回 changelist 模型（回写工作流，差异化于内置 Copilot） |
+| `IConflictResolver` | （IDEA 无内置） | 必须 `prepareInvocation` 用户确认（VS Code 工具确认机制，安全红线） |
+
+**Commit 流水线 hook 注入点**（M2 即建责任链，默认 Null hooks）：
+`staged diff → [Hook A: 提交信息生成] → message 定稿 → [Hook B: 提交前检查链=beforeCheckin] → [Hook C: 分组校验] → commit → [Hook D: checkinSuccessful] → push → [Hook E: checkinFailed→Hook F: 冲突解决]`
+
+---
+
+## 7. CI/CD 与发布策略
+
+- **发布渠道**：双市场（Marketplace + OpenVSX）。**立即**：`ovsx create-namespace <publisher>` 并 **claim ownership**（OpenVSX namespace 默认非排他，防抢注）。
+- **publisher / 扩展 id**：扩展显示名 **Hyper Git**，id `hyper-git`；publisher 建议与 git owner 一致取 `threefish-ai`（**待你最终确认 publisher id**，创建后不可改）。
+- **CI 流水线**（`.github/workflows/ci.yml`）：`push/PR → lint→build→test 矩阵(ubuntu/mac/win, Linux 用 xvfb-run -a) → package vsix(Linux 打包保 POSIX 位) → upload artifact`；`tag v* → publish(vsce + ovsx, environment:production 审批门, PAT as secret)`。PR 仅跑 ubuntu 单格快门，main/tag 跑全矩阵（控成本）。
+- **版本治理**：Marketplace 版本不可撤销 → **快速补丁版本为唯一回滚范式**；pre-release 用奇数 minor 吸收 M5 AI 等高风险特性；CHANGELOG 用 Keep a Changelog 格式。
+- **安全**：PAT 短过期(90d) + 最小 scope + 仅存 GitHub encrypted secret；action pin 到完整 commit SHA；启用 Dependabot + CodeQL + `pnpm audit`；AI/遥测默认关闭。
+- **engines.vscode**：M0-M4 锁 `^1.85.0`（`@types/vscode:1.85.0` 严格对齐，让 tsc 拦截越界 API）；M5 评估上调以支持 LM/Chat API。
+
+---
+
+## 8. 关键风险与规避
+
+| 风险 | 规避 |
+|---|---|
+| changelist 模型无法用原生 SCM group 表达 | 自建 `ChangelistRegistry`（已定为路径 B 核心）；`workspaceState` 持久化 |
+| Webview 性能/内存（Log 图 + Commit 窗口） | Log 数据虚拟滚动 + 增量 postMessage；`retainContextWhenHidden` 按视图区分；graph 用轻量 SVG |
+| `vscode.git` API 跨版本兼容 | `getAPI(1)` 锁主版本；Adapter 层防御性可选链 |
+| 与原生 Source Control 视图双胞胎冲突 | 不注册竞争 SCM Provider；独立视图容器；原生视图平行共存 |
+| 版本不可撤销误发 | CI 三平台门 + pre-release 通道 + 快速补丁回滚演练（tag→发布 < 10min） |
+| PAT 泄露供应链攻击 | secret 隔离 + 短过期 + 优先 Entra OIDC 联邦（待核实 GA）+ SHA pin |
+| 行级 partial commit 过早抽象 | 列入 M4（P2），MVP 仅文件级勾选提交 |
+| AI 接缝过早抽象（YAGNI 反例风险） | 只定义接口 + Null 实现，零 AI 依赖，不写 AI 逻辑 |
+
+---
+
+## 9. 验证方案（端到端）
+
+- **单元测试（Vitest，< 30s）**：`engine/model`、`engine/diff`（行级 patch）、`engine/scm-mapping`（Status→decorations）、`engine/commit`（hook 责任链顺序/阻断）、Conventional Commits linter 纯函数。
+- **集成测试（@vscode/test-electron + Mocha，< 2min）**：`adapter/git-repository`（真实 fixture 仓库读 changes/commit/stash）、`adapter/changelist-registry`（持久化往返）、`adapter/webview`（postMessage 协议契约）、Commit 全链路（勾选→message→commit→验证 `git log`）。
+- **手动回归清单**：多 changelist 新建/移动/删除/重启持久化；Amend；Commit and Push；Conventional Commits 拦截；Log 图过滤；分支 merge/rebase；shelve/unshelve with conflict；行级 partial commit。
+- **浏览器/编辑器验证**：按 AGENTS.md 浏览器验证协议——用户已认证 Chrome 主 profile 打开真实仓库，截图验证 UI 还原度（Commit 窗口 vs 图1/图2 对齐）。
+- **发布前自证**：Diff 分析、测试覆盖、三平台 CI 绿、`.vsix` 在干净 VS Code + Cursor 实机安装回归。
+
+---
+
+## 10. 立即下一步（Next Best Action）
+
+1. **建工作分支**（基于 `origin/feature/1.x.x`），创建 `package.json` + esbuild 骨架（复制官方 `esbuild-sample`），落地 M0。
+2. **PoC 验证两个关键风险点**：(a) `extensionDependencies:["vscode.git"]` + `getAPI(1)` 拿到 `Repository` 读 `workingTreeChanges`；(b) WebviewView Commit 编辑器 `postMessage → Repository.commit()`。两项跑通即消除主要技术不确定性。
+3. **并行**：`ovsx create-namespace` + claim ownership（防抢注）；将 Track1 的 56 功能矩阵固化为 `docs/requirements/idea-feature-matrix.md` 作为后续验收基线，并同步 `.agents/knowledge-map.md` 索引。
+4. **提交规范**：按用户偏好，commit 用 `/commit` 命令；PR 基线为 `origin/feature/1.x.x`，不直接推 master。
+
+---
+
+## 附录：调研来源（关键，IEEE 可溯源）
+
+**IDEA 源码（JetBrains/intellij-community）**
+- `platform/vcs-api/src/com/intellij/openapi/vcs/checkin/CheckinHandler.java`（11 hook 生命周期）
+- `plugins/git4idea/src/git4idea/checkin/GitCheckinEnvironment.kt`（commit + partial + amend）
+- `platform/vcs-impl/.../impl/PartialChangesUtil.kt`（行级提交）
+- `platform/vcs-api/.../changes/ChangeListManager.java`（changelist API 契约）
+- `platform/vcs-impl/.../changes/shelf/ShelveChangesManager.java`（Shelf）
+
+**VS Code 源码/文档（microsoft/vscode + code.visualstudio.com）**
+- `extensions/git/src/api/git.d.ts`（Repository 全签名，已逐行复核）
+- [Source Control API](https://code.visualstudio.com/api/extension-guides/scm-provider)、[Webview API](https://code.visualstudio.com/api/extension-guides/webview)、[Bundling](https://code.visualstudio.com/api/working-with-extensions/bundling-extension)、[Testing](https://code.visualstudio.com/api/working-with-extensions/testing-extension)、[Publishing](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)、[Continuous Integration](https://code.visualstudio.com/api/working-with-extensions/continuous-integration)
+- proposed API 状态：[#185269 scmHistoryProvider](https://github.com/microsoft/vscode/issues/185269)、[#195474/#199778 InputBoxValueProvider 已删](https://github.com/microsoft/vscode/issues/195474)、[#179000 multi-diff](https://github.com/microsoft/vscode/issues/179000)
+- AI 机制：[Language Model API](https://code.visualstudio.com/api/extension-guides/ai/language-model)、[Chat](https://code.visualstudio.com/api/extension-guides/ai/chat)、[Tools](https://code.visualstudio.com/api/extension-guides/ai/tools)、[BYOK Provider](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider)
+
+**发布生态**
+- [eclipse/openvsx cli](https://github.com/eclipse/openvsx/blob/master/cli/README.md)、[Cursor 使用 OpenVSX](https://forum.cursor.com/t/cursor-marketplace-installs-offers-outdated-version-of-open-vsx-extension-despite-latest-version-being-available-upstream/159718)、[HaaLeo/publish-vs-code-extension](https://github.com/marketplace/actions/publish-vs-code-extension)

--- a/docs/requirements/idea-feature-matrix.md
+++ b/docs/requirements/idea-feature-matrix.md
@@ -1,0 +1,215 @@
+# IntelliJ IDEA 社区版 Git/Commit 模块 调研报告
+
+> 调研目标：产出 IDEA「Git 工具窗口 + Commit 提交窗口」的【完整功能清单 + 关键源码锚点】，作为 VS Code 插件复刻的需求规约（Spec）基线。
+> 仓库：[JetBrains/intellij-community](https://github.com/JetBrains/intellij-community)（master 分支，2025–2026 年版本）
+> 官方文档：[IntelliJ IDEA Help 2026.1](https://www.jetbrains.com/help/idea/)
+> 调研时间：2026-06-27
+
+---
+
+## A. 模块地图（源码模块职责 + 代表类）
+
+### git4idea 插件层（`plugins/git4idea/src/git4idea/`）
+
+| 模块 | 一句话职责 | 代表类/文件路径 |
+|---|---|---|
+| `checkin/` | 提交（commit）流水线：环境实现、handler 工厂、Amend、staging area 管理、commit 后转换器、push-after-commit | `GitCheckinEnvironment.kt`、`GitCheckinHandlerFactory.kt`、`GitAmendCommitService.kt`、`GitRepositoryCommitter.kt`、`GitStagingAreaStateManager.kt`、`GitCommitAndPushExecutor.kt`、`GitPushAfterCommitDialog.java`、`GitPostCommitChangeConverter.kt` |
+| `commit/` | Git 提交数据模型与提交信息辅助：commit message 提供器、最近提交、签名（GPG）、合并提交信息策略 | `GitTemplateCommitMessageProvider.kt`、`GitRecentCommitsProvider.kt`、`GitCommitCompletionContributor.kt`、`signing/GpgAgentConfigurator.kt`、`signature/GitCommitSignature.kt`、`GitStagingAreaCommitMode.kt` |
+| `changes/` | 变更检测与历史：committed change list、文件历史、outgoing 变更、changes 视图刷新 | `GitCommittedChangeList.java`、`GitCommittedChangeListProvider.java`、`GitFileHistory.kt`、`GitOutgoingChangesProvider.java`、`GitChangesViewRefresher.java` |
+| `stash/` | Git stash 操作（push/apply/pop/drop/keep index）+ stash UI 与缓存 | `GitStashUtils.kt`（`GitStashOperations`、`loadStashStack`、`createStashHandler`）、`GitStashContentProvider.kt`、`GitStashDialog.kt`、`GitStashChangesSaver.java`、`GitStashCache.kt` |
+| `branch/` | 分支操作（create/checkout/delete/rename/merge/compare）+ branches popup/dashboard | `GitBranchWorker.java`、`GitBrancherImpl.java`、`GitCheckoutOperation.java`、`GitMergeOperation.java`、`GitCreateBranchOperation.kt`、`GitCompareBranchesUi.kt`、`ui/dashboard/BranchesDashboardTreeController.kt` |
+| `rebase/` | rebase（含 interactive、auto-squash、fixup、reword）+ rebase 编辑器 + 续接/中止 | `GitRebaser.java`、`GitInteractiveRebaseAction.kt`、`GitAutoSquashCommitAction.kt`、`GitRebaseProcess.java`、`interactive/GitInteractiveRebaseUsingLog.kt`、`GitRewordService.kt` |
+| `rollback/` | 回滚/撤销（revert、reset、unversioned→rollback） | `GitRollbackEnvironment.java` |
+| `actions/` | 顶层 Git Action 入口（branches、rebase、fetch、push-up-to-commit、working trees 等） | `GitBranchesComboBoxAction.java`、`GitRebase.java`、`GitFetch.java`、`GitPushUpToCommitAction.kt`、`actions/branch/*`、`actions/workingTree/*` |
+| `ui/` | Git UI（reset 对话框、tag、stash、branches widget、merge-rebase widget、branch dashboard） | `GitResetDialog.java`、`GitTagDialog.java`、`branch/GitBranchWidget.kt`、`toolbar/GitMergeRebaseWidget.kt` |
+| `push/`、`pull/`、`fetch/`、`merge/`、`cherrypick/`、`reset/`、`revert/` | 对应的 Git 命令流水线与对话框（详见各子目录） | `push/GitPushUtil.kt`、`cherrypick/GitCherryPickAction.kt`、`revert/`（commit-level revert from log） |
+| `annotate/`、`diff/`、`history/` | blame 注解、diff 对比、历史浏览 | `annotate/GitAnnotationProvider.kt`、`diff/`、`history/GitHistoryUtils.kt` |
+| `index/`、`status/` | staging area（index）操作与 status 计算 | `index/GitIndexUtil.kt`、`index/GitFileStatusWorker.kt` |
+| `ignore/`、`vfs/`、`util/`、`console/`、`conflicts/` | gitignore、VFS 集成、工具函数、控制台、冲突解决 | `ignore/`、`conflicts/GitConflictsUtil.kt` |
+
+### 平台层（`platform/`）
+
+| 模块 | 一句话职责 | 代表类/文件路径 |
+|---|---|---|
+| `vcs-api/`（变更/提交抽象） | VCS 抽象接口：ChangeListManager、CheckinHandler、CheckinEnvironment、CommitExecutor、CommitMessageProvider、RollbackEnvironment、ChangeProvider | `changes/ChangeListManager.java`、`changes/LocalChangeList`（接口）、`checkin/CheckinHandler.java`、`checkin/CheckinEnvironment`、`changes/CommitExecutor.java`、`changes/ui/CommitMessageProvider.java` |
+| `vcs-impl/`（实现） | CLM 实现、commit 对话框、shelf（shelve/unshelve）、partial changes、checkin handler 管理器、committed changes 浏览 | `changes/ChangeListManagerImpl.java`、`changes/ChangeListWorker.java`、`changes/ui/CommitChangeListDialog.java`、`changes/shelf/ShelveChangesManager.java`、`changes/shelf/ShelvedChangesViewManager.java`、`impl/PartialChangesUtil.kt`、`impl/CheckinHandlersManagerImpl.kt`、`impl/LineStatusTrackerManager.kt`、`changes/local/*`（ChangeListCommand 体系：AddList/EditName/MoveChanges/RemoveList/SetDefault） |
+| `vcs-log/` | Git Log 图（graph）、过滤、搜索、cherry-pick/revert 入口 | `platform/vcs-log/`（VcsLog UI 与数据模型） |
+| `dvcs-api/` | 分布式 VCS 抽象（branch、repository、working tree 通用逻辑） | `platform/dvcs-api/` |
+
+---
+
+## B. 功能全量矩阵（≥30 原子功能点，8 组）
+
+> 说明：「源码锚点」优先给关键类路径；「VS Code 原生对应物」对照 VS Code 内置 SCM/Git。
+
+### 组 1：Commit 窗口（Commit / Shelf / Stash 标签页 + 提交流水线）
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层 git/IDEA 机制 | 源码锚点（类路径） | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 1 | Commit 工具窗口（竖向，Alt+0） | 左侧竖向变更列表 + 提交信息区 + Diff 预览；非模态 | `Alt+0` / `Ctrl+K` | 平台 `CommitDialog/CommitToolWindow`，git4idea `GitCheckinEnvironment` | `vcs-impl/.../changes/ui/CommitChangeListDialog.java`、`DefaultCommitChangeListDialog.kt`；git4idea `checkin/GitCheckinEnvironment.kt` | 高 | 部分（SCM 面板，无竖向 commit 工具窗口形态） |
+| 2 | Commit Message 模板 | 默认填充 commit message（来自 `.git/COMMIT_TEMPLATE` / `commit.template` / merge message） | 打开 commit 窗口自动填充 | `git config commit.template`；EP `com.intellij.vcs.commitMessageProvider` | `commit/GitTemplateCommitMessageProvider.kt`；`vcs-api/.../changes/ui/CommitMessageProvider.java`；`checkin/GitCheckinEnvironment.getDefaultMessageFor`（merge message） | 低 | 无原生（需插件/git config） |
+| 3 | 提交信息历史与补全 | 点击历史按钮选最近提交信息；commit message 关键字补全 | 提交信息区历史按钮 / 输入触发补全 | `RecentCommitsProvider` + IDEA completion 体系 | `commit/GitRecentCommitsProvider.kt`、`GitCommitCompletionContributor.kt` | 中 | 无原生 |
+| 4 | Conventional Commits 校验 | **IDEA 无内置 Conventional Commits 强校验**；仅支持 commit message 规则（wrap/reformat）与 quick-fix；需第三方插件 | 设置 `Version Control \| Commit` + quick-fix | commit message 重排（`CodeStyle`），无语义校验 | 「待核实」官方未提供 CC 校验类；参考 WebSearch 结论（需第三方） | 低（IDEA 本身无） | 无原生（需插件） |
+| 5 | Amend last commit（修正上一提交） | 勾选 Amend，新改动并入上一次提交；可选指定被修正的提交 | Commit 窗口 Amend 复选框 + 下拉选择提交 | `git commit --amend`；`CommitToAmend`（Last/Specific） | `checkin/GitAmendCommitService.kt`、`GitAmendSpecificCommitSquasher.kt`；`GitCheckinEnvironment.isAmendCommitSupported/getAmendCommitDetails` | 中 | 无原生（git lens 等插件） |
+| 6 | Author 覆盖 | 指定本次提交作者（name+email） | 高级选项 `Author` | `git commit --author=` | `checkin/GitCheckinEnvironment`（`myNextCommitAuthor` / `CommitContext.commitAuthor`）、`GitRepositoryCommitter` | 低 | 无原生 |
+| 7 | Commit / Commit and Push | `Commit`（Ctrl+K）或 `Commit and Push`（Ctrl+Alt+K） | 按钮 / 快捷键 | commit 后可选 push；`CommitExecutor` + `GitCommitAndPushExecutor` | `checkin/GitCommitAndPushExecutor.kt`、`GitPushAfterCommitDialog.java`；`GitCheckinEnvironment.doCommit`（`commitContext.isPushAfterCommit`） | 中 | 是（Commit & Push 按钮，VS Code 1.69+） |
+| 8 | Sign-off 提交 | 勾选自动追加 `Signed-off-by` | 高级选项 | `git commit -s` | `checkin/GitRepositoryCommitter`（`myNextCommitSignOff` / `commitContext.isSignOffCommit`） | 低 | 无原生 |
+| 9 | Skip Git hooks（本次） | 勾选跳过本次 hook | 高级选项 `Run Git hooks` 取消 | `git commit --no-verify` | `checkin/GitSkipHooksCommitHandlerFactory.kt`、`GitCheckinEnvironment`（`myNextCommitSkipHook`） | 低 | 无原生 |
+| 10 | 提交前 Inspection / 代码检查 | 勾选 Reformat/Rearrange/Optimize imports/Cleanup/Update copyright/Check TODO/Analyze code/Run Configuration 作为提交检查 | 高级选项 `Commit Checks` / `Advanced Commit Checks` | `CheckinHandler` + `CodeAnalysisBeforeCheckinHandler` + 平台 inspection/checkin factory（EP `com.intellij.checkinHandlerFactory`） | `vcs-api/.../checkin/CheckinHandler.java`；平台各 `BeforeCheckinHandler`；git4idea 自带 `GitCRLF/LargeFile/UserName/DetachedRoot/FileName CheckinHandler`（见 `GitCheckinHandlerFactory.kt`） | 高 | 无原生 |
+| 11 | Commit Checks 执行顺序 | EARLY/LATE 排序，失败可阻断或后置 | 自动 | `CommitCheck.ExecutionOrder` | `checkin/GitCheckinHandlerFactory.kt`（各 handler 的 `getExecutionOrder()`） | 中 | 无 |
+| 12 | CRLF / 大文件 / 用户名 / detached HEAD / 坏文件名 预检 | 提交前提示 CRLF、大文件、未设 user.name、detached HEAD、Windows 非法文件名 | 自动弹窗 | 各 `GitCheckinHandler`（`runGitCheck` 返回 `CommitProblem`） | `GitCRLFCheckinHandlerFactory`、`GitLargeFileCheckinHandlerFactory`、`GitUserNameCheckinHandlerFactory`、`GitDetachedRootCheckinHandlerFactory`、`GitFileNameCheckinHandlerFactory`（同 `GitCheckinHandlerFactory.kt`） | 中 | 无 |
+| 13 | Editor 内联提交（gutter marker） | 点 gutter 变更标记 → 写 message → 提交单处改动 | gutter 变更标记工具栏 | `LineStatusTracker` + inline commit | `vcs-impl/.../impl/LineStatusTrackerManager.kt`；官方文档「Commit selected changes from the editor」 | 中 | 无原生 |
+| 14 | After Commit 上传文件 | 提交后上传到部署服务器 | 高级选项 `After Commit` | 部署插件 EP | 平台 Deployment 集成（git4idea 不负责） | 低 | 无 |
+
+### 组 2：Local Changes 变更列表（多 changelist 模型）
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 15 | 多 changelist | 同时维护多个命名变更列表 | Commit 窗口左侧树 | `ChangeListManager` + `LocalChangeList` 模型 | `vcs-api/.../changes/ChangeListManager.java`、`LocalChangeList`（接口）；`vcs-impl/.../changes/ChangeListManagerImpl.java`、`ChangeListWorker.java` | 高 | **无**（VS Code SCM 仅多 group，非命名 changelist） |
+| 16 | Active changelist | 设置默认活动列表；新改动落入此列表 | `Ctrl+Space` / 右键 Set Active | `getDefaultChangeList/setDefaultChangeList`；命令 `SetDefault` | `ChangeListManager`；`changes/local/SetDefault.java` | 中 | **无**（无 active 概念） |
+| 17 | 新建 changelist | `+` 新建命名列表 | `+` 按钮 / 右键 New Changelist | `ChangeListModification`；命令 `AddList` | `vcs-impl/.../changes/ui/NewChangelistDialog.java`、`NewEditChangelistPanel.kt`；`changes/local/AddList.java` | 低 | **无**（git stash/resource group 替代） |
+| 18 | 删除 changelist | 删除空列表（自动清理选项） | 右键 Delete | `scheduleAutomaticEmptyChangeListDeletion`；命令 `RemoveList` | `ChangeListManager.scheduleAutomaticEmptyChangeListDeletion`；`changes/local/RemoveList.java`；设置 `REMOVE_EMPTY_INACTIVE_CHANGELISTS` | 低 | 无 |
+| 19 | 重命名 changelist | 右键 Edit → 改名/改注释 | 右键 Edit Changelist | 命令 `EditName`/`EditComment` | `vcs-impl/.../changes/ui/EditChangelistDialog.java`；`changes/local/EditName.java`、`EditComment.java` | 低 | 无 |
+| 20 | Move changes between changelists | `⌘⇧M`/`Alt+Shift+M` 或拖拽移动变更到其他列表 | 快捷键 / 右键 Move to Another Changelist / 拖拽 | `ChangeListModification.moveChanges`；命令 `MoveChanges` | `changes/local/MoveChanges.java`；`vcs-impl/.../changes/ui/ChangeListChooser.java` | 中 | **无** |
+| 21 | Changelist 自动绑定分支 | （IDEA Git 无原生 changelist↔branch 自动绑定；**任务上下文（Tasks）** 可关联 changelist 与 branch） | 任务切换 | `ActiveChangeListTracker`；任务管理器 | `vcs-impl/.../impl/ActiveChangeListTracker.kt`；任务上下文集成「待核实」具体绑定类 | 中 | 无 |
+
+### 组 3：Partial / Selective / 按行（line-level）提交
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 22 | 选择性勾选文件提交 | 勾选/取消文件，未勾选保留 | 复选框 | changelist 内子集提交 | `vcs-impl/.../changes/ui/CommitDialogChangesBrowser.java`；`GitCheckinEnvironment.commit(changes)` 接受子集 | 低 | 是（SCM 文件勾选） |
+| 23 | 按代码块（chunk）提交 | Diff 中勾选 chunk 提交，其余保留 | Diff 区勾选 | `PartialLocalLineStatusTracker` + `PartialCommitHelper` | `vcs-impl/.../impl/PartialChangesUtil.kt`（`getPartialTracker`/`processPartialChanges`）；`vcs-api/.../vcs/ex/PartialCommitHelper`；`GitCheckinEnvironment.addPartialChangesToIndex` | **高** | 部分（git staging + chunk staging，VS Code 1.70+ 支持 staging selected lines） |
+| 24 | 按行（line）提交 | 右键行 → Split Chunks & Include Selected Lines | gutter 复选 / 右键 | `LineStatusTracker` 行级 exclusion | `PartialChangesUtil.convertExclusionState`；官方文档「Split Chunks and Include Selected Lines into Commit」 | **高** | 部分（Staged/Unstaged 选择行） |
+| 25 | Move Lines to Another Changelist | 编辑时把行级改动划入不同 changelist | gutter marker → 选 changelist | 行级 `ChangeListChange` + `PartialLocalLineStatusTracker` | `PartialChangesUtil`、`ChangeListChange`；官方文档「Put changes into different changelists」 | **高** | **无** |
+| 26 | Git Staging Area 模式 | 设置启用 → changelist 切换为 index 暂存模型 | 设置 `Enable staging area` | `GitStagingAreaStateManager` + index | `checkin/GitStagingAreaStateManager.kt`、`GitIndexInfoStagingAreaStateManager.kt`、`GitResetAddStagingAreaStateManager.kt`；`commit/GitStagingAreaCommitMode.kt` | 中 | 是（VS Code 原生 index 模型） |
+
+### 组 4：Shelf 与 Stash
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 27 | Shelve changes（IDEA patch） | 暂存选定改动为 IDEA patch；可选择部分文件 | 右键 Shelve Changes / Shelve Silently（`Ctrl+Shift+H`） | `ShelveChangesManager`（patch 文件存储） | `vcs-impl/.../changes/shelf/ShelveChangesManager.java`、`ShelveChangesAction.kt`、`ShelveChangesCommitExecutor.java` | 中 | **无**（需 git stash 替代） |
+| 28 | Unshelve silently / with conflict | 还原 shelf；静默或弹冲突解决 | `Ctrl+Shift+U` / Unshelve Silently（`Ctrl+Alt+U`）/ 拖拽 | `ShelvedChangesViewManager` + 3-way merge（冲突） | `shelf/UnshelveWithDialogAction.java`、`ShelvedChangesViewManager.java`、`RestoreShelvedChange.java` | 中 | 无 |
+| 29 | Stash changes（git native） | `git stash push`（可选 `--keep-index`、message、指定文件 pathspec） | 右键 Git \| Stash Changes | `git stash push [--keep-index] [--message] [-- pathspec]` | `stash/GitStashUtils.kt`（`createStashHandler`/`runStashInBackground`）；`ui/GitStashDialog.kt`、`GitStashContentProvider.kt` | 中 | 是（命令式，无原生 UI） |
+| 30 | Apply / Pop / Drop / Clear stash | Apply 保留 / Pop 移除 / Drop 单个 / Clear 全部；可选 Reinstate Index（`--index`）；Unstash as new branch | Stash tab 按钮 / 右键 | `git stash apply\|pop\|drop\|branch` | `stash/GitStashUtils.kt`（`GitStashOperations.dropStashWithConfirmation`/`clearStashesWithConfirmation`/`unstash`/`createUnstashHandler`） | 中 | 部分（命令式） |
+| 31 | Combine Stash & Shelf tab | 合并两个标签页 | 设置 `Combine stashes and shelves in one tab` | UI 合并 | `stash/ui/GitStashContentProvider.kt`、`shelf/ShelvedChangesViewManager.java` | 低 | 无 |
+| 32 | Import external patches 为 shelf | 导入 patch 作为 shelf 再 unshelve | Shelf 右键 Import Patches | patch 解析 + shelf | `shelf/ImportIntoShelfAction.java` | 低 | 无 |
+| 33 | Shelve base revision（DCVS） | 自动保存 base revision 以支持 3-way merge | 设置 `Shelve base revisions` | base revision 存储 | `shelf/ShelveChangesManager`（配置项） | 低 | 无 |
+| 34 | Save to Shelf（不重置本地） | 复制改动到 shelf 但保留本地 | `Ctrl+Shift+A` Save to Shelf | patch 复制 | `shelf/ShelveChangesAction.kt`（相关 action） | 低 | 无 |
+
+### 组 5：Diff（对比）
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 35 | 与 HEAD/分支/本地对比 | Diff Viewer 对比本地 vs HEAD / 任意分支 / 本地版本 | Diff 按钮（`Ctrl+D`）/ Compare HEAD, Staged and Local | `DiffProvider`/`GitDiffProvider` | `git4idea/diff/`；`ui/GitShowDiffWithBranchPanel.kt`；`branch/GitCompareBranchesUi.kt` | 中 | 是（editor diff） |
+| 36 | Compare HEAD/Staged/Local 三方 | 三窗 Diff（repo / 中央可编辑 staging / local） | 右键 Compare HEAD, Staged and Local Versions | staging area interactive staging | 官方文档「Stage changes interactively」；`checkin/GitIndexUtil`（`listStaged`/`listTree`） | 中 | 部分 |
+| 37 | Annotate（blame） | 编辑器/gutter 显示逐行作者/提交 | Annotate | `GitAnnotationProvider` | `annotate/GitAnnotationProvider.kt`；`actions/GitToggleAnnotationOptionsActionProvider.java` | 中 | 是（GitLens 等；VS Code 1.90+ 实验内置） |
+| 38 | Show History for selection | 选中代码/文件的历史 | 右键 Show History / Git History | `GitFileHistory`/`GitHistoryUtils` | `changes/GitFileHistory.kt`、`MutableLinearGitFileHistory.kt`；`history/GitHistoryUtils.kt` | 中 | 是（文件历史） |
+
+### 组 6：Log 提交图
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 39 | 提交图（graph） | 分支拓扑图、彩色节点 | Git 工具窗口 Log tab（`Alt+9`） | `platform/vcs-log`（VcsLog data + UI） | `platform/vcs-log/`（`VcsLogUi`、graph 渲染）；git4idea `log/` | **高** | 无原生（需 GitGraph 等插件） |
+| 40 | Search / filter（author/path/date/branch/regex） | 按 author、path、date、branch、正则过滤 | Log toolbar 过滤 | VcsLog filter 体系 | `platform/vcs-log/`（filter providers）；官方文档 [Log Tab](https://www.jetbrains.com/help/idea/log-tab.html) | 中 | 部分（无原生图形 log 过滤） |
+| 41 | Cherry-pick from log | 右键提交 → Cherry-Pick 到当前分支 | 右键 Cherry-Pick | `git cherry-pick` | `cherrypick/GitCherryPickAction.kt`；`branch/CherryPickedCommitsHighlighter.kt` | 中 | 无原生 |
+| 42 | Revert commit from log | 右键提交 → Revert Commit（生成反向提交） | 右键 Revert Commit | `git revert` | `revert/`（commit-level）；`actions/GitRevertResolvedAction.kt` | 中 | 无原生 |
+| 43 | Undo Commit / Push All up to Here / Drop（rebase） | 撤销最近提交 / 推送到某提交 / rebase 删除 | 右键 / Log action | soft reset / `git push <ref>` / interactive rebase | `actions/GitPushUpToCommitAction.kt`；`rebase/`（interactive） | 中 | 无原生 |
+| 44 | Reword / Squash / Fixup（from log，interactive rebase） | 在 log 内改写提交 | 右键 + interactive rebase | interactive rebase | `rebase/GitRewordAction.kt`、`GitAutoSquashCommitAction.kt`、`GitCommitSquashBySubjectAction.kt`、`interactive/GitInteractiveRebaseUsingLog.kt` | 高 | 无原生 |
+
+### 组 7：Branches
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 45 | Create / Checkout branch | 新建并检出 / 检出现有 / checkout-as-new | VCS widget / Branches pane | `git checkout -b/-` | `branch/GitCreateBranchOperation.kt`、`GitCheckoutOperation.java`、`GitCheckoutNewBranchOperation.java`；`actions/branch/GitCheckoutAsNewBranch.kt` | 低 | 是（命令面板） |
+| 46 | Delete / Rename branch | 删除本地/远程分支/标签、重命名 | 右键 Delete/Rename | `git branch -d/-D`/`-m`；`git push origin --delete` | `branch/GitDeleteBranchOperation.java`、`GitDeleteRemoteBranchOperation.java`、`GitRenameBranchOperation.java`、`GitDeleteTagOperation.java` | 低 | 部分 |
+| 47 | Compare branches | 对比两分支文件差异 | 右键 Compare | `GitCompareBranchesUi` + diff fs | `branch/GitCompareBranchesUi.kt`、`GitCompareBranchesFilesManager.java`、`GitCompareBranchesVirtualFileSystem.kt` | 中 | 无原生 |
+| 48 | Merge / Rebase / Pull / Push / Fetch（分支级） | 在分支上执行 merge/rebase/update/push/fetch | 分支右键菜单 | 各 operation worker | `branch/GitMergeOperation.java`、`GitBranchWorker.java`；`rebase/GitRebaser.java`；`actions/branch/GitPullBranchAction.kt`、`GitPushBranchAction.kt`、`GitRebaseBranchAction.kt`、`GitUpdateSelectedBranchAction.kt`；`actions/GitFetch.java` | 中 | 是（命令式） |
+| 49 | Branches Dashboard / Popup | 分支树状仪表盘 + popup 选择器 | Git 工具窗口 Branches pane | `BranchesDashboardTree*` + popup | `ui/branch/dashboard/BranchesDashboardTreeController.kt`、`BranchesTree.kt`；`ui/branch/GitBranchWidget.kt`、`popup/GitBranchesTreePopupOnBackend.kt` | 中 | 部分（VS Code status bar） |
+| 50 | Cleanup branches / Find merged | 清理已合并分支、查找合并的本地分支 | Cleanup action | `git branch --merged` | `ui/branch/cleanup/CleanupBranchesAction.kt`、`branch/FindMergedLocalBranchesAction.kt` | 低 | 无 |
+
+### 组 8：右键 / 内联操作
+
+| # | 功能名 | 用户可见行为 | 触发入口 | 底层机制 | 源码锚点 | 复刻难度 | VS Code 原生 |
+|---|---|---|---|---|---|---|---|
+| 51 | Revert / Rollback | 回滚未提交改动（`RollbackEnvironment`） | 右键 Rollback / `RollbackChangesDialog` | `git checkout --` / reset | `rollback/GitRollbackEnvironment.java`；`vcs-impl/.../changes/ui/RollbackChangesDialog.kt`、`RollbackWorker.java` | 中 | 是（Discard Changes） |
+| 52 | Reset HEAD（mixed/soft/hard/keep） | Git Reset 对话框选择模式 | 右键 / `GitResetHead` action | `git reset --soft/--mixed/--hard/--keep` | `actions/GitResetHead.java`；`ui/GitResetDialog.java` | 低 | 无原生（命令式） |
+| 53 | Ignore | 加入 .gitignore | 右键 Add to .gitignore | `ignore/` + `.gitignore` 写入 | `ignore/`（GitIgnore 集成） | 低 | 是 |
+| 54 | Compare / Show Diff | 对比改动 | 右键 Show Diff | `diff/` | `git4idea/diff/`；`ChangesBrowserBase`（diff producer） | 中 | 是 |
+| 55 | Jump to Source | 跳到源码 | 右键 Jump to Source / `F4` | 编辑器导航 | `vcs-impl/.../changes/ui/EditSourceForDialogAction.java` | 低 | 是 |
+| 56 | Copy revision | 复制 commit hash / 修订号 | 右键 Copy Revision / Copy Hash | 剪贴板 | `branch/GitRefDialog` 等（参考 Log 右键 Copy Hash） | 低 | 部分 |
+
+---
+
+## C. IDEA「多 changelist」模型 vs VS Code SCM「group」模型 差异要点
+
+| 维度 | IDEA 多 changelist | VS Code SCM group |
+|---|---|---|
+| 核心抽象 | `LocalChangeList`（命名、有 id、有 comment、可设 active）+ `Change` 可属于多个列表（同一文件不同 chunk 跨列表，`ChangeListChange` + `PartialLocalLineStatusTracker`） | `SourceControlResourceGroup`（按 type/自定义 label 分组，无「active」概念，无跨组同文件 chunk） |
+| 数据来源 | 平台 `ChangeListManager` 统一管理（含本地 changelist 持久化、`ChangeListListener` 事件） | 扩展点 `scm.ResourceGroups`（插件自行维护） |
+| Active 概念 | 有「active changelist」：新改动默认落入；`getDefaultChangeList`/`setDefaultChangeList` | 无；新改动归属由插件决定（通常单组 Staged/Changes） |
+| 行级跨列表 | 支持（`PartialChangesUtil`/`PartialLocalLineStatusTracker`：同一文件不同行属于不同 changelist） | 不支持原生；git staging 可部分行 stage，但无「命名列表」归属 |
+| 持久化 | `ChangeListManagerSerialization` 持久化 changelist 定义 | 插件自定义状态 |
+| 与 git index 关系 | 默认「changelist 即待提交集」（非 staging 模型）；可选切换为 Staging Area 模式（`GitStagingAreaCommitMode`） | 默认即 staging 模型（Changes/ Staged） |
+| 提交范围 | 提交所选 changelist（或其中勾选子集） | 提交整个 Staged group |
+| 自动绑定分支 | **无原生 changelist↔branch 自动绑定**；需 Tasks 上下文（`ActiveChangeListTracker`） | 无 |
+
+> **复刻映射建议**：VS Code SCM 的 `ResourceGroup` 难以 1:1 表达「active + 跨文件行级归属」，建议在插件层自建「changelist registry」（仿 `ChangeListManager` + `ChangeListChange`），将 SCM group 作为渲染层，并通过 `LineStatusTracker`-like 行级 tracker 支撑 partial commit。这是 IDEA 模型对 VS Code 最大的差异与复刻难点。
+
+---
+
+## D. IDEA Checkin 流水线（CheckinHandler 生命周期）hook 点清单
+
+> 来源：`platform/vcs-api/src/com/intellij/openapi/vcs/checkin/CheckinHandler.java`（完整源码已读）。
+> 注册：通过 `BaseCheckinHandlerFactory`/`VcsCheckinHandlerFactory`（EP `com.intellij.checkinHandlerFactory` 全局 + `com.intellij.vcs.checkinHandlerFactory` VCS 专属），由 `CheckinHandlersManagerImpl`（`platform/vcs-impl/.../impl/CheckinHandlersManagerImpl.kt`）聚合。
+> 现代 IDEA 推荐实现 `CommitCheck`（suspend 协程，返回 `CommitProblem`）替代旧 `beforeCheckin`。git4idea 的 `GitCheckinHandler` 抽象类同时实现 `CheckinHandler` + `CommitCheck`。
+
+| Hook 点 | 方法签名 | 触发时机 | 返回/语义 | AI 接入价值 |
+|---|---|---|---|---|
+| Before-Commit 配置面板（Before Commit 组） | `RefreshableOnComponent getBeforeCheckinConfigurationPanel()` | 构建 commit 窗口选项面板 | 注入复选框（如 Reformat/Optimize imports/Check TODO） | 高：注入「AI review before commit」开关 |
+| Before-Commit 设置项（Settings 页） | `UnnamedConfigurable getBeforeCheckinSettings()` | `Settings \| VCS \| Commit` 配置页 | 持久化设置 | 中：AI 规则配置 |
+| After-Commit 配置面板 | `RefreshableOnComponent getAfterCheckinConfigurationPanel(Disposable)` | 构建 After Commit 选项面板 | 注入部署等选项 | 低 |
+| **Before check-in（核心闸门）** | `ReturnResult beforeCheckin(CommitExecutor, PairConsumer)` / `beforeCheckin()` | 提交按钮按下后、真正 commit 前 | `COMMIT`/`CANCEL`/`CLOSE_WINDOW` 可阻断提交 | **高**：AI 代码审查/质量闸门，可阻断不良提交 |
+| **CommitCheck（现代协程闸门）** | `suspend CommitProblem? runCheck(CommitInfo)` / `runGitCheck(commitInfo, changes)` | beforeCheckin 的协程演进版；`commitInfo.isVcsCommit` 时执行 | 返回 `CommitProblem`（含 `showModalSolution`） | **高**：AI 异步审查最佳挂载点（仿 `GitCheckinHandler`） |
+| CommitCheck 执行顺序 | `CommitCheck.ExecutionOrder getExecutionOrder()` | 排序多个 CommitCheck | `EARLY`/`DEFAULT`/`LATE` | 中：控制 AI 检查与其他检查顺序 |
+| CommitCheck 启用开关 | `boolean isEnabled()` | 决定是否运行 | 布尔 | 中 |
+| **Successful 回调** | `void checkinSuccessful()`（`@RequiresEdt`） | 提交成功后 | 通知/后续动作 | 高：AI 提交摘要、自动生成 PR 描述 |
+| **Failed 回调** | `void checkinFailed(List<VcsException>)` | 提交失败后 | 异常列表 | 中：AI 诊断失败原因 |
+| **变更勾选变更通知** | `void includedChangesChanged()` | 用户勾选/取消变更时 | 实时感知提交范围 | **高**：AI 实时根据勾选范围动态生成 commit message |
+| Executor 过滤 | `boolean acceptExecutor(CommitExecutor)` | 决定本 handler 是否对某 executor 生效 | 默认对非 `LocalCommitExecutor` 生效（即 shelf/create patch 不跑该检查） | 中：区分 commit vs shelf vs push |
+| CommitProblem 模态解决 | `CommitProblem.showModalSolution(project, commitInfo)` | 检查发现问题时弹模态方案 | `ReturnResult` | 中：AI 给出修复建议弹窗 |
+
+> **CommitContext 关键字段**（贯穿整个流水线，承载 commit 选项）：`commitToAmend`、`isSkipHooks`、`commitAuthor`、`commitAuthorDate`、`isSignOffCommit`、`isPushAfterCommit`、`isCommitRenamesSeparately`、`commitWithoutChangesRoots`。源码：`GitCheckinEnvironment.updateState()` / `doCommit()`。
+>
+> **AI 接入建议**：实现一个 `CommitCheck`（EARLY 顺序）挂载 AI 审查 + 实现 `includedChangesChanged()` 动态生成 commit message + 实现 `checkinSuccessful()` 触发 AI 后处理，可完整复用 IDEA 提交流水线的「设计-实现-验证」闭环，无需重写 commit 引擎。
+
+---
+
+## E. 关键事实来源（循证索引）
+
+### 源码（GitHub master）
+- 提交 handler 生命周期：[`platform/vcs-api/.../checkin/CheckinHandler.java`](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-api/src/com/intellij/openapi/vcs/checkin/CheckinHandler.java)
+- git4idea 提交环境与 Amend：[`plugins/git4idea/.../checkin/GitCheckinEnvironment.kt`](https://github.com/JetBrains/intellij-community/blob/master/plugins/git4idea/src/git4idea/checkin/GitCheckinEnvironment.kt)、[`GitCheckinHandlerFactory.kt`](https://github.com/JetBrains/intellij-community/blob/master/plugins/git4idea/src/git4idea/checkin/GitCheckinHandlerFactory.kt)
+- ChangeListManager 抽象：[`platform/vcs-api/.../changes/ChangeListManager.java`](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-api/src/com/intellij/openapi/vcs/changes/ChangeListManager.java)
+- Partial changes 工具：[`platform/vcs-impl/.../impl/PartialChangesUtil.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-impl/src/com/intellij/openapi/vcs/impl/PartialChangesUtil.kt)
+- Shelf 管理：[`platform/vcs-impl/.../changes/shelf/ShelveChangesManager.java`](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-impl/src/com/intellij/openapi/vcs/changes/shelf/ShelveChangesManager.java)
+- Stash 操作：[`plugins/git4idea/.../stash/GitStashUtils.kt`](https://github.com/JetBrains/intellij-community/blob/master/plugins/git4idea/src/git4idea/stash/GitStashUtils.kt)
+- Checkin handler 聚合：[`platform/vcs-impl/.../impl/CheckinHandlersManagerImpl.kt`](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-impl/src/com/intellij/openapi/vcs/impl/CheckinHandlersManagerImpl.kt)
+- Commit message 提供器 EP：[`platform/vcs-api/.../changes/ui/CommitMessageProvider.java`](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-api/src/com/intellij/openapi/vcs/changes/ui/CommitMessageProvider.java)
+- changelist 命令体系：`platform/vcs-impl/.../changes/local/{AddList,EditName,EditComment,MoveChanges,RemoveList,SetDefault,SetReadOnly}.java`
+
+### 官方文档（jetbrains.com/help/idea 2026.1）
+- [Commit and push changes to Git repository](https://www.jetbrains.com/help/idea/commit-and-push-changes.html)（commit 窗口、amend、author、commit checks、partial commit、staging area、push）
+- [Shelve or stash changes](https://www.jetbrains.com/help/idea/shelving-and-unshelving-changes.html)（shelve/unshelve silently/with conflict、stash apply/pop/drop/keep index、combine tabs）
+- [Group changes into changelists](https://www.jetbrains.com/help/idea/managing-changelists.html)（active/create/move/delete/rename changelist）
+- [Log Tab](https://www.jetbrains.com/help/idea/log-tab.html)（graph/filter/cherry-pick/revert）
+- [Manage Git branches](https://www.jetbrains.com/help/idea/manage-branches.html)（create/checkout/delete/rename/compare/merge/rebase）
+- [Edit Git project history](https://www.jetbrains.com/help/idea/edit-project-history.html)（amend 历史、reword/squash/fixup）
+- [Investigate changes in Git repository](https://www.jetbrains.com/help/idea/investigate-changes.html)（history/annotate）
+
+---
+
+## F. 待核实 / 不确定项
+1. **LocalChangeList 接口/实现类的精确文件路径**：zread 多次返回「文件不存在」（API 类可能位于非直觉路径或为生成/移动类），但其方法语义已通过 `ChangeListManager.java`（大量引用）+ `PartialChangesUtil.kt`（`LocalChangeList` import）+ `ChangeListWorker.java`（实现侧）交叉证实存在。**建议**复刻阶段直接以 `ChangeListManager` API 为契约蓝本。
+2. **Conventional Commits 内置校验**：WebSearch 与文档检索均未发现 IDEA 内置 CC 强校验类；结论为「IDEA 无原生 CC 校验，依赖 commit message 规则/第三方插件」，需在复刻时自行实现 CC linter。
+3. **Changelist 自动绑定分支的具体类**：`ActiveChangeListTracker.kt` 存在，但「changelist↔branch」自动绑定疑似走 Tasks 上下文模块（非 git4idea），未定位到确切绑定类。
+4. **分支级 Pull/Push/Fetch 的精确 action 类**：`actions/branch/GitPullBranchAction.kt` 等结构已确认存在，但内部委托链（→ `GitBranchWorker`/`GitFetch`）未逐行核实。

--- a/docs/research/02-vscode-scm-integration.md
+++ b/docs/research/02-vscode-scm-integration.md
@@ -1,0 +1,404 @@
+# Track2 调研报告:VS Code SCM API 与 vscode.git 导出 API 集成路径
+
+> 调研对象:在 VS Code 中复刻 IDEA 风格 Git 工具窗口(多 changelist + Commit 窗口)的最佳集成路径。
+> 证据基线:microsoft/vscode 源码(`extensions/git/src/api/git.d.ts`、`api1.ts`、`vscode.d.ts`)、官方 SCM provider 指南、GitHub Issue 追踪记录、同类扩展(GitLens、vscode-pull-request-github)实践。
+> 检索时间:2026 年 6 月。所有关键事实附 GitHub 文件路径或官方文档 URL;存疑项标注「待核实」。
+
+---
+
+## 0. 核心结论(执行摘要)
+
+| 决策项 | 结论 |
+|---|---|
+| **推荐路径** | **路径 B(纯消费 vscode.git 导出 API + 自建 TreeView/WebviewView 渲染 IDEA UI),原生 Source Control 视图保持不动** |
+| **changelist 模型** | VS Code SCM 是「分组(group)」模型,不是 IDEA 的「多 changelist」。多 changelist 用**自建 TreeView** 表达最忠实;若想借用原生视图,可用「每个 changelist 一个 `SourceControlResourceGroup`」近似但语义有损 |
+| **Commit 窗口 UI** | 放在 **Secondary Side Bar 的 WebviewView**(自建视图容器),自带 Commit/Shelf/Stash 标签页 + Commit Message 编辑器;**不依赖也不替代**原生 `SourceControlInputBox`(稳定字段太弱,且 `SourceControlInputBoxValueProvider` 已被官方删除) |
+| **提交图(Log)** | 原生 Source Control Graph 的 `scmHistoryProvider` **仍是 proposed API**(截至 2025-05 无 stable 时间表),不能稳定复用。Log 提交图须自建 TreeView + 消费 `Repository.log()` |
+| **git 操作底座** | 全部复用 vscode.git 导出的 `API`(`commit/add/revert/diff/blame/log/stash/branch/merge/rebase`),不自调 git CLI(循证:GitHub PR 扩展即此模式) |
+
+**一句话理由**:VS Code 原生 SCM API 的设计哲学是「provider 负责填数据 + 框架负责渲染统一 UI」,与 IDEA「插件完全自绘工具窗口」相反。强行注册独立 SCM Provider(A/C)会与原生 git 视图**双胞胎冲突**,且无法表达 IDEA 的多 changelist + Commit 对话框这种「自绘」需求;而纯消费 git API + 自绘视图(B)既能拿到稳定的 git 能力,又拥有 100% 的 UI 自由度,与原生视图零冲突,符合「复用驱动 + 正交分解」。
+
+---
+
+## 1. SCM API 能力地图(稳定 API)
+
+> 来源:[官方 SCM provider 指南](https://code.visualstudio.com/api/extension-guides/scm-provider)、[VS Code API 参考](https://code.visualstudio.com/api/references/vscode-api)、`src/vscode-dts/vscode.d.ts`。下列为**稳定(public/stable)**能力,proposed 项单列。
+
+### 1.1 SourceControl(顶层 provider 句柄)
+
+由 `vscode.scm.createSourceControl(id, label, rootUri?)` 创建。稳定字段(来源:[vscode.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.d.ts) `export interface SourceControl`):
+
+| 成员 | 类型 | 能力 | IDEA 对应 |
+|---|---|---|---|
+| `id` / `label` | `readonly string` | provider 标识与显示名 | — |
+| `rootUri` | `readonly Uri \| undefined` | 仓库根 | 仓库根 |
+| `inputBox` | `SourceControlInputBox` | **唯一的**提交消息输入框 | Commit Message 区 |
+| `count` | `number \| undefined` | 在 provider 标题上显示的徽标数字 | Changes 计数 |
+| `commitTemplate` | `string \| undefined` | 预填入 inputBox 的模板 | Commit Message Template |
+| `acceptInputCommand` | `Command \| undefined` | 用户按 Ctrl/Cmd+Enter 提交时触发的命令 | Commit 按钮 |
+| `statusBarCommands` | `Command[]` | 状态栏下拉命令 | — |
+| `quickDiffProvider` | `QuickDiffProvider \| undefined` | 提供 gutter quick diff | 编辑器内联 diff 标记 |
+| `createResourceGroup(id, label)` | → `SourceControlResourceGroup` | 创建分组 | changelist 雏形 |
+| `selected` | `readonly boolean` | 是否为当前选中的 provider | active 仓库 |
+
+**硬限制**:
+- **每个 SourceControl 只有一个 `inputBox`**(单 Commit Message),无法表达「多 changelist 各自有独立 message」(IDEA 的 Default changelist 才有 message,其他可独立)。来源:[官方指南 SCM Input Box 段](https://code.visualstudio.com/api/extension-guides/scm-provider#scm-input-box)。
+- `SourceControl.contextValue`(用于 `when` 子句精细控制菜单)是 **proposed API**(`scmProviderOptions`,issue [#254910](https://github.com/microsoft/vscode/issues/254910))。来源:[vscode.proposed.scmProviderOptions.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts)。
+
+### 1.2 SourceControlResourceGroup(分组 = changelist 的近似)
+
+```
+createResourceGroup(id, label) → { id, label, resourceStates, hideWhenEmpty, ... dispose() }
+```
+
+- `resourceStates: SourceControlResourceState[]` — 你**全量覆盖**这个数组来更新分组内容(push 模型,非增量)。
+- `hideWhenEmpty: boolean` — 空分组自动隐藏。
+- 分组在视图里**默认可折叠**(VS Code 1.18+ SCM 视图即树状)。来源:[官方指南 Source Control Model 段](https://code.visualstudio.com/api/extension-guides/scm-provider#source-control-model)。
+
+**能否多 group 折叠?** 能。一个 SourceControl 下 `createResourceGroup` 可调用多次,每个 group 独立折叠。git 扩展自己就建了 `merge` / `index` / `workingTree` / `untracked` 四个 group。来源:`extensions/git/src/repository.ts`(git.d.ts 的 `RepositoryState` 暴露了 `mergeChanges/indexChanges/workingTreeChanges/untrackedChanges`,对应这四个 group)。
+
+**changelist 表达力的硬限制**:
+- group 是「只读展示容器」,**没有 group 级别的 commit message、没有 group 级别的 active 概念**。IDEA 的 active changelist(active 时新增文件自动落入)在原生 SCM 里无对应物。
+- group 之间**无法跨 group 拖拽移动文件**(move changes)——SCM 视图不支持跨 group DnD,只能靠 `scm/resourceState/context` 菜单命令实现。
+
+### 1.3 SourceControlResourceState(单个文件条目)
+
+稳定字段(来源:[官方指南](https://code.visualstudio.com/api/extension-guides/scm-provider#source-control-view) + [Haxe externs 镜像](https://vshaxe.github.io/vscode-extern/vscode/SourceControlResourceState.html)):
+
+| 成员 | 能力 |
+|---|---|
+| `resourceUri: Uri` | 文件路径(渲染主标签) |
+| `command?: Command` | **单击**该文件时的命令(通常打开 diff) |
+| `decorations?: SourceControlResourceDecorations` | 状态色/图标/删除线等 |
+| `multiDiffEditorOriginalUri?` / `multiDiffEditorModifiedUri?` | 接入 multi-diff 编辑器(proposed `scmMultiDiffSource`,见下) |
+
+### 1.4 SourceControlResourceDecorations(状态色 M/A/D/U...)
+
+稳定字段(来源:[Haxe externs](https://vshaxe.github.io/vscode-extern/vscode/SourceControlResourceDecorations.html) + 官方指南):
+
+| 成员 | 对应 IDEA 状态色 |
+|---|---|
+| `strikeThrough?: boolean` | 删除(D) |
+| `faded?: boolean` | 未跟踪/弱化(U) |
+| `tooltip?: string` | 悬停提示 |
+| `letter?: string` | 单字母角标(M/A/D/R/C/U) |
+| `color?: ThemeColor` | 状态色(如 `gitDecoration.modifiedResourceForeground`) |
+| `iconPath?: string \| Uri \| {light, dark}` | 自定义图标 |
+| `source?: string` | 来源标注 |
+
+> IDEA 的 M/A/D/U/Renamed/Copied 完全可由 `letter` + `color` 组合复刻(git 扩展就是这么做的,见其 `Resource` 类的 decorations 计算)。
+
+### 1.5 QuickDiff(编辑器 gutter 内联 diff)
+
+```
+quickDiffProvider?: QuickDiffProvider  // provideOriginalResource(uri) → 原始资源 Uri
+```
+配合 `registerTextDocumentContentProvider` 提供原始内容。来源:[官方指南 Quick Diff 段](https://code.visualstudio.com/api/extension-guides/scm-provider#quick-diff)。能力完备,可直接复用。
+
+### 1.6 SourceControlInputBox(提交消息框)— 关键硬限制
+
+**稳定字段仅有**:`value: string`、`visible: boolean`、`placeholder: string`。来源:[官方指南 SCM Input Box](https://code.visualstudio.com/api/extension-guides/scm-provider#scm-input-box) + WebSearch 交叉确认。
+
+**致命限制(循证)**:曾用于「按 provider 动态提供 inputBox 值/校验」的 `SourceControlInputBoxValueProvider` 提案,**已被官方删除**(PR [microsoft/vscode#199778](https://github.com/microsoft/vscode/issues/199778),issue [#195474](https://github.com/microsoft/vscode/issues/195474) 标题由 `SourceControlInputBoxValueProvider API proposal` 改为 `scm/inputBox menu contribution`)。结论:**无法在原生 inputBox 上做 Conventional Commits 实时校验、无法嵌多行模板编辑器、无法加自定义按钮**。
+
+> 这一硬限制直接决定了:IDEA 的 Commit Message 多行编辑区(模板/校验/Amend/Author)无法落在原生 inputBox 上 → 必须自建 WebviewView(见第 5 节)。
+
+### 1.7 SCM 菜单贡献点(自定义二级菜单/inline 按钮)
+
+来源:[官方指南](https://code.visualstudio.com/api/extension-guides/scm-provider#source-control-view)。**全部稳定**,且能力足够复刻 IDEA 文件右键菜单:
+
+| 菜单 id | 作用位置 | 可放 `inline`(行内按钮) |
+|---|---|---|
+| `scm/title` | provider 标题栏 | ✅ navigation 组行内 |
+| `scm/resourceGroup/context` | **分组(changelist)右键** | ✅ |
+| `scm/resourceState/context` | **文件右键** | ✅ |
+| `scm/resourceFolder/context` | 文件夹节点右键 | ✅ |
+| `scm/repository` | Repositories 视图每项 | ✅ |
+| `scm/sourceControl` | Repositories 视图右键 | ❌ |
+| `scm/change/title` | 内联 diff 编辑器标题栏 | ❌ |
+
+`when` 子句可用 `scmProvider` / `scmResourceGroup` context key 精细控制。来源:官方指南示例 `when: "scmProvider == git && scmResourceGroup == merge"`。
+
+> 结论:**每个文件的二级菜单、行内 inline 按钮、分组级菜单都能自定义**——这部分原生 SCM 完全够用。
+
+### 1.8 提交图(SourceControlHistoryItem)— proposed,不可稳定复用
+
+`SourceControlHistoryItem` / `SourceControlHistoryItemChange` / `scmHistoryProvider` **至今仍是 proposed API**。VS Code 团队成员 lszomoru 2025-05-13 在 issue [#185269](https://github.com/microsoft/vscode/issues/185269) 明确:「计划 finalize 但无时间表」。定义文件:[vscode.proposed.scmHistoryProvider.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts)。
+
+> 第三方扩展在 Marketplace 发布时使用 proposed API 受限(需特批)。因此 **IDEA 的 Log 提交图不能依赖原生 Source Control Graph,必须自建 TreeView**。
+
+### 1.9 Multi-Diff 编辑器 — proposed
+
+`scmMultiDiffSource`(多文件并排 diff 审查)是 proposed,跟踪 issue [#179000](https://github.com/microsoft/vscode/issues/179000),`vscode.changes` 命令标注「experimental, subject to change」。IDEA 风格的「提交前多文件 diff 预览」短期须自建 Webview 或逐文件 diff。
+
+---
+
+## 2. vscode.git 扩展导出 API(已读源码确认)
+
+> 来源:`extensions/git/src/api/git.d.ts`(完整签名)+ `extensions/git/src/api/api1.ts`(实现)。两文件已逐行读取,下述为源码直接摘录的事实。
+
+### 2.1 版本机制与稳定性
+
+```ts
+export interface GitExtension {
+  readonly enabled: boolean;
+  readonly onDidChangeEnablement: Event<boolean>;
+  getAPI(version: 1): API;   // 唯一版本入口,version 必须传字面量 1
+}
+```
+来源:[git.d.ts `GitExtension`](https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/git.d.ts)。
+
+- **版本机制**:`getAPI(1)` 是唯一导出形态,以字面量 `1` 锁定主版本;若 git 扩展 disabled 会抛错,需监听 `onDidChangeEnablement`。
+- **稳定性**:**这是稳定公开的扩展导出 API**,不是 proposed。第三方扩展经 Marketplace 发布无需特批。来源:官方 [extensions/git/README.md](https://github.com/microsoft/vscode/blob/main/extensions/git/README.md) 明示「The Git extension exposes an API, reachable by any other extension」。
+- **untrusted workspace**:git 扩展在 untrusted workspace 下功能受限(`supportUntrusted: false`),消费方需在 trusted 环境使用。来源:git 扩展 package.json(待核实具体 policy 字段,行为可观察)。
+
+### 2.2 消费声明方式(循证:GitHub PR 扩展即此模式)
+
+**package.json**:
+```json
+{ "extensionDependencies": ["vscode.git"] }
+```
+> `extensionDependencies` 声明运行时依赖,保证激活顺序与可用性。来源:[Extension Manifest 参考](https://code.visualstudio.com/api/references/extension-manifest)。**注意**:不需要 `enabledApiProposals`,因为这不是 proposed API。
+
+**TypeScript 类型**:官方要求「把 `extensions/git/src/api/git.d.ts` 复制进你的扩展源码」。来源:官方 git README。
+
+**运行时获取**(标准模式,来源:[Stack Overflow 官方回答](https://stackoverflow.com/questions/59442180/vs-code-git-extension-api) + [dev.to 实操](https://dev.to/bwfiq/live-syncing-to-a-git-repository-with-a-vs-code-extension-3p8m)):
+```ts
+const gitExt = vscode.extensions.getExtension<GitExtension>('vscode.git')!;
+await gitExt.activate();              // 防御性激活
+const api = gitExt.exports.getAPI(1); // → API
+```
+
+### 2.3 `API` 表面能力(源码确认)
+
+来源:[git.d.ts `API`](https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/git.d.ts) + api1.ts 实现。
+
+| 能力 | API | 备注 |
+|---|---|---|
+| 仓库发现 | `api.repositories: Repository[]`、`onDidOpenRepository`、`onDidCloseRepository`、`getRepository(uri)`、`getRepositoryRoot(uri)` | 多仓库支持完备 |
+| 状态生命周期 | `api.state: 'uninitialized'\|'initialized'` + `onDidChangeState` | 初始化前 `repositories` 为空 |
+| 发布事件 | `onDidPublish` | Commit & Push 完成回调 |
+
+### 2.4 `Repository` 能力(源码逐项确认)— 这是最关键的能力底座
+
+来源:[git.d.ts `Repository`](https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/git.d.ts)。
+
+| IDEA 功能域 | Repository 方法 | 覆盖度 |
+|---|---|---|
+| **变更模型** | `state.indexChanges` / `workingTreeChanges` / `mergeChanges` / `untrackedChanges` + `Status` 枚举(INDEX_MODIFIED/ADDED/DELETED/RENAMED/COPIED + MODIFIED/DELETED/UNTRACKED/IGNORED/INTENT_TO_ADD/INTENT_TO_RENAME/TYPE_CHANGED + 冲突 7 种 ADDED_BY_US...BOTH_MODIFIED) | ✅ 完全覆盖 IDEA 的 M/A/D/U/Renamed/Copied + 冲突 |
+| **stage/unstage** | `add(paths)`、`revert(paths)`(unstage,IDEA 语义)、`clean(paths)`、`restore(paths, {staged, ref})` | ✅ |
+| **commit** | `commit(message, opts?: {all, amend, signoff, signCommit, empty, noVerify, useEditor})` | ✅ 含 amend/signoff/no-verify |
+| **diff** | `diffWithHEAD`、`diffWith(ref)`、`diffIndexWithHEAD`、`diffBetween(ref1,ref2)`、`diffBetweenPatch`、`diffBetweenWithStats` | ✅ 覆盖与分支/HEAD/本地比较 |
+| **blame** | `blame(path)` → string | ✅ Show History/Annotate |
+| **log** | `log(opts?: {maxEntries, path, range, author, grep, refNames, sortByAuthorDate, shortStats})` → `Commit[]` | ✅ 含按作者/路径/消息过滤,Commit 带 hash/message/parents/authorDate/authorName/shortStat |
+| **branch** | `createBranch(name, checkout, ref?)`、`deleteBranch`、`getBranch`、`getBranches(query)`、`setBranchUpstream` | ✅ 创建/检出/删除/重命名(重命名无直接 API,待核实)/比较 |
+| **merge/rebase** | `merge(ref)`、`mergeAbort()`、`rebase(branch)` | ✅ |
+| **stash** | `createStash({message, includeUntracked, staged})`、`applyStash(index)`、`popStash(index)`、`dropStash(index)` | ✅ stash/apply/drop(pop=apply+drop) |
+| **tag** | `tag(name, message, ref?)`、`deleteTag` | ✅ |
+| **fetch/pull/push** | `fetch(options)`、`pull(unshallow?)`、`push(remote, branch, setUpstream, force)` + `ForcePushMode` 枚举 | ✅ push 含 force-with-lease |
+| **checkout** | `checkout(treeish)` | ✅ |
+| **commit 对象** | `getCommit(ref)`、`show(ref, path)`、`buffer(ref, path)`、`getObjectDetails` | ✅ |
+| **worktree** | `createWorktree`、`deleteWorktree` | ✅ |
+| **migrateChanges** | `migrateChanges(sourceRepoPath, {confirmation, deleteFromSource, untracked})` | ⚠️ 源码有,IDEA 对应「Move Changes to Another Changelist/Repo」语义待核实 |
+
+**事件**:`onDidCommit`、`onDidCheckout`、`state.onDidChange`(状态变更)、`ui.onDidChangeSelection`(provider 选中变化)。来源:git.d.ts `Repository` / `RepositoryState` / `RepositoryUIState`。
+
+**InputBox 桥接**:`repository.inputBox`(只暴露 `value` get/set)是原生 `SourceControlInputBox` 的薄包装。来源:api1.ts `ApiInputBox`:
+```ts
+class ApiInputBox implements InputBox {
+  #inputBox: SourceControlInputBox;
+  set value(v) { this.#inputBox.value = v; }
+  get value() { return this.#inputBox.value; }
+}
+```
+即:**通过 git API 只能读写原生 inputBox 的 value,无法增强其 UI**——再次印证须自建 Commit 编辑器。
+
+### 2.5 可注册的扩展点(API.register*)
+
+git API 还允许第三方**注入**能力而非仅消费:`registerPostCommitCommandsProvider`、`registerBranchProtectionProvider`、`registerCredentialsProvider`、`registerRemoteSourceProvider`、`registerPushErrorHandler`、`registerSourceControlHistoryItemDetailsProvider`(提交图 hover/头像/链接增强,注意这是「增强原生 Graph」而非「自建 Graph」)。来源:git.d.ts `API`。
+
+---
+
+## 3. 集成路径对比(决策表)
+
+| 维度 | A. 注册独立 SCM Provider(包装 git CLI) | **B. 纯消费 vscode.git API + 自建 TreeView/WebviewView(推荐)** | C. 注册 SCM Provider + 复用 vscode.git 数据源 |
+|---|---|---|---|
+| **git 操作实现** | 自调 `child_process` git(或包装 `git.path`) | **全部复用 `api.getAPI(1)` 的 Repository 方法** | 复用 git API 读数据,但 stage/commit 走自己的 SourceControl |
+| **与原生 Source Control 视图关系** | **双胞胎冲突**:活动栏会出现两个 Git provider,用户混淆;`extensionDependencies: ["vscode.git"]` 后两者并存 | **零冲突**:原生 git 视图照常,我们的 UI 在**独立视图容器**(Secondary Side Bar) | 双胞胎冲突(同 A) |
+| **多 changelist 表达** | 多 `SourceControlResourceGroup` 近似(语义有损:无 group 级 message/active) | **自建 TreeView,每个 changelist 一个根节点**,可挂独立 message/active 标记,语义无损 | 同 A,有损 |
+| **Commit 窗口(模板/校验/Amend/Author)** | 受限于原生 inputBox(单行,无校验,Provider 已删)→ **无法实现** | **自建 WebviewView 编辑器,100% 自由**(多行/模板/Conventional Commits 校验/Amend/Author) | 同 A,无法实现 |
+| **Log 提交图** | 原生 Graph 是 proposed,不可稳定用 → 仍需自建 | 自建 TreeView + `Repository.log()`(稳定) | 自建(同 B) |
+| **文件右键菜单/状态色** | 原生 SCM 菜单贡献点(强) | 自建 TreeView 的 `view/item/context`(同样强,且更可控) | 原生 SCM 菜单(强) |
+| **性能** | 自管 git 进程,需自行处理状态轮询/缓存 | **复用 git 扩展已优化的状态机**(增量 status、diff 缓存、操作队列),性能最优 | 双重状态管理,冗余 |
+| **迁移/维护成本** | 高:重写 git 状态机、diff 解析、错误码映射 | **中:需自绘 UI,但 git 逻辑全复用** | 最高:既要管 SCM provider 契约又要桥接 git API |
+| **与 AI Agent 未来扩展(提交信息生成/审查)耦合度** | 自管状态,AI 集成需额外适配 | **天然契合**:AI 可直接读 `Repository.state.*Changes` + 调 `commit()` | 冗余 |
+| **循证先例** | SVN 扩展(非 git 场景才合理) | **GitLens、vscode-pull-request-github 均为消费 git API 模式** | 无知名先例 |
+
+### 推荐路径:B(纯消费 vscode.git API + 自建视图)
+
+**理由(对应 AGENTS.md 准则)**:
+
+1. **复用驱动(拿来主义)**:git 状态机、diff/blame/log/stash/branch/merge/rebase 全部已由 vscode.git 团队(Lszomoru 等)实现并优化,重造=重复造轮子,违背「Compose over Reinvent」。GitHub 官方的 PR 扩展(microsoft/vscode-pull-request-github)即采用此模式,源码含 `gitExtensionIntegration.ts`。来源:[vscode-pull-request-github 仓库](https://github.com/microsoft/vscode-pull-request-github)。
+
+2. **正交分解(Engine/Adapter/Agent/UI 分层)**:
+   - **Engine**:vscode.git API(不可变底座)
+   - **Adapter**:我们封装一层 `GitRepositoryAdapter`,把 `Repository` 适配成领域模型(Changelist/FileChange)
+   - **UI**:自建 TreeView(changes)+ WebviewView(commit dialog)+ TreeView(log/branches/stash)
+   - **Agent**(未来):AI 层只依赖 Adapter 的领域模型,不碰 vscode API
+
+3. **单一事实源**:git 真实状态只在 vscode.git 维护一份,我们的 Adapter 是只读视图 + 委托写操作,杜绝 Split-Brain(若走 A/C,两套状态会断裂)。
+
+4. **系统完整性(涟漪效应预判)**:路径 A/C 会与原生 git 视图产生「谁是 source of truth」的竞争(用户在原生视图 stage,我们的视图不同步);路径 B 不接管原生视图,只做增量 UI,涟漪最小。
+
+5. **规避 proposed API 陷阱**:B 不依赖任何 proposed API(scmHistoryProvider/scmMultiDiffSource/scmProviderOptions/scmInputBoxValueProvider 全避开),可在 Marketplace 无障碍发布。
+
+---
+
+## 4. changelist 模型映射方案(路径 B 下的落地)
+
+### 4.1 概念映射
+
+| IDEA 概念 | VS Code 落地(路径 B) | 实现 |
+|---|---|---|
+| Changelist(多组) | 自建 TreeView 的**一级节点** | `vscode.window.createTreeView('sofia.changes', {...})`,每个 changelist 一个 `TreeItem`(collapsible) |
+| Active changelist | 一级节点带 `description=active` + 图标徽标;新增文件默认归入此节点 | Adapter 维护 `activeChangelistId`,TreeView 高亮 |
+| Changelist 内文件 | 一级节点下的**叶子节点** | `TreeItem` with `resourceUri` + `iconPath`(状态色)+ `description`(M/A/D) |
+| 文件状态色 M/A/D/U/R/C | 叶子节点的 `iconPath`(ThemeIcon + ThemeColor)或 `description` 文字 | 复用 git 扩展同款 `gitDecoration.*Foreground` ThemeColor |
+| Move changes(跨 changelist 移文件) | 叶子节点右键 `Move to Changelist...` 命令 | Adapter 维护内存 changelist→files 映射;stage/commit 时按 changelist 过滤 `add(paths)` |
+
+### 4.2 与 git 的语义桥接(关键设计)
+
+git 本身**没有 changelist** 概念,只有 stage(index)。IDEA 的 changelist 是「工作区变更的逻辑分组」。映射策略:
+
+- **物理层**:所有变更仍来自 `Repository.state.workingTreeChanges`(单一事实源)。
+- **逻辑层**:Adapter 维护一个**本地 changelist 分配表**(`Map<filePath, changelistId>`),持久化到 workspace state(`context.workspaceState`)或 `.idea` 风格本地文件。
+- **提交语义**:「Commit 某 changelist」= `add(该 changelist 的 paths)` + `commit(msg)` + (可选)保留其余未 stage。这正向复刻 IDEA「selective commit」。
+- **Default changelist**:即 active changelist,未显式分配的变更自动落入。
+
+> 注意:此设计下,changelist 是**纯客户端逻辑分组**,不写 git 元数据(IDEA 的 changelist 也仅存于 `.idea/workspace.xml`,同理)。这与 git 的 stage 是两套正交机制,需在 UI 上明确区分(可提供「stage = 临时索引」「changelist = 持久分组」的认知锚点)。
+
+### 4.3 备选(若要借用原生 SCM 视图)
+
+放弃 TreeView,改为**注册一个自己的 SourceControl + 每个 changelist 一个 ResourceGroup**。代价:无 group 级 message、无 active 概念、与原生 git 视图双胞胎。**不推荐**,仅作为「快速 MVP」降级方案。
+
+---
+
+## 5. Commit 窗口 UI 落地(路径 B 下的落地)
+
+### 5.1 容器选择:Secondary Side Bar 的 WebviewView + 自定义视图容器
+
+**package.json 贡献**(来源:[viewsContainers 贡献点](https://code.visualstudio.com/api/references/contribution-points#contributes.viewsContainers)):
+```json
+{
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [{ "id": "sofia-git", "title": "SOFIA Git", "icon": "..." }]
+    },
+    "views": {
+      "sofia-git": [
+        { "id": "sofia.changes",  "name": "Changes",  "type": "tree" },
+        { "id": "sofia.commit",   "name": "Commit",   "type": "webview" },
+        { "id": "sofia.log",      "name": "Log",      "type": "tree" },
+        { "id": "sofia.shelf",    "name": "Shelf",    "type": "tree" },
+        { "id": "sofia.stash",    "name": "Stash",    "type": "tree" }
+      ]
+    }
+  }
+}
+```
+
+> GitLens 正是此模式:在 Source Control 活动栏挂自定义视图(来源:[gitkraken/vscode-gitlens issue #213](https://github.com/gitkraken/vscode-gitlens/issues/213) 讨论其视图置于 SCM 面板)。
+
+### 5.2 IDEA 顶部 Commit/Shelf/Stash 标签页 → VS Code 表达
+
+两种实现,择一:
+
+- **方案 1(推荐):平铺视图节点**。上图 `sofia-git` 容器下并列 Changes/Commit/Log/Shelf/Stash 五个 view,用户点击切换(等价标签页)。
+- **方案 2:单 WebviewView 内自绘 Tabs**。一个 `sofia.main` webview 内用前端框架渲染 IDEA 风格 Tab 栏 + 各面板内容。自由度最高但失去原生 a11y/快捷键集成。
+
+### 5.3 Commit Message 编辑器(替代原生 inputBox)
+
+- 用 `WebviewView` 渲染一个**多行 Monaco-like 编辑器**(可用 `<textarea>` + 自绘,或内嵌 Monaco via webview)。
+- 能力复刻:模板注入、Conventional Commits 实时校验(前端逻辑)、Amend 开关、Author 覆盖、sign-off/fixup 选项。
+- 提交动作:webview 通过 `acquireVsCodeApi().postMessage` 把 message + opts 发回扩展,扩展调 `repository.commit(message, opts)`(opts 映射 `amend/signoff/signCommit/noVerify`)。
+- **与原生 inputBox 的协同**:可选「单向同步」——把自建编辑器的 value 回写 `repository.inputBox.value`,让原生视图也能看到(反之亦然,监听 inputBox 变化)。但因 inputBox 单行且无校验,这只是兼容性糖,主交互在自建编辑器。
+
+### 5.4 底部 Commit / Commit and Push 按钮
+
+WebviewView 底部固定区:
+- **Commit** → `repository.commit(msg, opts)`
+- **Commit and Push** → `repository.commit(msg, opts)` 成功后 `repository.push(remote, branch, false, force)`;或监听 `api.onDidPublish`
+- 提交前 Inspection(IDEA 的 pre-commit code inspection):复用 VS Code 诊断——`vscode.languages.getDiagnostics()` 对所选文件取 diagnostics 作为「问题」提示;可选触发 `vscode.executeCodeActionProvider` 预跑 reformat/optimize imports。
+
+### 5.5 右侧 diff 预览
+
+- **方案 1(推荐,零成本)**:单击 Changes 树叶节点 → `vscode.commands.executeCommand('vscode.diff', originalUri, modifiedUri, title)`,originalUri 用 `api.toGitUri(uri, 'HEAD')`(git 扩展提供的 git scheme 资源,自动取 HEAD 版本)。来源:git.d.ts `API.toGitUri`。
+- **方案 2**:Webview 内嵌 diff 视图(自绘,工作量大,不推荐除非要并排多文件)。
+
+### 5.6 Shelf(IDEA 独有,git 无原生对应)
+
+git 的 stash ≠ IDEA 的 shelve。IDEA shelve 是 patch 存储于 `.idea/shelf/`。落地:
+- **近似用 stash**:`createStash({message, includeUntracked, staged})` 存、`applyStash/popStash` 取、`dropStash` 删。语义接近「shelve silently / unshelve」。
+- **忠实复刻 IDEA shelve**:自实现 patch 序列化(`git diff > patch` via `repository.diffBetweenPatch`),存到扩展 storage;apply 用 `repository.apply(patch, {threeWay})` 处理冲突(unshelve with conflict)。来源:git.d.ts `apply(patch, {allowEmpty, reverse, threeWay})` + `diffBetweenPatch`。
+- 推荐 MVP 用 stash 近似,v2 再做忠实 shelve。
+
+---
+
+## 6. 风险与待核实项
+
+| 项 | 状态 | 说明 |
+|---|---|---|
+| `scmHistoryProvider`(提交图)stable | proposed,无时间表 | 来源:issue [#185269](https://github.com/microsoft/vscode/issues/185269)(lszomoru 2025-05)。→ 自建 Log TreeView |
+| `scmMultiDiffSource`(多文件 diff) | proposed,experimental | 来源:issue [#179000](https://github.com/microsoft/vscode/issues/179000)。→ 单文件 diff 或自建 webview |
+| `scmProviderOptions`(SourceControl.contextValue) | proposed | 来源:[vscode.proposed.scmProviderOptions.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts)。路径 B 不需要 |
+| `SourceControlInputBoxValueProvider` | **已删除** | 来源:PR microsoft/vscode#199778 / issue [#195474](https://github.com/microsoft/vscode/issues/195474)。→ 不可用,自建编辑器 |
+| `Repository` 分支**重命名** API | 待核实 | git.d.ts 未见 `renameBranch`;可能需 `branch -m` via 暂无暴露,或用 `setBranchUpstream` 间接。落地时需验证,必要时降级为「删除+创建+checkout」 |
+| `migrateChanges` 的 IDEA 语义对应 | 待核实 | api1.ts 有实现,但「move changes 跨仓库」与 IDEA「跨 changelist」语义不同,需在设计文档澄清 |
+| untrusted workspace 下 git API 行为 | 待核实 | git 扩展 `supportUntrusted` 策略需查其 package.json 确认具体限制 |
+| vscode.git API 跨版本兼容 | 稳定(主版本 1) | `getAPI(1)` 锁主版本;次版本新增字段对消费方透明。建议在 Adapter 层做防御性可选链 |
+
+---
+
+## 7. 关键来源清单(IEEE 风格可溯源)
+
+**源码(GitHub,microsoft/vscode)**:
+- [extensions/git/src/api/git.d.ts](https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/git.d.ts) — GitExtension/API/Repository 全部签名(已逐行读取)
+- [extensions/git/src/api/api1.ts](https://github.com/microsoft/vscode/blob/main/extensions/git/src/api/api1.ts) — API 实现,ApiInputBox 桥接(已逐行读取)
+- [extensions/git/README.md](https://github.com/microsoft/vscode/blob/main/extensions/git/README.md) — 导出 API 公开声明
+- [src/vscode-dts/vscode.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.d.ts) — 稳定 SCM 接口(Note:经 zread 获取为截断版,稳定字段以官方指南+Haxe externs 镜像交叉确认)
+- [src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts) — 提交图 proposed
+- [src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts](https://github.com/microsoft/vscode/blob/main/src/vscode-dts/vscode.proposed.scmProviderOptions.d.ts) — SourceControl.contextValue proposed
+
+**官方文档(code.visualstudio.com)**:
+- [Source Control API – Extension Guides](https://code.visualstudio.com/api/extension-guides/scm-provider) — SCM provider 权威指南(已读全文)
+- [VS Code API Reference](https://code.visualstudio.com/api/references/vscode-api) — 稳定 API 索引
+- [Extension Manifest – extensionDependencies](https://code.visualstudio.com/api/references/extension-manifest)
+- [Contribution Points – viewsContainers/views](https://code.visualstudio.com/api/references/contribution-points#contributes.viewsContainers)
+- [Using Proposed API](https://code.visualstudio.com/api/advanced-topics/using-proposed-api)
+
+**Issue 追踪(proposed API 状态证据)**:
+- [microsoft/vscode#185269 – history provider proposed API(2025-05 仍无 stable 时间表)](https://github.com/microsoft/vscode/issues/185269)
+- [microsoft/vscode#195474 – scm/inputBox menu(InputBoxValueProvider 已删除)](https://github.com/microsoft/vscode/issues/195474)
+- [microsoft/vscode#199778 – delete scmInputBoxValueProvider proposal](https://github.com/microsoft/vscode/issues/199778)
+- [microsoft/vscode#179000 – Multi File Diff Editor(experimental)](https://github.com/microsoft/vscode/issues/179000)
+- [microsoft/vscode#254910 – scmProviderOptions(contextValue proposed)](https://github.com/microsoft/vscode/issues/254910)
+
+**同类扩展先例(消费 git API 模式)**:
+- [microsoft/vscode-pull-request-github](https://github.com/microsoft/vscode-pull-request-github)(含 `src/gitExtensionIntegration.ts`)
+- [gitkraken/vscode-gitlens](https://github.com/gitkraken/vscode-gitlens)(issue [#213](https://github.com/gitkraken/vscode-gitlens/issues/213) 讨论视图容器挂载)
+- [microsoft/vscode-extension-samples – source-control-sample](https://github.com/microsoft/vscode-extension-samples/blob/main/source-control-sample/README.md)
+
+**实操参考**: [Stack Overflow – VS Code Git Extension API](https://stackoverflow.com/questions/59442180/vs-code-git-extension-api)、[dev.to – Live Syncing via Git API](https://dev.to/bwfiq/live-syncing-to-a-git-repository-with-a-vs-code-extension-3p8m)、[Haxe externs – SourceControlResourceState](https://vshaxe.github.io/vscode-extern/vscode/SourceControlResourceState.html) / [SourceControlResourceDecorations](https://vshaxe.github.io/vscode-extern/vscode/SourceControlResourceDecorations.html)
+
+---
+
+## 8. 下一步最佳行动建议(Next Best Action)
+
+1. **固化决策**:本报告推荐路径 B,建议在 `.temp/` 输出一份《集成路径决策 ADR》,锁定「消费 vscode.git API + 自建视图容器」。
+2. **产出 Adapter 层接口设计**:基于 git.d.ts 的 `Repository`/`RepositoryState`/`Change`/`Status`,定义 `GitRepositoryAdapter`(领域模型 Changelist/FileChange/Commit),作为 Engine 与 UI/Agent 的正交边界。
+3. **PoC 验证关键风险点**:(a) `extensionDependencies: ["vscode.git"]` + `getAPI(1)` 拿到 `Repository` 并读取 `workingTreeChanges`;(b) 自建 TreeView 渲染 changelist;(c) WebviewView Commit 编辑器 postMessage → `repository.commit()`。三项跑通即可消除主要技术不确定性。
+4. **v1 范围裁剪(YAGNI)**:Shelf 先用 stash 近似;Log 先用 `Repository.log()` 自建 TreeView;多文件 diff 先单文件 `vscode.diff`。复杂项排入 v2。
+5. **并行 Track**:本报告聚焦集成路径;建议并行启动「IDEA Git 工具窗口 UI 细节调研」(各面板交互/快捷键/状态机)与「AI Agent 提交信息生成/代码审查」调研,三者可在 Adapter 层汇合。
+
+
+############################################################

--- a/docs/research/03-extension-blueprint.md
+++ b/docs/research/03-extension-blueprint.md
@@ -1,0 +1,296 @@
+# VS Code 扩展工程蓝图:技术栈决策 + 工程骨架 + IDEA→VS Code UI 表面映射表
+
+> 本文档面向 Track3,目标:让开发可立即落地。所有事实论断均附 GitHub 路径或官方文档 URL,不确定处标注「待核实」。遵循 AGENTS.md 的熵减、正交分解、复用驱动、单一事实源原则。
+
+## 一、技术栈决策表
+
+| 维度 | 决策 | 理由与证据 | 次选/风险 |
+|------|------|-----------|-----------|
+| **语言** | **TypeScript(strict)** | VS Code 官方与 `vscode-extension-samples` 全量使用 TS;`@types/vscode` 提供完整类型,版本由 `engines.vscode` 锁定。[Extension Anatomy](https://code.visualstudio.com/api/get-started/extension-anatomy) | — |
+| **打包** | **esbuild**(CJS format) | 官方 `esbuild-sample` 已默认 esbuild,推荐优先于 webpack。`format: 'cjs'`、`platform: 'node'`、`external: ['vscode']`、`bundle: true`。[官方 esbuild.js](https://github.com/microsoft/vscode-extension-samples/blob/master/esbuild-sample/esbuild.js) / [Bundling Extensions](https://code.visualstudio.com/api/working-with-extensions/bundling-extension) | webpack(历史遗留项目可用) |
+| **类型检查** | **tsc --noEmit 独立运行** | esbuild 仅 strip 类型、不做类型检查,故需 `tsc --noEmit` 并行。`esbuild-sample/package.json` 的 `scripts` 体现:`compile = check-types && lint && esbuild`。[package.json](https://github.com/microsoft/vscode-extension-samples/blob/master/esbuild-sample/package.json) | — |
+| **单元测试** | **Vitest**(纯逻辑层,不含 vscode API) | Vitest 速度快、API 与 Jest 兼容。**关键约束**:Vitest 仅用于 `engine/adapter` 中不依赖 `vscode` 命名空间的纯函数(git 解析、diff 算法、变更分组)。ESM-only 与 VS Code 扩展宿主 CJS 不兼容,故**禁止**把 Vitest 套进扩展宿主集成测试。[vitest-dev/vscode Issue #168](https://github.com/vitest-dev/vscode/issues/168) | mocha(若团队更熟悉) |
+| **集成测试** | **@vscode/test-electron + Mocha** | 官方唯一推荐路径,在 Extension Development Host 内运行,可访问真实 `vscode` API。Linux CI 需 `xvfb-run`。[Testing Extensions](https://code.visualstudio.com/api/working-with-extensions/testing-extension) | — |
+| **测试时长** | 单元 < 30s,集成 < 2min,**总计 < 3min** | 契合 AGENTS.md「本地运行 < 3 min」。策略:Vitest 默认 worker 并行 + 仅对 `engine/` 跑;集成测试用最小 fixture 仓库 + `--grep` 分片。 | — |
+| **Lint** | **ESLint 9 flat config + typescript-eslint** | `esbuild-sample` 已采用 `@eslint/js` + `typescript-eslint` + `@stylistic/eslint-plugin`。[package.json devDeps](https://github.com/microsoft/vscode-extension-samples/blob/master/esbuild-sample/package.json) | — |
+| **格式化** | **Prettier**(与 ESLint 解耦,仅管格式) | 避免 stylistic 插件与 Prettier 职责重叠,`@stylistic/eslint-plugin` 仅保留 ESLint 无法覆盖项 | — |
+| **包管理器** | **pnpm**(用户硬约束) | AGENTS.md「JS/TS 必须用 pnpm」。注意:`vsce package` 与 `.vsix` 打包兼容 pnpm,但需在 `package.json` 声明 `packageManager` 字段并配 `.npmrc` 的 `node-linker=hoisted` 以规避某些原生依赖 hoisting 问题 | — |
+| **发布打包** | **@vscode/vsce**(`vsce package` → `.vsix`) | 官方打包工具,`vscode:prepublish` 触发 esbuild production bundle。[Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) | — |
+| **engines.vscode 基线** | **`^1.85.0`**(Nov 2023) | 见下方「engines.vscode 版本策略」专节 | — |
+
+**关于 engines.vscode 版本策略**:VS Code API 一旦稳定即向后兼容(扩展在更高版本无条件运行);基线越低可用 API 越少。`@types/vscode` 的 `devDependencies` 版本**必须**与 `engines.vscode` 的最低版本一致(而非最新),这样若误用更高版本 API,`tsc` 会编译失败。本项目当前基线分支为 `feature/1.x.x`,结合 2026 年 6 月的时间点,目标扩展主版本建议设为 `1.x`(与分支呼应),`engines.vscode` 锁定 `^1.85.0` 以获得稳定且足够现代的 API 面(含 SCM、Tree、Webview 全部所需稳定 API)。证据:[Extension Manifest](https://code.visualstudio.com/api/references/extension-manifest) / [vscode-discussions #2437](https://github.com/microsoft/vscode-discussions/discussions/2437)。
+
+---
+
+## 二、工程骨架蓝图
+
+### 2.1 目录树(呼应 AGENTS.md 正交分解:Engine/Adapter/Agent/UI)
+
+```
+sofia-git/
+├── .vscode/
+│   ├── launch.json          // Extension Host + Webview 调试配置
+│   ├── tasks.json           // esbuild watch / tsc --noEmit tasks
+│   └── recommended-settings.json
+├── esbuild.js               // 沿用官方 esbuild-sample 范式
+├── .vscodeignore            // 排除 src/、tests/、node_modules
+├── package.json             // Extension Manifest + contributes
+├── tsconfig.json            // strict, outDir 标记对纯逻辑层可见
+├── eslint.config.mjs        // flat config
+├── .prettierrc
+├── pnpm-lock.yaml
+├── .npmrc                   // node-linker=hoisted(规避 vsce/pnpm hoisting)
+│
+├── src/
+│   ├── extension.ts         // 唯一入口:activate/deactivate,仅做装配(DI)
+│   │
+│   ├── engine/              // 【引擎层】与 VS Code 无关的纯领域逻辑,可独立测试
+│   │   ├── git/             //   git 命令封装:status/diff/log/blame/branch/stash/shelve 语义解析
+│   │   ├── model/           //   领域模型:FileChange、Changelist、Commit、Branch、StashEntry
+│   │   ├── diff/            //   diff 计算与行级 patch(partial commit 基础)
+│   │   └── scm-mapping/     //   文件状态色映射:M/A/D/U/Renamed/Copied → decorations
+│   │
+│   ├── adapter/             // 【适配层】桥接 engine ↔ vscode API,封装 I/O 与翻译
+│   │   ├── scm/             //   SourceControlProvider 实现(createSourceControl/ResourceGroup)
+│   │   ├── tree/            //   TreeDataProvider 实现(Local Changes、Branches、Log、Shelf、Stash)
+│   │   ├── webview/         //   WebviewView 宿主(Commit 窗口、Log 图)+ postMessage 协议
+│   │   ├── diff/            //   TextDocumentContentProvider 自定义 diff 源(scheme 注册)
+│   │   ├── commands/        //   command 注册与分发,menu when-clause 上下文键
+│   │   └── storage/         //   globalState/workspaceState/SecretStorage 封装
+│   │
+│   ├── agent/               // 【代理层】AI 能力(预留),与 engine/adapter 解耦
+│   │   ├── commit-message/  //   AI 提交信息生成
+│   │   ├── review/          //   提交前 AI 代码审查
+│   │   ├── semantic-group/  //   AI 变更语义分组
+│   │   ├── conflict/        //   AI 冲突解决
+│   │   └── llm-client/      //   抽象 LLM 适配(支持多 provider)
+│   │
+│   ├── ui/                  // 【UI 层】Webview 前端产物(独立 esbuild/web bundle)
+│   │   ├── commit-view/     //   Commit 提交窗口 React/Preact 前端
+│   │   ├── log-graph/       //   Log 提交图渲染(SVG/Canvas 自绘 graph)
+│   │   └── shared/          //   共享组件 + postMessage 类型契约
+│   │
+│   ├── shared/              // 【契约层】跨层共享类型(webview↔host 消息协议、常量)
+│   │   └── protocol.ts      //   单一事实源:message type 定义
+│   │
+│   └── infra/               // 【基础设施】日志、错误处理、事件总线、配置读取
+│
+├── media/                   // 图标(SVG)、Commit 窗口 webview 的 HTML/CSS 入口
+│
+└── tests/
+    ├── unit/                // Vitest:engine/* 与 diff/scm-mapping 纯逻辑
+    ├── integration/         // @vscode/test-electron + Mocha:adapter/* 适配层
+    └── fixtures/            // 测试用 git 仓库快照(最小化)
+```
+
+**职责边界说明(单一事实源 + 正交分解)**:
+- `engine/` 零依赖 `vscode`,可被 Vitest 与未来 CLI 双复用,是项目核心 IP。
+- `adapter/` 是唯一接触 `vscode` API 的层(除 `extension.ts`),把引擎领域模型翻译为 SCM/Tree/Webview 表面。
+- `agent/` 依赖 `engine/` 但不依赖 `adapter/`,确保 AI 能力可独立演进与替换 provider。
+- `shared/protocol.ts` 是 webview↔extension 通信的**唯一类型契约源**,前端与宿主共同引用,杜绝双份定义。
+- `ui/` 前端走独立 bundle(esbuild `format: 'iife'`),产物放 `media/`。
+
+### 2.2 package.json 核心 contributes 片段示意
+
+以下聚焦本项目所需的 `viewsContainers` / `views` / `commands` / `menus` / `configuration` / `keybindings`,语法遵循 [Contribution Points](https://code.visualstudio.com/api/references/contribution-points)。
+
+```jsonc
+{
+  "name": "sofia-git",
+  "displayName": "Sofia Git",
+  "engines": { "vscode": "^1.85.0" },
+  "main": "./dist/extension.js",
+  "contributes": {
+    "viewsContainers": {
+      // 活动栏(最左侧)新增容器;也支持 activitybar/panel
+      "activitybar": [
+        {
+          "id": "sofia-git",
+          "title": "Sofia Git",
+          "icon": "media/sofia-git-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      // Commit 提交窗口用 WebviewView 放 Secondary Side Bar 槽位
+      "sofia-git-commit": [
+        { "id": "sofiaGit.commitView", "name": "Commit", "type": "webview" }
+      ],
+      // Local Changes / Branches / Log / Shelf / Stash 用 TreeView
+      "sofia-git": [
+        { "id": "sofiaGit.localChanges", "name": "Local Changes" },
+        { "id": "sofiaGit.branches",     "name": "Branches" },
+        { "id": "sofiaGit.log",          "name": "Log" },
+        { "id": "sofiaGit.shelf",        "name": "Shelf" },
+        { "id": "sofiaGit.stash",        "name": "Stash" }
+      ]
+    },
+    "viewsWelcome": [ /* 空仓库欢迎视图 */ ],
+    "commands": [
+      { "command": "sofiaGit.commit",          "title": "Commit",           "icon": "$(check)" },
+      { "command": "sofiaGit.commitAndPush",   "title": "Commit and Push",  "icon": "$(cloud-upload)" },
+      { "command": "sofiaGit.stage",           "title": "Stage",            "icon": "$(add)" },
+      { "command": "sofiaGit.unstage",         "title": "Unstage",          "icon": "$(remove)" },
+      { "command": "sofiaGit.moveChangelist",  "title": "Move to Changelist" },
+      { "command": "sofiaGit.shelve",          "title": "Shelve Changes" },
+      { "command": "sofiaGit.unshelve",        "title": "Unshelve Silently" },
+      { "command": "sofiaGit.stashCreate",     "title": "Stash Changes" },
+      { "command": "sofiaGit.stashApply",      "title": "Apply Stash" },
+      { "command": "sofiaGit.branchCreate",    "title": "New Branch" },
+      { "command": "sofiaGit.branchCheckout",  "title": "Checkout" },
+      { "command": "sofiaGit.diffWithHead",    "title": "Compare with HEAD" },
+      { "command": "sofiaGit.showHistory",     "title": "Show History" }
+    ],
+    "menus": {
+      // 视图标题栏操作
+      "view/title": [
+        { "command": "sofiaGit.commitAndPush", "when": "view == sofiaGit.commitView", "group": "navigation" }
+      ],
+      // 树节点右键:Local Changes 文件项
+      "view/item/context": [
+        { "command": "sofiaGit.stage",        "when": "view == sofiaGit.localChanges && viewItem == fileChange", "group": "1_modify@1" },
+        { "command": "sofiaGit.moveChangelist","when": "view == sofiaGit.localChanges && viewItem == fileChange", "group": "1_modify@2" }
+      ],
+      // SCM 视图集成(若走 SCM API)
+      "scm/resourceState/context": [
+        { "command": "sofiaGit.moveChangelist", "when": "scmProvider == sofia-git", "group": "1_modify@2" }
+      ],
+      // 命令面板的命令可见性控制
+      "commandPalette": [
+        { "command": "sofiaGit.shelve", "when": "false" } // 仅右键触发,不在面板暴露
+      ]
+    },
+    "keybindings": [
+      { "command": "sofiaGit.commit", "key": "ctrl+enter", "mac": "cmd+enter", "when": "editorTextFocus && sofiaGit.commitInputFocus" }
+    ],
+    "configuration": {
+      "title": "Sofia Git",
+      "properties": {
+        "sofiaGit.commit.template":      { "type": "string", "default": "", "description": "Commit message 模板" },
+        "sofiaGit.commit.conventional":  { "type": "boolean", "default": true, "description": "Conventional Commits 校验" },
+        "sofiaGit.log.graphTheme":       { "type": "string", "default": "classic" },
+        "sofiaGit.agent.enabled":        { "type": "boolean", "default": false, "description": "启用 AI 代理能力" },
+        "sofiaGit.agent.provider":       { "type": "string", "enum": ["claude","openai"], "default": "claude" }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "pnpm run package",
+    "compile":   "pnpm run check-types && pnpm run lint && node esbuild.js",
+    "watch":     "pnpm npm-run-all -p watch:*",
+    "watch:esbuild": "node esbuild.js --watch",
+    "watch:tsc":     "tsc --noEmit --watch -p tsconfig.json",
+    "package":  "pnpm run check-types && pnpm run lint && node esbuild.js --production",
+    "check-types": "tsc --noEmit",
+    "lint": "eslint",
+    "test:unit":       "vitest run",
+    "test:integration": "node ./tests/run-integration.js"
+  }
+}
+```
+
+> `activationEvents: []` 空数组即可:`onCommand`、`onView`、`onStartupFinished` 等已可由 `contributes` 自动推断(自 1.74 起)。[Extension Anatomy](https://code.visualstudio.com/api/get-started/extension-anatomy)
+
+---
+
+## 三、IDEA → VS Code UI 表面映射表
+
+> 对照 Track1 的功能区域,逐一映射到具体 VS Code API。核心决策:**Local Changes 走 SCM API(复用原生 Source Control 视图)**,而非自建 TreeView,以最大化复用原生 diff/stage/discard 能力(复用驱动)。
+
+| IDEA 功能区域 | VS Code 实现载体 | 关键 API / 贡献点 | 关键设计点 |
+|--------------|-----------------|------------------|-----------|
+| **统一 Git 工具窗口(顶部容器)** | Activity Bar 视图容器 + 视图槽位 | `viewsContainers.activitybar` + `views` + 拖入 Secondary Side Bar | 一个 `sofia-git` 容器承载所有 TreeView;Commit 窗口作为 `type:"webview"` 视图,可置 Secondary Side Bar |
+| **Commit 提交窗口** | **WebviewView**(Commit 窗口主体) + **SCM Input Box**(原生 commit 输入,可选) | `vscode.window.registerWebviewViewProvider` / `sourceControl.inputBox` / `acceptInputCommand` | 主体走 WebviewView 以承载模板、Conventional 校验、Amend/Author 控件;Ctrl+Enter 提交通过 `keybindings` + `when` 子句锚定。证据:[Source Control API - SCM Input Box](https://code.visualstudio.com/api/extension-guides/scm-provider) |
+| **Commit / Commit and Push 按钮** | 视图标题栏 inline 图标按钮 | `menus: view/title` + `group: "navigation"` + `$(check)`/`$(cloud-upload)` codicon | navigation 组内联渲染,溢出自动进 `…` 菜单 |
+| **Changes 变更文件树(多 changelist)** | **SCM ResourceGroup**(主) — 每个 changelist = 一个 ResourceGroup | `vscode.scm.createSourceControl(id,'Sofia Git')` + `sourceControl.createResourceGroup(id,label)` | 与原生 Git 一致的设计:Staged / Local Changes 各为 group。证据:[Source Control API - Source Control Model](https://code.visualstudio.com/api/extension-guides/scm-provider) |
+| **文件状态色 M/A/D/U/Renamed/Copied** | `SourceControlResourceState` + `SourceControlResourceDecorations` + `ThemeColor` | `decorations: { iconPath, strikeThrough, faded, tooltip }`、`letter`、`color: new ThemeColor('gitDecoration.modified')` | 复用 `gitDecoration.*` 主题色 token 保持视觉一致。证据:[Source Control API](https://code.visualstudio.com/api/extension-guides/scm-provider) / [vscode.SourceControlResourceState](https://vshaxe.github.io/vscode-extern/vscode/SourceControlResourceState.html) |
+| **Commit Message 多行编辑区 + 模板/校验** | WebviewView 内多行 `<textarea>` + 模板逻辑在 `engine/` | webview 前端 + `shared/protocol.ts` 消息协议 | 校验逻辑下沉 `engine/`,webview 仅渲染结果 |
+| **move changes / active changelist** | `scm/resourceState/context` 菜单 + 命令重设 group 的 `resourceStates` | `menus: scm/resourceState/context` | 同一文件可跨 group 移动(原生支持) |
+| **右侧 diff 预览** | 原生 diff(`vscode.diff`) + 自定义 diff 源 | `vscode.commands.executeCommand('vscode.diff', leftUri, rightUri)` + `registerTextDocumentContentProvider`(自定义 scheme 提供 HEAD 版本内容) | 单击 ResourceState 时,其 `command` 字段触发 diff。证据:[Source Control API - Source Control View](https://code.visualstudio.com/api/extension-guides/scm-provider) |
+| **partial commit / selective commit / 行级** | 原生 Quick Diff 行级暂存 + 自定义 `scm/change/title` 命令 | `quickDiffProvider` + `scm/change/title` 菜单 + `stageChange(uri, changes, index)` | 行级暂存复用原生能力,`engine/diff/` 提供行级 patch 计算 |
+| **Log 提交图(graph)** | **Webview**(全功能 graph 自绘) | `WebviewView` + 前端 SVG/Canvas 渲染 + `postMessage` 传输 commit 列表 | graph 自绘(参考 GitLens 风格),而非 TreeView(TreeView 无法绘制连线)。证据:[Webview API](https://code.visualstudio.com/api/extension-guides/webview) |
+| **Log 搜索/作者/路径/日期过滤/blame** | Webview 内过滤器 + `engine/git/` 执行 `git log --author/--since/-- path` | postMessage ↔ engine | blame 可用 `vscode.commands.executeCommand('git.blame')`(待核实:原生是否可复用)或自建 `registerDocumentRangeCoverageProvider`(待核实 API 名) |
+| **Branches(创建/检出/删除/rename/compare/merge/rebase)** | **TreeView** + `view/item/context` 右键 | `TreeDataProvider` + `menus: view/item/context` + `when: viewItem == branch\|remoteBranch` | TreeView 足够;每节点 `command` 触发检出,`contextValue` 控制菜单项可见性 |
+| **Shelf(shelve/unshelve silently/with conflict)** | TreeView(Shelf 节点)+ engine 语义映射 | `TreeDataProvider` + engine 封装 git stash 派生语义 | IDEA Shelf 是私有概念,VS Code 无原生对应;用 git stash + patch 元数据模拟,`engine/git/` 负责语义转换 |
+| **Stash(stash/apply/drop)** | TreeView(Stash 节点) | `TreeDataProvider` + engine 执行 `git stash list/apply/drop` | engine 解析 `git stash list` 为模型 |
+| **Console(Git 操作输出)** | **OutputChannel** | `vscode.window.createOutputChannel('Sofia Git', { log: true })` | 用 log 模式 OutputChannel 获得 trace/debug/info 分级 |
+| **Inspection(提交前代码检查)** | 命令触发 `vscode.execute...` 诊断 + agent 层 AI 审查 | `vscode.commands.executeCommand('vscode.executeDocumentDiagnostisProvider', uri)`(待核实精确 API) + `agent/review/` | 复用 VS Code 诊断能力 + 预留 AI 审查 |
+| **Rollback/Revert/Ignore/Compare/Show History** | 命令 + context menu | `scm/resourceState/context` + 命令实现 | revert→engine `git checkout --`;ignore→写 `.gitignore`;history→打开 Log Webview 跳转 |
+| **Diff(与分支/HEAD/本地)** | `vscode.diff` + `registerTextDocumentContentProvider` | 自定义 scheme(如 `sofiagit:HEAD/<ref>/<path>`)提供任意 ref 版本 | 单一 diff 入口,ref 解析下沉 engine |
+| **StatusBar(当前分支/状态)** | StatusBarItem | `vscode.window.createStatusBarItem` | 复用原生 SCM 状态条或并行 |
+| **状态持久化** | `globalState`/`workspaceState`/`SecretStorage` | `context.globalState`/`context.workspaceState`/`context.secrets` | globalState 存 UI 偏好;SecretStorage 存 LLM API key(AI 层)。证据:[VS Code API Reference](https://code.visualstudio.com/api/references/vscode-api) |
+
+**映射表核心结论**:复用驱动原则下,**Local Changes 必须走 SCM API**(原生 Source Control 视图),把文件状态色、行级暂存、discard、diff 全部复用 VS Code 既有能力,避免重复造轮子;**Log 图与 Commit 窗口必须走 Webview**(TreeView 无法绘制 graph 连线、Input Box 无法承载复杂表单);**Branches/Shelf/Stash 走 TreeView**(结构性树数据,原生右键菜单足够)。
+
+---
+
+## 四、关键陷阱与规避
+
+### 4.1 VS Code SCM 视图与原生 Source Control 的冲突(最高优先级)
+
+- **陷阱**:VS Code 自带 Git 扩展已注册 `id: 'git'` 的 `SourceControl`。若本项目也提供 SCM provider,会出现两个并列的「源代码管理」条目,用户困惑;`gitDecoration.*` 主题色与 `scmProvider`/`scmResourceGroup` context key 易串。
+- **规避**:
+  1. 本项目 SCM 用**独立 `id`(如 `sofia-git`)**,通过 `when: scmProvider == sofia-git` 隔离菜单项,绝不硬绑 `git`。
+  2. 产品定位上明确:本项目是「IDEA 风格增强层」,**默认不接管原生 Git**,而是作为并列的增强 SCM provider;若要替代,需提供 `configuration` 开关 `sofiaGit.replaceNativeGit`(关闭原生 git 扩展需 `extensions.json`,影响大,默认关闭)。
+  3. 文件状态色复用 `ThemeColor('gitDecoration.modified')` 等**已存在的主题 token**,而非新造,保证深色模式一致。[Source Control API](https://code.visualstudio.com/api/extension-guides/scm-provider)
+
+### 4.2 Webview 性能与内存
+
+- **陷阱**:Webview 是独立 iframe 进程,Log 图与 Commit 窗口各开一个,内存占用高;大量 commit 数据 `postMessage` 传输(结构化克隆)会卡顿。
+- **规避**:
+  1. **数据分页/虚拟滚动**:Log 图前端对 > 500 条 commit 做虚拟列表;宿主侧只传当前可见窗口的 commit。
+  2. **`retainContextWhenHidden`** 默认 `false`:视图隐藏时销毁 webview,按需重建;Commit 窗口可设 `true`(状态需保留),Log 设 `false`。
+  3. **postMessage 改用增量更新**(diff-patch),非全量替换。
+  4. 遵循 Matt Bierner(Webview 作者)的性能建议:避免在 webview 内做重计算,graph 渲染用轻量 SVG 而非重型框架。[Matt Bierner 博客](https://blog.mattbierner.com/vscode-webview-web-learnings/)
+
+### 4.3 Activation 时机
+
+- **陷阱**:扩展若用 `onStartupFinished` 或 `*` 全量激活,拖慢编辑器启动。
+- **规避**:`activationEvents: []` 留空,依赖 `contributes` 自动推断:`onView:sofiaGit.localChanges`(打开视图时)、`onCommand:sofiaGit.*`(命令触发时)。**避免** `onStartupFinished`,除非确有必要(如需预先扫描仓库)。[Extension Anatomy](https://code.visualstudio.com/api/get-started/extension-anatomy)
+
+### 4.4 engines.vscode 版本策略
+
+- **陷阱**:`@types/vscode` 用最新版而 `engines.vscode` 设旧基线,导致用了新 API 但 CI 通过、用户装上后运行时 `TypeError`。
+- **规避**:`@types/vscode` 的 `devDependencies` **严格对齐** `engines.vscode` 的最低版本(本项目 `^1.85.0` → `@types/vscode: 1.85.0`),让 `tsc` 在编译期拦截。[vscode-discussions #2437](https://github.com/microsoft/vscode-discussions/discussions/2437)
+
+### 4.5 esbuild CJS 与 Vitest ESM 的测试架构割裂
+
+- **陷阱**:把所有测试(含依赖 `vscode` API 的)塞进 Vitest,会因 ESM/CJS 不兼容爆炸。
+- **规避**:严格分层——**Vitest 仅测 `engine/`(零 vscode 依赖)**,`@vscode/test-electron + Mocha` 测 `adapter/`(需 vscode API)。这是本骨架把 `engine/` 与 `adapter/` 物理分层的核心动因之一。[vitest-dev/vscode Issue #168](https://github.com/vitest-dev/vscode/issues/168)
+
+### 4.6 `.vscodeignore` 与 vsce 包体积
+
+- **规避**:`.vscodeignore` 必须排除 `src/`、`tests/`、`esbuild.js`、`tsconfig.json`、`.eslintrc` 等,只发布 `dist/` + `media/` + `package.json` + `README.md`,否则 `.vsix` 膨胀。
+
+### 4.7 拼写/契约漂移(Single Source of Truth)
+
+- **规避**:`shared/protocol.ts` 是 webview↔host 消息类型的唯一来源,前端与宿主均 import;杜绝在两侧各定义一份 message interface 造成 split-brain。
+
+---
+
+## 五、Next Best Action(主动导航建议)
+
+1. **立即落地**:用 `pnpm` 初始化项目,复制 `esbuild-sample` 的 `esbuild.js` + `package.json` 脚本结构作为骨架零点(零试错,官方验证过)。
+2. **Track 协同**:本骨架的 `engine/` 分层是为 Track2(git 引擎实现)与 Track4(AI agent)准备的并发协作边界——Track2 只动 `engine/`,Track4 只动 `agent/`,Track1(UI 描摹)对应 `adapter/scm|tree|webview` + `ui/`。
+3. **风险前置验证**:优先做 PoC——(a) 一个最小 SCM provider(`createSourceControl` + 单 ResourceGroup)验证与原生 Git 共存;(b) 一个最小 WebviewView 验证 Log graph 自绘管线。两项验证通过后再全量铺开。
+4. **待核实项跟进**:(a) `vscode.executeDocumentDiagnostisProvider` 的精确命令名(用于 Inspection);(b) 原生 `git.blame` 命令是否可直接复用于本项目;(c) IDEA Shelf 与 git stash 的语义映射细节需 Track1 输出 IDEA 侧行为描述后细化。
+
+---
+
+**核心参考来源**(均经核实可达):
+- [Extension Anatomy](https://code.visualstudio.com/api/get-started/extension-anatomy)
+- [Source Control API](https://code.visualstudio.com/api/extension-guides/scm-provider)
+- [Webview API](https://code.visualstudio.com/api/extension-guides/webview)
+- [Bundling Extensions](https://code.visualstudio.com/api/working-with-extensions/bundling-extension)
+- [Testing Extensions](https://code.visualstudio.com/api/working-with-extensions/testing-extension)
+- [Extension Manifest / engines.vscode](https://code.visualstudio.com/api/references/extension-manifest)
+- [Contribution Points](https://code.visualstudio.com/api/references/contribution-points)
+- [esbuild-sample esbuild.js](https://github.com/microsoft/vscode-extension-samples/blob/master/esbuild-sample/esbuild.js)
+- [esbuild-sample package.json](https://github.com/microsoft/vscode-extension-samples/blob/master/esbuild-sample/package.json)
+- [Vitest 与 @vscode/test-electron 兼容性 Issue #168](https://github.com/vitest-dev/vscode/issues/168)
+- [engines.vscode 基线讨论 vscode-discussions #2437](https://github.com/microsoft/vscode-discussions/discussions/2437)
+- [Matt Bierner: Webview 性能](https://blog.mattbierner.com/vscode-webview-web-learnings/)
+- [vscode.SourceControlResourceState 类型](https://vshaxe.github.io/vscode-extern/vscode/SourceControlResourceState.html)
+- [内置 git 扩展源码 microsoft/vscode/extensions/git](https://github.com/microsoft/vscode/tree/main/extensions/git)
+
+> 注:本调研未写入任何文件(当前 Plan 模式)。完整 Markdown 产物已在上方输出,可直接交付主 Agent 整合或落盘为 `docs/.agents/track3-vscode-extension-blueprint.md`。

--- a/docs/research/04-publishing-cicd.md
+++ b/docs/research/04-publishing-cicd.md
@@ -1,0 +1,259 @@
+# Track4: VS Code 扩展发布策略 + CI/CD 流水线蓝图
+
+> 复刻目标:把"IDEA Git 工具窗口 + Commit 窗口"的 VS Code 扩展,从源码可靠、安全、自动化地交付到所有目标编辑器用户(原生 VS Code、Cursor、Windsurf、Gitpod、VSCodium/Code-OSS)。
+> 所有事实论断均附 GitHub 路径或官方文档 URL;不确定项标注"待核实"。
+
+---
+
+## 1. 发布前置清单(Manifest + Publisher + 凭证)
+
+### 1.1 `package.json` 必填 / 推荐字段(逐字段说明)
+
+依据 [Publishing Extensions 官方文档](https://code.visualstudio.com/api/working-with-extensions/publishing-extension):
+
+| 字段 | 必填性 | 说明与依据 |
+|---|---|---|
+| `name` | **必填** | 扩展唯一短名。Marketplace 要求扩展名全局唯一,重名报 `ERROR The extension 'name' already exists`。 |
+| `publisher` | **必填** | 与 Marketplace Publisher ID 一致;OpenVSX 中即"命名空间 (namespace)"。 |
+| `version` | **必填** | **仅支持 `major.minor.patch`**,不支持 semver 预发布标签(`-beta` 等)。 |
+| `engines.vscode` | **必填** | 兼容性闸门。`^1.85.0` 表 ≥1.85 全可用;pre-release 须 `>= 1.63.0`。 |
+| `main` / `browser` | 视情况 | 扩展入口;`browser` 用于 web 扩展(平台特定扩展同时跑浏览器须 target `web`)。 |
+| `icon` | 强烈推荐 | 相对路径指向 **≥128×128 PNG**(禁止 SVG)。 |
+| `repository` | 推荐 | 公开 GitHub URL;`vsce` 据此自动改写 README 相对链接与图片地址。 |
+| `license` | 推荐 | 项目已 MIT,填 `"MIT"` 并附 `LICENSE` 文件。 |
+| `categories` / `keywords` | 推荐 | 分类 + 标签,**keywords 上限 30**。 |
+| `README.md` / `CHANGELOG.md` | 推荐 | Marketplace 卡片正文 + 版本历史 tab。 |
+| `galleryBanner.color` / `pricing` / `sponsor` | 可选 | 横幅色 / `Free`/`Trial`(`vsce>=2.10.0`) / 赞助链接(`vsce>=2.9.1`)。 |
+| `scripts.vscode:prepublish` | 推荐 | 打包前钩子,通常 `"npm run compile"`。 |
+
+**安全硬约束**(违规即拒绝发布):
+- `icon` 不可为 SVG;`badges` 不可为 SVG(除非来自可信徽章提供方);
+- `README.md` / `CHANGELOG.md` 图片 URL **必须 https**,且不得为 SVG。
+
+### 1.2 Publisher 与凭证
+
+**VS Code Marketplace**(后端为 Azure DevOps,见 [Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token)):
+1. 创建 Azure DevOps 组织;
+2. 创建 PAT —— **Organization 选 `All accessible organizations`**(选错单一组织是常见失败),**Scopes = Marketplace → Manage**;
+3. [Marketplace publisher 管理页](https://marketplace.visualstudio.com/manage/publishers/) → Create publisher(ID 创建后**不可改**);
+4. `vsce login <publisher id>` 验证。
+
+**OpenVSX**(依据 [eclipse/openvsx cli/README.md](https://github.com/eclipse/openvsx/blob/master/cli/README.md) 与 [Publishing Extensions Wiki](https://github.com/eclipse-openvsx/openvsx/wiki/Publishing-Extensions)):
+1. [open-vsx.org](https://open-vsx.org/) 用 Eclipse/GitHub OAuth 登录,生成 access token;
+2. `ovsx create-namespace <name>`(name = `publisher`)—— **首次发布前必须先建 namespace**;
+3. token 通过 `--pat` 或环境变量 `OVSX_PAT` 提供;`ovsx login <name>` 本地存储(keytar + 文件 fallback)。
+
+> **关键安全循证**:`create-namespace` **不自动授予独占发布权**,初始时任何人都能在该 namespace 发布;**必须额外 claim ownership** 才能 exclusive(原话见 [cli/README.md](https://github.com/eclipse/openvsx/blob/master/cli/README.md))。
+
+> **循证更新**:官方现已推荐用 **Microsoft Entra ID + 工作负载身份联邦 (Workload Identity Federation) + 托管标识** 替代长效 PAT(`vsce publish --azure-credential`,需 `vsce>=2.26.1`),消除泄露风险。详见 [Secure automated publishing 章节](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_secure-automated-publishing-to-visual-studio-marketplace)。GitHub Actions 原生不支持 Azure 托管标识,但可用 **GitHub OIDC → Entra 联邦凭证**等效方案(待核实 GA 状态)。
+
+### 1.3 `.vscodeignore` 与依赖锁定
+- 创建 `.vscodeignore` 排除运行时不需要文件(`**/*.ts`、`**/*.map`、测试源、`.github/`);`devDependencies` 自动排除。
+- **关键提醒**:Windows 上打包**丢失 POSIX 可执行位**,部分 `node_modules` 依赖失效;**应在 Linux/macOS 打包**([FAQ](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_common-questions))。
+
+---
+
+## 2. 发布渠道决策
+
+### 2.1 两市场本质差异
+
+| 维度 | VS Code Marketplace (`vsce`) | OpenVSX (`ovsx`) |
+|---|---|---|
+| 治理 | 微软专有(Azure DevOps) | Eclipse 基金会,厂商中立开源(EPL) |
+| 覆盖编辑器 | 原生 VS Code / Insiders | **Cursor、Windsurf、AWS Kiro、Gitpod、VSCodium、Code-OSS、Theia** |
+| 自托管 | 不支持 | 可自建 registry |
+| 来源 | [code.visualstudio.com](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) | [eclipse/openvsx](https://github.com/eclipse/openvsx)、[open-vsx.org](https://open-vsx.org/) |
+
+### 2.2 Cursor / Windsurf 等 AI IDE 市场归属(决定性循证)
+
+- **Cursor 使用 Open VSX registry,而非 VS Code Marketplace**。来源:[Cursor 论坛官方回复](https://forum.cursor.com/t/cursor-marketplace-installs-offers-outdated-version-of-open-vsx-extension-despite-latest-version-being-available-upstream/159718)、[安全研究 mazinahmed.net](https://mazinahmed.net/blog/publishing-malicious-vscode-extensions/)(明确指出 OpenVSX 驱动 Cursor/Windsurf/Kiro 等 AI IDE)、[devclass 报道](https://www.devclass.com/development/2025/04/08/vs-code-extension-marketplace-wars-cursor-users-hit-roadblocks/1629343)。
+- 后果:**只**发 Marketplace 时,Cursor/Windsurf 用户**装不到**(除非手动 `.vsix`)。
+
+### 2.3 决策:**双市场同时发布**
+
+理由(契合本项目"未来引入 AI Agent 自主代理能力"的受众):
+1. **AI 受众主战场在 OpenVSX**:Cursor/Windsurf 用户是 AI 提交/AI 代码审查的核心早期采用者,却只能从 OpenVSX 安装;
+2. **Marketplace 是事实主流**:原生 VS Code 基数最大,pre-release/平台包/verified publisher 等特性更完善;
+3. **边际成本低**:`ovsx` 与 `vsce` CLI 几乎同构,同一 VSIX 可直接 `ovsx publish`,CI 仅追加一个 step;
+4. **抢注风险**:OpenVSX namespace 默认非排他,**务必 `create-namespace` 后立即 claim ownership**([cli/README.md](https://github.com/eclipse/openvsx/blob/master/cli/README.md))。
+
+> 已有成熟 Action 一键双发:`HaaLeo/publish-vs-code-extension`(支持 vsce + ovsx,见 [GitHub Marketplace Action](https://github.com/marketplace/actions/publish-vs-code-extension))——符合 AGENTS.md"复用驱动,优先组合而非重复造轮子"。
+
+---
+
+## 3. CI/CD 流水线蓝图
+
+### 3.1 总体架构
+
+```
+[ push/PR ] ──▶ lint ──▶ build ──▶ test 矩阵(ubuntu/macos/windows) ──▶ package vsix ──▶ upload artifact
+                                                                              │
+[ tag v* ] ─────────────────────────────────────────────────────────────────▶ publish(vsce + ovsx)
+```
+
+### 3.2 `.github/workflows/ci.yml`(骨架)
+
+依据 [Continuous Integration 官方文档](https://code.visualstudio.com/api/working-with-extensions/continuous-integration):
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main, master]
+    tags: ['v*']
+  pull_request:
+
+permissions:
+  contents: read           # 最小权限:默认只读
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'pnpm' }   # 本项目统一 pnpm(AGENTS.md)
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint && pnpm run compile
+      - run: xvfb-run -a pnpm test                  # Linux 需 xvfb 包装 Electron
+        if: runner.os == 'Linux'
+      - run: pnpm test
+        if: runner.os != 'Linux'
+
+  package:
+    needs: test
+    runs-on: ubuntu-latest        # 必须 Linux 打包,保 POSIX 文件属性
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: 'pnpm' }
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm dlx @vscode/vsce package
+      - uses: actions/upload-artifact@v4
+        with: { name: vsix, path: '*.vsix' }
+
+  publish:
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: production       # 加审批门 + secret 隔离
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { name: vsix }
+      - run: pnpm dlx @vscode/vsce publish --packagePath *.vsix
+        env: { VSCE_PAT: ${{ secrets.VSCE_PAT }} }
+      - run: pnpm dlx ovsx publish *.vsix
+        env: { OVSX_PAT: ${{ secrets.OVSX_PAT }} }
+```
+
+**核心要点**(均循证):
+- **`xvfb-run -a npm test`** 仅 Linux 需要(Electron 需 X server),官方原话见 [CI 文档 GitHub Actions 节](https://code.visualstudio.com/api/working-with-extensions/continuous-integration#_github-actions);Linux 另需 `libasound2 libgbm1 libgtk-3-0 libnss3`([GitLab CI 节](https://code.visualstudio.com/api/working-with-extensions/continuous-integration#_gitlab-ci))。
+- **PAT 作为 GitHub encrypted secret**,`vsce`/`ovsx` 默认读环境变量,命令行不明文。
+- **发布条件**:`startsWith(github.ref, 'refs/tags/v')`,打 tag 才发布。
+- **平台特定扩展**:若引入 native node 模块(git 二进制),需 `vsce package --target win32-x64 win32-arm64 linux-x64 darwin-arm64 ...`,每 target 产独立 vsix;`--target` 自 `vsce 1.99.0` 支持([Platform-specific extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_platform-specific-extensions))。纯 TS 初期**无需**,降本。
+
+### 3.3 关键 Action 版本
+- `actions/checkout@v4`、`actions/setup-node@v4`、`actions/upload-artifact@v4`、`actions/download-artifact@v4`;
+- `@vscode/test-electron`(或新版 VS Code Test CLI)驱动集成测试;
+- 第三方:`HaaLeo/publish-vs-code-extension`(双发)、`github/codeql-action`(SAST)。
+
+---
+
+## 4. 版本与发布治理
+
+### 4.1 SemVer(Marketplace 特殊约束)
+- 仅支持 `major.minor.patch`,**不支持 semver 预发布后缀**([官方原话](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_pre-release-extensions))。
+- 版本号不可重发;pre-release 与 release 版本号必须互异。
+
+### 4.2 Pre-release 通道(odd/even 约定)
+官方推荐([同上](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_pre-release-extensions)):
+- **release 用 偶数 minor**:`1.2.*`、`1.4.*`;
+- **pre-release 用 奇数 minor**:`1.3.*`、`1.5.*`;
+- `vsce publish --pre-release`,需 `engines.vscode >= 1.63.0`;
+- VS Code 自动更新到最高版本,故发 release 前应先发更高 pre-release,避免 pre-release 用户回滚。
+
+### 4.3 CHANGELOG 维护
+- `CHANGELOG.md` 放根目录,Marketplace 自动渲染独立 tab;
+- 建议 [Keep a Changelog](https://keepachangelog.com/) 格式,配合 Conventional Commits 自动生成;
+- 图片必须 https、非 SVG。
+
+### 4.4 回滚方案 —— 版本不可撤销是核心约束
+
+| 操作 | 效果 | 可逆性 |
+|---|---|---|
+| `vsce unpublish <id>` | **整个扩展下架**,保留统计但失去自动更新来源 | 重发需重新积累 |
+| 删除**单个版本**(管理页 More Actions → Reports → Delete this version) | 删该版本 | **不可逆**,**不可删最新版本**,**版本号永久不可复用** |
+| 覆盖同版本号发布 | Marketplace **拒绝重复版本** | 不支持 |
+
+**官方推荐对策**(综合 [Publishing Extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_removing-specific-extension-versions)、[vsce issue #846](https://github.com/microsoft/vscode-vsce/issues/846)、[Stack Overflow](https://stackoverflow.com/questions/69342687/ive-published-a-wrong-version-number-to-vscode-marketplace-best-way-to-handle)):
+1. **首选**:立即发更高版本号的修复版(`1.2.3` 坏→发 `1.2.4`),自动更新推送修复;
+2. **次选**:最新版本严重缺陷时,先删该版本(管理页),再发修复版(注意该版本号永久作废);
+3. **回滚演练**:CI 保证 tag→发布 < 10 min,这是唯一可靠回滚路径;
+4. **绝不用 `unpublish` 回滚**:丢失统计与信用([Reddit 踩坑](https://www.reddit.com/r/vscode/comments/1idwar5/i_made_a_terrible_mistake_unpublishing_my/));
+5. **Deprecate 替代删除**:可申请标记 deprecated,UI 显示删除线但不失信用([deprecate 流程](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#_deprecating-extensions))。
+
+OpenVSX 删除策略相对宽松,但为双市场一致,统一遵循"出新版本即回滚"。
+
+---
+
+## 5. 风险与规避(逐条)
+
+### 5.1 PAT 泄露(最高危)
+- **风险**:PAT 进 commit/日志,攻击者可投毒发布恶意扩展(供应链攻击)。先例:Eclipse 曾因泄露的 OpenVSX token 紧急吊销([安全报道](https://www.informationsecurity.com.tw/article/article_detail.aspx?aid=12417))。
+- **规避**:
+  1. PAT 仅存 GitHub **encrypted secrets**,绝不入仓;
+  2. PAT **短过期**(90 天)+ 最小 scope(Marketplace Manage);
+  3. 优先迁移 **Entra 托管标识 + OIDC 联邦**(消除长效 secret);
+  4. CI `permissions: contents: read`,publish job 用 `environment: production` 加审批门;
+  5. 所有 action **pin 到完整 commit SHA**,防 tag 篡改([OpenSSF](https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/));
+  6. 启用 secret scanning + push protection。
+
+### 5.2 版本/发布不可撤销
+- **风险**:误发坏版本无法"静默删除",已安装用户已收到坏更新。
+- **规避**:见 §4.4,以"快速补丁版本"为唯一回滚范式;发布前必过 3 平台测试门;pre-release 通道吸收 AI Agent 等高风险不稳定特性。
+
+### 5.3 CI 多平台测试成本
+- **风险**:`ubuntu×macos×windows` 计费累积;Windows/macOS runner 倍率高。
+- **规避**:
+  1. PR 仅跑 `ubuntu-latest` 单格快速门;
+  2. main 与 tag 跑完整矩阵;
+  3. 纯 TS 无原生依赖时省去 platform-specific 打包,只产通用 vsix;
+  4. `fail-fast: false` 保留全量失败信号(熵减);
+  5. Linux 用 `xvfb-run -a` 而非常驻进程。
+
+### 5.4 供应链与遥测合规
+- **供应链**:Dependabot security updates + `pnpm audit` step + CodeQL([GitHub Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use));考虑 SBOM(`syft`/`cyclonedx`)随 Release 附带。
+- **遥测**:未来引入 AI Agent(调外部 LLM),**必须**提供 `telemetry.enableTelemetry` 开关,默认关闭;遵守 [VS Code telemetry API](https://code.visualstudio.com/api/extension-capabilities/common-capabilities)(最新隐私 API 细节待核实)。
+- **许可证**:项目已 MIT,填 `"license": "MIT"` 并保留 `LICENSE` 文件。
+
+---
+
+## 关键来源索引
+
+- [Publishing Extensions — VS Code 官方](https://code.visualstudio.com/api/working-with-extensions/publishing-extension)
+- [Continuous Integration — VS Code 官方](https://code.visualstudio.com/api/working-with-extensions/continuous-integration)
+- [microsoft/vscode-vsce](https://github.com/microsoft/vscode-vsce) / [microsoft/vscode-test](https://github.com/microsoft/vscode-test)
+- [eclipse/openvsx — cli/README.md](https://github.com/eclipse/openvsx/blob/master/cli/README.md) / [Publishing Extensions Wiki](https://github.com/eclipse-openvsx/openvsx/wiki/Publishing-Extensions) / [open-vsx.org](https://open-vsx.org/)
+- [Cursor 使用 OpenVSX(官方论坛)](https://forum.cursor.com/t/cursor-marketplace-installs-offers-outdated-version-of-open-vsx-extension-despite-latest-version-being-available-upstream/159718) / [OpenVSX 驱动 AI IDE 安全分析](https://mazinahmed.net/blog/publishing-malicious-vscode-extensions/)
+- [GitHub Actions 安全(OpenSSF)](https://openssf.org/blog/2024/08/12/mitigating-attack-vectors-in-github-workflows/) / [GitHub Secure use reference](https://docs.github.com/en/actions/reference/security/secure-use)
+- [Publish VS Code Extension Action(双发)](https://github.com/marketplace/actions/publish-vs-code-extension)
+- [vsce 版本不可删 issue #846](https://github.com/microsoft/vscode-vsce/issues/846) / [版本回滚 SO](https://stackoverflow.com/questions/69342687/ive-published-a-wrong-version-number-to-vscode-marketplace-best-way-to-handle)
+
+---
+
+## 下一步最佳行动建议(Next Best Action)
+
+1. **先落地 §3.2 `ci.yml` 的 test+package+artifact 三 job**:验证 3 平台通过率与 `xvfb` 集成,暂不接 publish(零风险)。
+2. **同步创建 Publisher + OpenVSX namespace**:立即 `ovsx create-namespace` 并 **claim ownership**,防止命名空间抢注。
+3. **PAT 治理决策点**:评估是否一步到位上 Entra 托管标识(消除 PAT),还是先用 secret + 短过期 PAT 过渡——决定 publish job 认证实现。
+4. **pre-release 路线**:AI Agent 自主代理属高风险新特性,建议首版即建立 `odd minor` pre-release 通道(如 `0.3.x`)吸收早期 Cursor/Windsurf 反馈,稳定后升 `0.4.x` release。
+
+> 风险提示:`engines.vscode` 下限、是否需 native git 二进制(影响 platform-specific)、与 Cursor 不支持 API 的兼容边界,需在扩展架构 Track 协同确定,反向影响本流水线的矩阵与打包策略。
+
+
+############################################################

--- a/docs/research/05-ai-agent-seams.md
+++ b/docs/research/05-ai-agent-seams.md
@@ -1,0 +1,251 @@
+# Track5:AI Agent 架构预留设计报告(Hyper Git)
+
+> 调研截至 2026/06/27。所有事实论断附来源(GitHub 路径/官方文档 URL)。不确定处标注"待核实"。
+> 核心立场:本扩展定位为 **IDEA Git 工具窗口的完整复刻**。VS Code 内置 Copilot **已有**提交信息生成能力([VS Code 官方介绍](https://code.visualstudio.com/docs/sourcecontrol/overview)),因此我们的 AI 层必须做"差异化与可组合性",而非重复造轮子——这契合 AGENTS.md 的"复用驱动"与"正交分解"。
+
+---
+
+## 1. AI 落地场景清单(git/commit 环节)
+
+按"价值 × 难度 × 与 VS Code 内置能力的差异化"三维度评估。
+
+| # | 场景 | 输入 | 输出 | 价值 | 难度 | 推荐落地机制 |
+|---|------|------|------|------|------|------|
+| 1 | **AI 提交信息生成** | staged diff(可含历史 commit 风格、团队 Conventional Commits 规范、本次 changelist 分组意图) | 符合规范的单行 subject + 多行 body,流式输出 | 高 | 低 | Language Model API(`vscode.lm`)+ prompt-tsx;触发位为 SCM `inputBox` 旁按钮(复刻 IDEA 的 ✨ 图标) |
+| 2 | **提交前 AI 代码审查(本地 PR review)** | staged 文件 + diff + 仓库上下文(相关符号/调用方) | 问题列表(严重度、文件:行、建议修复),可阻断或放行 commit | 极高 | 中 | Language Model API + Chat Tools(供 Agent 调用 `read_file`/`grep_symbols`);**对接 IDEA 的 `beforeCheckin` hook 语义** |
+| 3 | **AI 变更语义分组(自动 changelist 归类)** | Local Changes 全部变更文件 + diff 摘要 | 建议的 changelist 分组(如 "feature-A 相关"、"重构"、"配置"),支持一键应用 | 高 | 中 | Language Model API(聚类式 prompt);结果写回 changelist 模型(本扩展自管的分组数据结构) |
+| 4 | **AI 冲突解决助手** | merge conflict 文件(ours/theirs/base 三方) | 建议的合并结果 + 解释,可逐块采纳 | 高 | 高 | Language Model API(三方 diff prompt)+ inline diff 预览;**注意:需用户确认,不可自动写入**(参考 VS Code 工具确认机制 [`prepareInvocation`](https://code.visualstudio.com/api/extension-guides/ai/tools)) |
+| 5 | **AI Release Notes / Changelog** | 区间内的 commit 列表 + tag 范围 | 面向用户的 release notes(markdown) | 中 | 低 | Language Model API + prompt-tsx;接入 Log 视图的"生成 changelog"动作 |
+| 6 | **AI Blame 解释** | 某行/某块的 commit history(blame 输出) | 该变更的业务意图解释、是否为热修/回退关联 | 中 | 中 | Chat Participant(`@sofia-git`)+ Chat Tools(`git_blame`/`git_show`) |
+| 7 | **AI Commit 摘要搜索**(Log 增强) | 自然语言查询("上周修复登录 bug 的提交") | 匹配的 commit 列表 | 中 | 中 | Chat Participant + Chat Tools;复用 Log 过滤管道 |
+
+**差异化设计要点**(对齐"复用驱动"):
+- VS Code 内置 Copilot 仅做场景 1 的"通用版",**无团队规范注入、无 changelist 分组上下文、无本地代码审查阻断能力**。我们的差异化 = **把 commit 流程的完整上下文(changelist/staged 状态/团队规范)作为 prompt 上下文**,并把 AI 结果**回写到 IDE 工作流**(分组直接落到 changelist 树、审查阻断 commit 按钮),这是内置 Copilot 做不到的。
+- 业界实践佐证差异化方向:GitLens 已支持 AI commit message 生成(OpenAI/Anthropic/Gemini 多 provider)[GitLens Discussion #2581](https://github.com/gitkraken/vscode-gitlens/discussions/2581);Microsoft 官方建议 subject ≤ 50 字符、body ≤ 2 句、遵循 Conventional Commits([VS 官方博客](https://devblogs.microsoft.com/visualstudio/customize-your-ai-generated-git-commit-messages/));CodeRabbit 已有"semantic diffs that group related code movement"(场景 3 的先例)[CodeRabbit docs](https://docs.coderabbit.ai/changelog);AI 冲突解决在业界仍是"emerging niche",差异化机会最大([前述搜索结论](https://code.visualstudio.com/api/extension-guides/ai/tools))。
+
+---
+
+## 2. VS Code AI 官方机制能力地图(2026 现状)
+
+### 2.1 Language Model API(`vscode.lm`)——**底层模型访问,所有 AI 场景的基础**
+- **核心 API**:`vscode.lm.selectChatModels({vendor, id, family, version})` 返回 `LanguageModelChat[]`;`model.sendRequest(messages, options, token)` 返回流式 `LanguageModelChatResponse`([LM API 官方文档](https://code.visualstudio.com/api/extension-guides/ai/language-model))。
+- **关键约束**:
+  - **不支持 system message**,仅 User/Assistant 两种消息([同上](https://code.visualstudio.com/api/extension-guides/ai/language-model))——persona/规则必须放在第一条 User message。
+  - Copilot 模型**需用户同意(consent)**,以认证对话框形式呈现,故 `selectChatModels` **必须在用户主动触发的动作(如命令)中调用**([同上](https://code.visualstudio.com/api/extension-guides/ai/language-model))。
+  - 模型列表会变(gpt-4o/claude-3.5-sonnet 等),必须**防御式编程**:无匹配模型时 `selectChatModels` 返回空数组,需优雅降级([同上](https://code.visualstudio.com/api/extension-guides/ai/language-model))。
+  - **限流**:VS Code 对每个扩展的请求数透明计量并影响用户配额;**不得用于集成测试**([同上](https://code.visualstudio.com/api/extension-guides/ai/language-model))。
+  - 推理非确定性,可单测的部分是"prompt 构造 + 响应解析"这一**确定性层**,模型交互层不可单测([同上](https://code.visualstudio.com/api/extension-guides/ai/language-model))。
+
+### 2.2 Chat Participant API(`@sofia-git`)——**对话式入口**
+- 注册 `vscode.chat.createChatParticipant(id, handler)`,实现 `ChatRequestHandler`;通过 `ChatContext` 获取 `history`/`prompt`,用 `ChatResponseStream` 流式返回 markdown/按钮/进度/文件树([Chat Participant 官方文档](https://code.visualstudio.com/api/extension-guides/ai/chat),[教程](https://code.visualstudio.com/api/extension-guides/ai/chat-tutorial))。
+- **适用场景**:场景 6(AI Blame 解释)、7(自然语言搜 commit)等"用户提问式"交互;**不适合**提交信息生成(那是单向生成,不是对话)。
+- 推荐:作为 `@sofia-git` 领域专家,而非通用 chat。
+
+### 2.3 Language Model Tools API(Chat Tools)——**让 AI 调用我们的 git 能力**
+- 在 `package.json` 的 `contributes.languageModelTools` 声明工具,代码中 `vscode.lm.registerTool(name, instance)`,实现 `prepareInvocation`(确认)+ `invoke`(执行)([Tools 官方文档](https://code.visualstudio.com/api/extension-guides/ai/tools))。
+- **适用场景**:场景 2(审查需读文件/查符号)、6(blame 需调 git)。例如注册 `sofia_git_blame`、`sofia_get_staged_diff`、`sofia_read_file` 工具,让 Agent 自主调用。
+- **关键价值**:把本扩展的 git 能力(Engine 层)**暴露给任意 Agent**(内置 Copilot Agent、MCP Agent、第三方),实现"可组合性"——这是复刻 IDEA 之外的核心增值点。
+- 工具名规范 `{verb}_{noun}`,参数名 `{noun}`;`canBeReferencedInPrompt: true` 让用户用 `#` 引用([同上](https://code.visualstudio.com/api/extension-guides/ai/tools))。
+- 官方建议:工具会执行有副作用操作时,`prepareInvocation` 必须给用户**确认消息**([同上](https://code.visualstudio.com/api/extension-guides/ai/tools))——**这是 AI 冲突解决不可自动写入的安全依据**。
+
+### 2.4 prompt-tsx(`@vscode/prompt-tsx`)——**prompt 的结构化编排**
+- 用 TSX 声明 prompt,支持按模型上下文窗口**动态裁剪**、工具结果(`prompt-tsx-parts`)回填、`@vscode/prompt-tsx-elements` 复用元素([prompt-tsx 官方文档](https://code.visualstudio.com/api/extension-guides/ai/prompt-tsx),[GitHub microsoft/vscode-prompt-tsx](https://github.com/microsoft/vscode-prompt-tsx),npm `0.4.0-alpha.x` — alpha,待核实稳定性)。
+- **适用场景**:复杂 prompt(提交信息生成含团队规范 + diff + 历史风格;审查含代码上下文)。**当前版本为 alpha,生产需谨慎评估**。
+
+### 2.5 Language Model Chat Provider API(BYOK)——**模型来源可切换的关键**
+- `vscode.lm.registerLanguageModelChatProvider(vendor, provider)`,provider 实现 `provideLanguageModelChatInformation`(模型发现)+ `provideLanguageModelChatResponse`(流式响应)+ `provideTokenCount`(token 计数)([LM Chat Provider 官方文档](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider))。
+- BYOK 自 2025/03 首发,2025/10 v1.104 扩展为 Provider API,支持 Ollama(本地)/OpenRouter/OpenAI 等([BYOK 官方博客](https://code.visualstudio.com/blogs/2025/10/22/bring-your-own-key))。
+- **Copilot Business/Enterprise 管理员可禁用 BYOK 策略**([同上](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider))——企业部署需考虑。
+
+### 2.6 关键事实:VS Code 内置 Copilot 已有 commit message 生成
+- SCM 输入框旁的 ✨ 图标,分析 staged diff + 历史 commit 风格生成([VS Code overview](https://code.visualstudio.com/docs/sourcecontrol/overview),[community discussion #51577](https://github.com/orgs/community/discussions/51577))。**这是我们必须差异化的对手,也是可共存的伙伴**。
+- Claude Code 扩展已有 issue 请求支持 SCM "Generate Commit Message" provider([claude-code issue #70673](https://github.com/anthropics/claude-code/issues/70673))——说明业界在往"provider 注册"方向收敛。
+
+---
+
+## 3. 当前架构必须预留的"接缝(seam)"
+
+### 3.1 分层归属总览(对齐 AGENTS.md 的 Engine/Adapter/Agent/UI 正交分解)
+
+| 层 | 职责 | AI 相关接缝 |
+|----|------|------------|
+| **Engine** | 纯 git 领域逻辑(diff/commit/blame 的纯函数,无 VS Code 依赖) | 无 AI,但**必须暴露稳定的领域 DTO**(StagedDiff / CommitResult / ConflictHunk)供 Agent 层消费 |
+| **Adapter** | VS Code 平台适配(SCM API 包装、LM API 包装、文件系统) | **ILlmProvider**(封装模型来源切换)、**IChatToolRegistry**(注册工具) |
+| **Agent** | AI 能力实现(各 AI 场景的 provider) | **ICommitMessageProvider / IPreCommitInspector / IChangelistGrouper / IConflictResolver** |
+| **UI** | Webview/命令交互 | AI 触发入口(按钮/命令)、结果渲染、确认对话框 |
+
+### 3.2 接缝契约(中文伪接口描述)
+
+**接缝 1:ILlmProvider(模型来源抽象,Adapter 层)——最关键的接缝**
+```
+接口 ILlmProvider:
+  方法 selectModel(偏好: 模型偏好): Promise<模型句柄 | 空>
+    // 偏好含: 来源优先级[vscodeLM, byokOllama, 自带Key/OpenAI兼容, 本地回退]
+  方法 stream(messages: 消息[], 取消令牌): AsyncIterable<文本片段 | 工具调用>
+  方法 countTokens(text): Promise<number>
+  属性 来源标识: 字符串  // 用于 UI 显示当前用哪个模型
+  属性 可用性: 'ok' | '未授权' | '无限流' | '无可用模型'
+```
+**实现策略**:
+- `VscodeLmProvider`:封装 `vscode.lm.selectChatModels`([LM API](https://code.visualstudio.com/api/extension-guides/ai/language-model))。
+- `ByokProvider`:基于 `registerLanguageModelChatProvider` 或消费他人注册的 provider([Provider API](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider))。
+- `OpenAiCompatibleProvider`:直连 OpenAI 兼容端点([BYOK 博客提到 OpenAI Compatible provider](https://code.visualstudio.com/blogs/2025/10/22/bring-your-own-key))。
+- **为何现在就抽**:模型来源是"未来切换/企业本地化/避免云端强依赖"的命脉。若现在硬编码 `vscode.lm`,未来接 Ollama/自带 key 需大面积重构。这是"防患于未然"而非 YAGNI 反例——因为**契约本身不引入任何 AI 依赖**,只是约束调用边界。
+
+**接缝 2:ICommitMessageProvider(Agent 层)**
+```
+接口 ICommitMessageProvider:
+  方法 generate(输入: { stagedDiff, 历史风格样本, 团队规范, 当前changelist分组 }, 
+                流式回调: (片段) => void, 取消令牌): Promise<{ 消息, 置信度 }>
+  方法 validate(消息, 规范): { 合法: bool, 违规项: [] }  // Conventional Commits 校验
+```
+- 默认实现:`NullCommitMessageProvider`(返回空,UI 显示"AI 未启用")+ `LmCommitMessageProvider`(走 ILlmProvider + prompt-tsx)。
+- **为何现在抽**:提交信息是 commit 流水线的核心产物,留接缝让未来可"无 AI → 内置 LM → 自带 key"平滑切换。
+
+**接缝 3:IPreCommitInspector(Agent 层)——对齐 IDEA CheckinHandler 的 beforeCheckin 语义**
+```
+接口 IPreCommitInspector:   // 直接对齐 IDEA CheckinHandler.beforeCheckin / CommitCheck
+  方法 inspect(输入: { staged文件, diff, 仓库上下文 }): Promise<检查结果>
+    // 检查结果 = { 通过: bool, 问题列表: [{文件, 行, 严重度, 说明, 建议修复}], 阻断提交: bool }
+  方法 getBeforeCheckinPanel(): 配置面板描述   // 对齐 IDEA getBeforeCheckinConfigurationPanel
+```
+- **对齐证据**:IDEA 的 `CheckinHandler` 提供 `beforeCheckin()`(提交前处理,返回 COMMIT/CANCEL)、`checkinSuccessful()`、`checkinFailed()`、`includedChangesChanged()`、`getBeforeCheckinConfigurationPanel()`(返回插入"Before Commit"面板的配置组件)([CheckinHandler.java 源码](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-api/src/com/intellij/openapi/vcs/checkin/CheckinHandler.java))。我们的 `IPreCommitInspector` 是其在 VS Code 侧的等价物。
+- 默认实现:`BuiltInInspector`(TODO 检查、reformat、optimize imports 等非 AI 检查)+ `AiCodeReviewInspector`(可选)。
+
+**接缝 4:IChangelistGrouper(Agent 层)**
+```
+接口 IChangelistGrouper:
+  方法 suggest(输入: { 全部变更文件, diff摘要 }): Promise<分组建议[]>
+    // 分组建议 = { 名称, 文件列表, 理由, 建议的commit信息 }
+  方法 apply(分组建议): void   // 写回 changelist 模型
+```
+
+**接缝 5:IConflictResolver(Agent 层)**
+```
+接口 IConflictResolver:
+  方法 suggest(输入: { 冲突文件, ours, theirs, base }): Promise<解决建议[]>
+    // 解决建议 = { 区块, 建议合并文本, 置信度, 理由 }
+  方法 apply(建议, 用户确认): void   // 必须用户逐块确认,对齐 VS Code 工具确认机制
+```
+
+**接缝 6:IChatToolRegistrar(Adapter 层)——把 git 能力暴露给 Agent**
+```
+接口 IChatToolRegistrar:
+  方法 注册工具(工具名, 工具实现: { prepareInvocation, invoke }): IDisposable
+  方法 注销工具(工具名): void
+```
+- 注册 `sofia_get_staged_diff` / `sofia_git_blame` / `sofia_read_file` / `sofia_move_to_changelist` 等工具([Tools API](https://code.visualstudio.com/api/extension-guides/ai/tools))。这些工具的 `invoke` 直接调 Engine 层的 git 纯函数。
+
+### 3.3 "为何现在就抽而非 YAGNI 反例"的统一论证
+
+> YAGNI 反对的是"为不存在的需求写实现"。这里我们**不写 AI 实现**,只写**接口契约 + Null 实现**,这是"开闭原则的接缝预留",成本极低(几个接口 + 空实现),收益是未来 AI 层**零重构**接入。具体:
+1. **接缝只定义契约,不引入 AI 依赖**——当前 `package.json` 不依赖 Copilot,未启用 AI 的用户无负担([LM API 官方发布建议](https://code.visualstudio.com/api/extension-guides/ai/language-model):非 AI 功能不应强依赖 Copilot)。
+2. **IDEA 的 CheckinHandler 模式已被验证为成熟的 hook 机制**(20+ 年生产验证),复刻其语义是"复用驱动",不是臆测设计。
+3. **关键:ILlmProvider 必须现在抽**——因为它是"未来支持本地/自带 key/不强依赖云端"的唯一命脉,若晚抽,所有 AI 调用散落各处,迁移成本爆炸。
+
+---
+
+## 4. Commit 流水线的可插拔点
+
+```mermaid
+flowchart TD
+    Start([用户点击 Commit]) --> Gather[Engine: 收集 staged diff<br/>+ 当前 changelist 上下文]
+    Gather --> Hook1{"【Hook A: 提交信息生成】<br/>ICommitMessageProvider<br/>默认 Null, 可选 LM"}
+    Hook1 -- 未启用AI/用户已手填 --> Msg[提交消息定稿]
+    Hook1 -- 启用 --> GenMsg[Agent: 流式生成建议消息<br/>+ Conventional Commits 校验]
+    GenMsg --> MsgConfirm{用户确认/编辑消息}
+    MsgConfirm --> Msg
+    Msg --> Hook2{"【Hook B: 提交前检查】<br/>IPreCommitInspector 链<br/>= IDEA beforeCheckin"}
+    Hook2 -- 检查通过 --> Group{"【Hook C: 分组校验】<br/>IChangelistGrouper<br/>可选: 提示拆分多 commit"}
+    Hook2 -- 阻断 --> Block[展示问题列表<br/>阻断提交, 返回 Gather]
+    Group -- 单组/用户确认 --> Commit[Engine: git commit]
+    Group -- 建议拆分 --> Split[提示用户拆分<br/>回 Hook A]
+    Commit --> Hook4{"【Hook D: 成功后处理】<br/>= IDEA checkinSuccessful"}
+    Hook4 --> Push[可选: Commit and Push]
+    Push --> Hook5{"【Hook E: 失败处理】<br/>= IDEA checkinFailed<br/>可触发 IConflictResolver"}
+    Hook5 -. 冲突 .-> Resolve["【Hook F: 冲突解决】<br/>IConflictResolver<br/>用户逐块确认"]
+    Resolve --> Commit
+
+    classDef hook fill:#ffe082,stroke:#f57f17,stroke-width:2px,color:#000
+    classDef engine fill:#b3e5fc,stroke:#0277bd,stroke-width:2px,color:#000
+    classDef agent fill:#c8e6c9,stroke:#2e7d32,stroke-width:2px,color:#000
+    classDef decision fill:#fff9c4,stroke:#f57f17,color:#000
+    class Hook1,Hook2,Group,Hook4,Hook5,Resolve hook
+    class Gather,Commit,Push engine
+    class GenMsg,Split agent
+    class Hook3,MsgConfirm,Block decision
+```
+
+**Hook 注入点说明**(每个 Hook 对应一个接缝,默认全部 Null 实现,通过配置开关启用):
+
+| Hook | 接缝 | IDEA 对应 | 默认行为 | 启用后 |
+|------|------|-----------|----------|--------|
+| A 提交信息生成 | ICommitMessageProvider | (IDEA 无内置,有插件) | 用户手填 | AI 流式建议 |
+| B 提交前检查 | IPreCommitInspector | `beforeCheckin`/`CommitCheck` | 内置非 AI 检查(TODO/reformat) | + AI 代码审查 |
+| C 分组校验 | IChangelistGrouper | (IDEA 无内置) | 单组提交 | 提示语义拆分 |
+| D 成功后处理 | (回调) | `checkinSuccessful` | 刷新变更树 | + AI release notes 累积 |
+| E 失败处理 | (回调) | `checkinFailed` | 展示错误 | + 触发冲突解决 |
+| F 冲突解决 | IConflictResolver | (IDEA 无内置) | 手动解决 | AI 三方合并建议 |
+
+**实现要点**:
+- Hook 链采用**有序责任链**,每个 Hook 返回 `COMMIT | CANCEL | DEFER`(直接对齐 IDEA `CheckinHandler.ReturnResult` 枚举,见 [CheckinHandler.java](https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-api/src/com/intellij/openapi/vcs/checkin/CheckinHandler.java))。
+- `includedChangesChanged()` 等价物:当用户在 commit 对话框勾选/取消文件时,通知 Hook 链刷新(对齐 IDEA 同名方法)——这对 AI 分组/审查的增量更新至关重要。
+
+---
+
+## 5. 渐进式 AI 引入路线(从"无 AI"到"可选 AI")
+
+### 阶段 0:纯复刻期(当前)——**接缝已埋,AI 未启用**
+- 所有 AI 接缝提供 **Null 实现**(Null Object 模式)。
+- `ILlmProvider.selectModel` 恒返回"无可用模型",UI 不显示 AI 按钮。
+- **`package.json` 不声明 Copilot 依赖**(遵循[官方发布建议](https://code.visualstudio.com/api/extension-guides/ai/language-model)),未启用 AI 的用户零负担。
+- 关键:**Hook 链已就位**,提交流程已预留注入点,但链中只有内置非 AI 检查。
+
+### 阶段 1:可选 AI 期——**配置开关 + 模型来源可切换**
+- 新增配置:`sofia.ai.enabled`(总开关)、`sofia.ai.modelSource`(`vscodeLM` | `byok` | `openaiCompatible`)、`sofia.ai.commitMessage.enabled` 等细粒度开关。
+- `ILlmProvider` 按 `modelSource` 路由:
+  - `vscodeLM`:走 `vscode.lm.selectChatModels`([LM API](https://code.visualstudio.com/api/extension-guides/ai/language-model))——需 Copilot 订阅 + 用户 consent。
+  - `byok`:走 BYOK/Ollama([Provider API](https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider))——**本地化、不强依赖云端、企业友好**。
+  - `openaiCompatible`:用户自带 key + 端点([BYOK 博客](https://code.visualstudio.com/blogs/2025/10/22/bring-your-own-key))。
+- UI:开关启用后才出现 ✨ 按钮、AI 审查选项。**默认全关,显式 opt-in**。
+- 落地场景 1(提交信息生成)与场景 2(审查)的 MVP。
+
+### 阶段 2:Agent 化期——**Chat Tools 暴露 + Chat Participant**
+- 通过 `IChatToolRegistrar` 注册 `sofia_*` 系列工具,让**任意 Agent**(内置 Copilot Agent、MCP)能调用本扩展的 git 能力([Tools API](https://code.visualstudio.com/api/extension-guides/ai/tools))。
+- 注册 `@sofia-git` Chat Participant,支持场景 6/7(AI blame 解释、自然语言搜 commit)([Chat API](https://code.visualstudio.com/api/extension-guides/ai/chat))。
+- 落地场景 3(语义分组)、4(冲突解决)、5(release notes)。
+
+### 阶段 3:自主代理期——**多步 Agent 工作流**
+- 组合 Chat Tools + prompt-tsx,实现"一句话完成:分析变更 → 分组 → 生成多条 commit 信息 → 逐个提交"的自主工作流。
+- 安全红线:所有有副作用操作(commit/push/merge)的 Agent 动作**必须经 `prepareInvocation` 用户确认**([Tools 确认机制](https://code.visualstudio.com/api/extension-guides/ai/tools)),对齐 AGENTS.md 的"系统完整性"与二阶思维。
+
+### 平滑切换的设计保障
+1. **配置驱动**:`sofia.ai.*` 配置项决定走 Null 实现还是真实实现,运行时可切,无需重启式重构。
+2. **模型来源解耦**:`ILlmProvider` 使"云端 → 本地 → 自带 key"切换是单点改动,不波及 Agent 层。
+3. **不强依赖云端**:BYOK/Ollama 路径保证企业/离线场景可用([BYOK 博客](https://code.visualstudio.com/blogs/2025/10/22/bring-your-own-key)明确支持 Ollama 本地模型)。
+4. **与内置 Copilot 共存而非冲突**:我们的 AI 聚焦"流程上下文注入 + 回写工作流 + 工具暴露",不重复造通用 commit message 生成。
+
+---
+
+## 关键来源汇总(可溯源)
+
+**VS Code 官方 AI 机制**
+- Language Model API:https://code.visualstudio.com/api/extension-guides/ai/language-model
+- Chat Participant API:https://code.visualstudio.com/api/extension-guides/ai/chat (教程:https://code.visualstudio.com/api/extension-guides/ai/chat-tutorial)
+- Language Model Tools API:https://code.visualstudio.com/api/extension-guides/ai/tools
+- prompt-tsx:https://code.visualstudio.com/api/extension-guides/ai/prompt-tsx | https://github.com/microsoft/vscode-prompt-tsx
+- Language Model Chat Provider API(BYOK):https://code.visualstudio.com/api/extension-guides/ai/language-model-chat-provider | 博客:https://code.visualstudio.com/blogs/2025/10/22/bring-your-own-key
+- Source Control API:https://code.visualstudio.com/api/extension-guides/scm-provider
+- 内置 Copilot commit message:https://code.visualstudio.com/docs/sourcecontrol/overview | https://github.com/orgs/community/discussions/51577
+
+**IDEA hook 机制(可插拔设计参考)**
+- CheckinHandler 源码:https://github.com/JetBrains/intellij-community/blob/master/platform/vcs-api/src/com/intellij/openapi/vcs/checkin/CheckinHandler.java (确认 `beforeCheckin`/`checkinSuccessful`/`checkinFailed`/`includedChangesChanged`/`getBeforeCheckinConfigurationPanel`/`ReturnResult` 枚举)
+- 扩展点文档:https://plugins.jetbrains.com/docs/intellij/intellij-platform-extension-point-list.html
+
+**业界 AI×git 实践**
+- GitLens AI(多 provider):https://github.com/gitkraken/vscode-gitlens/discussions/2581
+- Microsoft AI commit 最佳实践:https://devblogs.microsoft.com/visualstudio/customize-your-ai-generated-git-commit-messages/
+- Conventional Commits 规范:https://www.conventionalcommits.org/en/v1.0.0/
+- CodeRabbit 语义分组:https://docs.coderabbit.ai/changelog
+- Claude Code SCM provider 请求(行业趋势):https://github.com/anthropics/claude-code/issues/70673
+- 本地 LLM commit(Ollama + qwen2.5):https://lobste.rs/s/ndcp7o/conventional_commit_message_generator

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,15 @@
+# 调研报告索引（循证依据）
+
+> 五路并行调研（IDEA 源码 / VS Code SCM API / 开发实践 / 发布 CI / AI Agent）的完整报告。
+> 所有事实论断附 GitHub 源码路径或官方文档 URL；不确定项标注「待核实」。
+> 调研日期：2026-06-27。
+
+| # | 报告 | 核心结论 |
+|---|---|---|
+| 01 | [IDEA 功能复刻矩阵](../requirements/idea-feature-matrix.md) | 56 功能点 / 8 组；多 changelist + 行级跨列表归属是 VS Code 复刻最大差异 |
+| 02 | [VS Code SCM 集成路径](./02-vscode-scm-integration.md) | **路径 B**：消费 vscode.git API + 自建 changelist registry + 自绘视图；scmHistoryProvider 等仍 proposed |
+| 03 | [扩展工程蓝图](./03-extension-blueprint.md) | TS+esbuild+Vitest+test-electron；engine/adapter/agent/ui 正交分层 |
+| 04 | [发布 + CI/CD](./04-publishing-cicd.md) | 双市场（Cursor/Windsurf 走 OpenVSX）；CI 三平台 + xvfb；版本不可撤销 |
+| 05 | [AI Agent 接缝](./05-ai-agent-seams.md) | ILlmProvider/IPreCommitInspector 现在抽（对齐 IDEA CheckinHandler），实现延后 M5 |
+
+> 综合方案见 [工程实施方案](../architecture/engineering-plan.md)。


### PR DESCRIPTION
## 背景
将前序五路并行调研 + 工程方案的会话级产物，固化为仓库内可长期引用、可跨上下文跳转的循证资产，作为后续 M1-M5 开发与验收的基线。

## 交付内容
- **`docs/requirements/idea-feature-matrix.md`** — IDEA Git/Commit 模块 **56 个原子功能点 / 8 组** + CheckinHandler 11 hook 生命周期（已读 `git4idea` / `vcs-api` / `vcs-impl` 源码）。**后续验收的需求基线**。
- **`docs/architecture/engineering-plan.md`** — 全链路工程方案：路径 B 架构决策、模块正交分解、IDEA 功能复刻优先级矩阵、M0-M5 里程碑、风险与验证。**开发蓝图**。
- **`docs/research/`** — 四路循证报告：
  - `02-vscode-scm-integration.md`（SCM API + vscode.git 集成路径 → 路径 B 依据）
  - `03-extension-blueprint.md`（技术栈 + 工程骨架 + IDEA→VS Code UI 映射）
  - `04-publishing-cicd.md`（双市场发布 + CI/CD + 版本治理）
  - `05-ai-agent-seams.md`（AI 接缝 + IDEA CheckinHandler 对齐 + 渐进式引入）
- **`docs/README.md` + `docs/research/README.md`** — 文档与调研总索引。
- **`.agents/knowledge-map.md`** — 补充 `docs/` 文档条目。
- **`.agents/issue.md`** — 追加 #3（pnpm 11.9 需 Node ≥22.13）、#4（CI 集成测试需先构建 dist/）两条 Issue 经验。

## 说明
纯文档变更，不影响代码与测试。所有事实论断附 GitHub 源码路径或官方文档 URL。

🤖 Generated with [Claude Code](https://github.com/claude)