### PR TITLE
feat(Parity-Batch3): partial/hunk 级提交 + undo/drop/fixup + cleanup + 3-way diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ## [Unreleased]
 
+### Added — Parity Batch 3（partial commit + 高级操作，0.0.4）
+
+- **partial / 行级提交**（IDEA PartialChangesUtil 等价）：`engine/diff/hunk-parser`（unified diff 解析，7 单测）+ hunk 选择暂存/取消暂存（QuickPick 勾选）+ 光标处 hunk 暂存——经 patch 重建 + `git apply --cached`。
+- **undo commit**（soft reset，保留改动到暂存区）、**drop commit**（`git rebase --onto`，重写历史二次确认）、**fixup**（autosquash rebase，经 env 注入 `GIT_SEQUENCE_EDITOR`）。
+- **cleanup branches**（`git branch --merged` 批量删除）、**copy branch ref**、**3-way diff 概览**（HEAD↔Staged↔Working）。
+- `execGit` 支持 env 注入（为 autosquash 等 rebase 自动化铺路）。
+
 ### Added — Parity Batch 2（UI 丰富度，0.0.3）
 
 - **Git 提交图（WebviewPanel）**：`git log --graph --oneline --decorate --all`（CLI）获取拓扑，语义着色渲染（graph 连线 / refs / hash）——补齐 IDEA Log 提交图的可视化拓扑。命令面板 + Log 视图标题按钮。

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hyper Git",
   "icon": "media/icon.png",
   "description": "在 VS Code 上完整复刻 IntelliJ IDEA 的 Git 工具窗口与 Commit 提交窗口，并为未来 AI Agent 自主代理预留架构接缝。",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "threefish-ai",
   "license": "MIT",
   "preview": true,
@@ -132,7 +132,16 @@
       { "command": "hyperGit.compareBranches", "title": "比较分支", "category": "Hyper Git" },
       { "command": "hyperGit.rewordCommit", "title": "改写最新提交信息", "category": "Hyper Git" },
       { "command": "hyperGit.showGraph", "title": "查看提交图（Graph）", "category": "Hyper Git", "icon": "$(git-commit)" },
-      { "command": "hyperGit.showConsole", "title": "打开 Console", "category": "Hyper Git" }
+      { "command": "hyperGit.showConsole", "title": "打开 Console", "category": "Hyper Git" },
+      { "command": "hyperGit.partialStage", "title": "部分暂存（Hunk）…", "category": "Hyper Git" },
+      { "command": "hyperGit.partialUnstage", "title": "部分取消暂存（Hunk）…", "category": "Hyper Git" },
+      { "command": "hyperGit.stageHunkAtCursor", "title": "暂存光标处 Hunk", "category": "Hyper Git" },
+      { "command": "hyperGit.undoLastCommit", "title": "撤销最近提交（soft）", "category": "Hyper Git" },
+      { "command": "hyperGit.dropCommit", "title": "删除提交（rebase）", "category": "Hyper Git" },
+      { "command": "hyperGit.fixupCommit", "title": "Fixup 到提交（autosquash）", "category": "Hyper Git" },
+      { "command": "hyperGit.cleanupBranches", "title": "清理已合并分支", "category": "Hyper Git" },
+      { "command": "hyperGit.copyBranchRef", "title": "复制分支引用", "category": "Hyper Git" },
+      { "command": "hyperGit.threeWayDiff", "title": "3-way Diff 概览", "category": "Hyper Git" }
     ],
     "menus": {
       "view/title": [
@@ -164,9 +173,14 @@
         { "command": "hyperGit.rebaseBranch", "when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/", "group": "1_branch@4" },
         { "command": "hyperGit.branchRename", "when": "view == hyperGit.branches && viewItem == hyperGit.branch", "group": "1_branch@5" },
         { "command": "hyperGit.compareBranches", "when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/", "group": "1_branch@6" },
+        { "command": "hyperGit.copyBranchRef", "when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/", "group": "1_branch@7" },
         { "command": "hyperGit.cherryPick", "when": "view == hyperGit.log && viewItem == hyperGit.commit", "group": "1_commit@1" },
         { "command": "hyperGit.revertCommit", "when": "view == hyperGit.log && viewItem == hyperGit.commit", "group": "1_commit@2" },
+        { "command": "hyperGit.dropCommit", "when": "view == hyperGit.log && viewItem == hyperGit.commit", "group": "1_commit@3" },
+        { "command": "hyperGit.fixupCommit", "when": "view == hyperGit.log && viewItem == hyperGit.commit", "group": "1_commit@4" },
         { "command": "hyperGit.ignorePath", "when": "view == hyperGit.changes && viewItem == hyperGit.fileChange", "group": "1_file@4" },
+        { "command": "hyperGit.partialStage", "when": "view == hyperGit.changes && viewItem == hyperGit.fileChange", "group": "1_file@5" },
+        { "command": "hyperGit.partialUnstage", "when": "view == hyperGit.changes && viewItem == hyperGit.fileChange", "group": "1_file@6" },
         { "command": "hyperGit.stashApply", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@1" },
         { "command": "hyperGit.stashPop", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@2" },
         { "command": "hyperGit.stashDrop", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@3" }
@@ -191,7 +205,8 @@
         { "command": "hyperGit.revertCommit", "when": "false" },
         { "command": "hyperGit.branchRename", "when": "false" },
         { "command": "hyperGit.compareBranches", "when": "false" },
-        { "command": "hyperGit.ignorePath", "when": "false" }
+        { "command": "hyperGit.ignorePath", "when": "false" },
+        { "command": "hyperGit.copyBranchRef", "when": "false" }
       ]
     },
     "configuration": {

--- a/src/adapter/advanced-commands.ts
+++ b/src/adapter/advanced-commands.ts
@@ -1,0 +1,197 @@
+import * as vscode from 'vscode';
+import type { BranchNode, BranchesTreeProvider } from './tree/branches-tree';
+import type { GitRepositoryService } from './git-repository-service';
+import type { LogNode } from './tree/log-tree';
+
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/**
+ * 注册高级 git 操作（Batch 3）—— 补齐 IDEA Log/Branches 的高级动作。
+ * undo commit（soft reset）/ drop commit（rebase --onto）/ fixup（autosquash，经 env 注入 GIT_SEQUENCE_EDITOR）
+ * / cleanup branches（--merged 批量删）/ copy branch ref / 3-way diff 概览。
+ */
+export function registerAdvancedCommands(service: GitRepositoryService, branchesTree: BranchesTreeProvider): vscode.Disposable[] {
+	const subs: vscode.Disposable[] = [];
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.undoLastCommit', async () => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const ok = await vscode.window.showWarningMessage('撤销最近一次提交（soft reset，保留改动到暂存区）？', { modal: true }, '撤销');
+			if (ok !== '撤销') {
+				return;
+			}
+			try {
+				await service.execGit(['reset', '--soft', 'HEAD~1']);
+				branchesTree.refresh();
+				void vscode.window.showInformationMessage('已撤销最近提交（soft）');
+			} catch (e) {
+				void vscode.window.showErrorMessage(`撤销失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.dropCommit', async (node?: LogNode) => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const hash = node?.kind === 'commit' ? node.commit.hash : await pickCommitHash(service);
+			if (!hash) {
+				return;
+			}
+			const ok = await vscode.window.showWarningMessage(
+				`删除提交 ${hash.slice(0, 7)}？将用 rebase 重写历史（可能冲突；已推送的提交勿用）。`,
+				{ modal: true },
+				'删除提交',
+			);
+			if (ok !== '删除提交') {
+				return;
+			}
+			try {
+				await service.execGit(['rebase', '--onto', `${hash}^`, hash]);
+				branchesTree.refresh();
+				void vscode.window.showInformationMessage(`已删除提交 ${hash.slice(0, 7)}`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`删除失败（可能需手动解冲突）：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.fixupCommit', async (node?: LogNode) => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const hash = node?.kind === 'commit' ? node.commit.hash : await pickCommitHash(service);
+			if (!hash) {
+				return;
+			}
+			const ok = await vscode.window.showWarningMessage(
+				`将当前已暂存改动 fixup 到 ${hash.slice(0, 7)}？将重写历史（autosquash rebase）。`,
+				{ modal: true },
+				'Fixup',
+			);
+			if (ok !== 'Fixup') {
+				return;
+			}
+			try {
+				await service.execGit(['commit', `--fixup=${hash}`]);
+				await service.execGit(['rebase', '-i', '--autosquash', `${hash}^`], {
+					env: { ...process.env, GIT_SEQUENCE_EDITOR: ':' },
+				});
+				branchesTree.refresh();
+				void vscode.window.showInformationMessage(`已 fixup 到 ${hash.slice(0, 7)}`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`Fixup 失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.cleanupBranches', async () => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const headName = repo.state.HEAD?.name;
+			const base = headName ?? 'main';
+			let merged: string[] = [];
+			try {
+				const out = await service.execGit(['branch', '--merged', base]);
+				merged = out
+					.split('\n')
+					.map((s) => s.trim().replace(/^\*\s*/, ''))
+					.filter((s) => s && s !== base && s !== 'main' && s !== 'master' && s !== headName);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`查询已合并分支失败：${errMsg(e)}`);
+				return;
+			}
+			if (merged.length === 0) {
+				void vscode.window.showInformationMessage('无可清理的已合并分支');
+				return;
+			}
+			const picks = await vscode.window.showQuickPick(
+				merged.map((b) => ({ label: b, picked: true })),
+				{ canPickMany: true, title: `已合并到 ${base} 的本地分支（勾选删除）` },
+			);
+			if (!picks || picks.length === 0) {
+				return;
+			}
+			let deleted = 0;
+			for (const p of picks) {
+				try {
+					await service.execGit(['branch', '-d', p.label]);
+					deleted++;
+				} catch {
+					/* 跳过删除失败的分支（如未完全合并） */
+				}
+			}
+			branchesTree.refresh();
+			void vscode.window.showInformationMessage(`已删除 ${deleted} 个已合并分支`);
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.copyBranchRef', async (node?: BranchNode) => {
+			if (node?.kind !== 'branch') {
+				return;
+			}
+			const ref = node.ref.name ?? '';
+			if (ref) {
+				await vscode.env.clipboard.writeText(ref);
+				void vscode.window.showInformationMessage(`已复制 ${ref}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.threeWayDiff', async () => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			try {
+				const staged = await service.execGit(['diff', '--cached', '--stat']);
+				const working = await service.execGit(['diff', '--stat']);
+				const content = [
+					'# 3-way Diff 概览（HEAD ↔ Staged ↔ Working）',
+					'',
+					'## 已暂存改动（HEAD ↔ Staged）',
+					'',
+					staged.trim() || '_(无)_)',
+					'',
+					'## 未暂存改动（Staged ↔ Working）',
+					'',
+					working.trim() || '_(无)_',
+					'',
+				].join('\n');
+				const doc = await vscode.workspace.openTextDocument({ content, language: 'markdown' });
+				await vscode.window.showTextDocument(doc, { preview: true });
+			} catch (e) {
+				void vscode.window.showErrorMessage(`3-way diff 失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	return subs;
+}
+
+async function pickCommitHash(service: GitRepositoryService): Promise<string | undefined> {
+	const repo = service.repo;
+	if (!repo) {
+		return undefined;
+	}
+	const commits = await repo.log({ maxEntries: 30 });
+	const items = commits.map((c) => ({
+		label: (c.message.split('\n', 1)[0] ?? c.hash).slice(0, 50),
+		description: `${c.authorName ?? ''} · ${c.hash.slice(0, 7)}`,
+		hash: c.hash,
+	}));
+	const pick = await vscode.window.showQuickPick(items, { placeHolder: '选择 commit' });
+	return pick?.hash;
+}

--- a/src/adapter/git-repository-service.ts
+++ b/src/adapter/git-repository-service.ts
@@ -107,13 +107,13 @@ export class GitRepositoryService implements vscode.Disposable {
 	 * （cherry-pick / revert / reset / branch rename / stash list / compare 等）。仓库根为工作目录。
 	 * 仅作为 API 缺口的补充，不重造 vscode.git 已覆盖的能力。
 	 */
-	async execGit(args: string[]): Promise<string> {
+	async execGit(args: string[], options?: { env?: NodeJS.ProcessEnv }): Promise<string> {
 		const repo = this._repo;
 		if (!repo) {
 			throw new Error('未找到 Git 仓库');
 		}
 		return new Promise((resolve, reject) => {
-			execFile(this.api.git.path, args, { cwd: repo.rootUri.fsPath, maxBuffer: 20 * 1024 * 1024, encoding: 'utf8' }, (err, stdout) => {
+			execFile(this.api.git.path, args, { cwd: repo.rootUri.fsPath, maxBuffer: 20 * 1024 * 1024, encoding: 'utf8', env: options?.env }, (err, stdout) => {
 				if (err) {
 					logGit(args, undefined, err.message);
 					reject(err);

--- a/src/adapter/partial-commands.ts
+++ b/src/adapter/partial-commands.ts
@@ -1,0 +1,177 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { buildPatch, parseUnifiedDiff } from '../engine/diff/hunk-parser';
+import type { ChangeItem, GitRepositoryService } from './git-repository-service';
+
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/**
+ * 注册 partial / 行级提交命令（Batch 3）—— IDEA PartialChangesUtil 等价物。
+ *
+ * hunk 选择暂存：解析 `git diff` 为 hunks，QuickPick 勾选 → 重建 patch → `git apply --cached`。
+ * 光标处 hunk 暂存：定位光标所在 hunk → 暂存该 hunk。
+ */
+export function registerPartialCommands(service: GitRepositoryService): vscode.Disposable[] {
+	const subs: vscode.Disposable[] = [];
+
+	/** 把 patch 经临时文件应用到 index（reverse=true 时为取消暂存）。 */
+	const applyToIndex = async (patch: string, reverse: boolean): Promise<void> => {
+		const tmp = path.join(os.tmpdir(), `hg-patch-${Date.now()}-${Math.random().toString(36).slice(2)}.diff`);
+		fs.writeFileSync(tmp, patch);
+		try {
+			const args = ['apply', '--cached', '--whitespace=nowarn'];
+			if (reverse) {
+				args.push('--reverse');
+			}
+			args.push(tmp);
+			await service.execGit(args);
+		} finally {
+			try {
+				fs.unlinkSync(tmp);
+			} catch {
+				/* ignore */
+			}
+		}
+	};
+
+	const pickHunks = async (diff: string, title: string): Promise<{ indices: number[] } | undefined> => {
+		const files = parseUnifiedDiff(diff);
+		if (files.length === 0) {
+			void vscode.window.showInformationMessage('无改动');
+			return undefined;
+		}
+		const file = files[0];
+		const picks = file.hunks.map((h, i) => ({
+			label: `Hunk ${i + 1}`,
+			description: h.header,
+			detail: h.body.slice(0, 6).join('\n'),
+			index: i,
+		}));
+		const sel = await vscode.window.showQuickPick(picks, { canPickMany: true, title, placeHolder: '勾选 hunk（详见 detail）' });
+		if (!sel || sel.length === 0) {
+			return undefined;
+		}
+		return { indices: sel.map((s) => s.index) };
+	};
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.partialStage', async (change?: ChangeItem) => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const rel = change?.relativePath ?? (await pickUnstagedFile(service));
+			if (!rel) {
+				return;
+			}
+			try {
+				const diff = await service.execGit(['diff', '--', rel]);
+				if (!diff.trim()) {
+					void vscode.window.showInformationMessage('该文件无未暂存改动');
+					return;
+				}
+				const sel = await pickHunks(diff, `暂存 hunk：${rel}`);
+				if (!sel) {
+					return;
+				}
+				const file = parseUnifiedDiff(diff)[0];
+				await applyToIndex(buildPatch(file, sel.indices), false);
+				void vscode.window.showInformationMessage(`已暂存 ${sel.indices.length} 个 hunk`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`暂存失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.partialUnstage', async (change?: ChangeItem) => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const rel = change?.relativePath ?? (await pickStagedFile(service));
+			if (!rel) {
+				return;
+			}
+			try {
+				const diff = await service.execGit(['diff', '--cached', '--', rel]);
+				if (!diff.trim()) {
+					void vscode.window.showInformationMessage('该文件无已暂存改动');
+					return;
+				}
+				const sel = await pickHunks(diff, `取消暂存 hunk：${rel}`);
+				if (!sel) {
+					return;
+				}
+				const file = parseUnifiedDiff(diff)[0];
+				await applyToIndex(buildPatch(file, sel.indices), true);
+				void vscode.window.showInformationMessage(`已取消暂存 ${sel.indices.length} 个 hunk`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`取消暂存失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.stageHunkAtCursor', async () => {
+			const editor = vscode.window.activeTextEditor;
+			const repo = service.repo;
+			if (!editor || !repo) {
+				return;
+			}
+			const rel = repoRelative(repo.rootUri.fsPath, editor.document.uri.fsPath);
+			if (!rel) {
+				void vscode.window.showWarningMessage('文件不在当前仓库内');
+				return;
+			}
+			const cursorLine = editor.selection.active.line + 1;
+			try {
+				const diff = await service.execGit(['diff', '--', rel]);
+				const files = parseUnifiedDiff(diff);
+				if (files.length === 0) {
+					void vscode.window.showInformationMessage('无未暂存改动');
+					return;
+				}
+				const file = files[0];
+				const overlapping = file.hunks
+					.map((h, i) => ({ h, i }))
+					.filter(({ h }) => cursorLine >= h.newStart && cursorLine < h.newStart + Math.max(h.newCount, 1));
+				if (overlapping.length === 0) {
+					void vscode.window.showInformationMessage('光标不在改动 hunk 内');
+					return;
+				}
+				await applyToIndex(buildPatch(file, overlapping.map((o) => o.i)), false);
+				void vscode.window.showInformationMessage('已暂存光标处 hunk');
+			} catch (e) {
+				void vscode.window.showErrorMessage(`暂存失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	return subs;
+}
+
+function repoRelative(root: string, fsPath: string): string | null {
+	const rel = path.relative(root, fsPath).split(path.sep).join('/');
+	return rel.startsWith('..') || path.isAbsolute(rel) ? null : rel;
+}
+
+async function pickUnstagedFile(service: GitRepositoryService): Promise<string | undefined> {
+	const items = service.getChanges().filter((c) => !c.staged);
+	if (items.length === 0) {
+		return undefined;
+	}
+	const pick = await vscode.window.showQuickPick(items.map((c) => ({ label: c.relativePath })), { placeHolder: '选择文件' });
+	return pick?.label;
+}
+
+async function pickStagedFile(service: GitRepositoryService): Promise<string | undefined> {
+	const items = service.getChanges().filter((c) => c.staged);
+	if (items.length === 0) {
+		return undefined;
+	}
+	const pick = await vscode.window.showQuickPick(items.map((c) => ({ label: c.relativePath })), { placeHolder: '选择已暂存文件' });
+	return pick?.label;
+}

--- a/src/engine/diff/hunk-parser.ts
+++ b/src/engine/diff/hunk-parser.ts
@@ -1,0 +1,106 @@
+/**
+ * Unified Diff hunk 解析器（纯逻辑，零 vscode 依赖）。
+ *
+ * 这是 partial / 行级提交的命脉：解析 `git diff` 的 unified diff，切分为文件与 hunk，
+ * 并能从「选中的 hunk 子集」重建一个合法 patch 供 `git apply --cached` 暂存（IDEA PartialChangesUtil 等价物）。
+ */
+
+/** 一个 hunk：对应 `@@ -oldStart,oldCount +newStart,newCount @@ context`。 */
+export interface DiffHunk {
+	readonly header: string;
+	readonly oldStart: number;
+	readonly oldCount: number;
+	readonly newStart: number;
+	readonly newCount: number;
+	/** hunk 体（每行以 ' '/'-'/'+'/'\\' 起始）。 */
+	readonly body: readonly string[];
+}
+
+/** 一个文件的 diff：文件头 + hunks。 */
+export interface DiffFile {
+	readonly oldPath: string;
+	readonly newPath: string;
+	/** 文件头行（diff --git / index / --- / +++ 等）。 */
+	readonly headerLines: readonly string[];
+	readonly hunks: readonly DiffHunk[];
+}
+
+const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@.*$/;
+const BODY_RE = /^[ +\\-]/;
+
+function stripPathPrefix(p: string): string {
+	if (p.startsWith('a/') || p.startsWith('b/')) {
+		return p.slice(2);
+	}
+	return p;
+}
+
+/**
+ * 解析 unified diff 文本为 DiffFile[]（仅保留含 hunk 的文件）。
+ */
+export function parseUnifiedDiff(diff: string): DiffFile[] {
+	const lines = diff.split('\n');
+	const files: DiffFile[] = [];
+	let i = 0;
+	while (i < lines.length) {
+		if (!lines[i].startsWith('diff --git ')) {
+			i++;
+			continue;
+		}
+		const headerLines: string[] = [lines[i]];
+		i++;
+		let oldPath = '';
+		let newPath = '';
+		while (i < lines.length && !HUNK_RE.test(lines[i]) && !lines[i].startsWith('diff --git ')) {
+			const line = lines[i];
+			if (line.startsWith('--- ')) {
+				oldPath = stripPathPrefix(line.slice(4).trim());
+			} else if (line.startsWith('+++ ')) {
+				newPath = stripPathPrefix(line.slice(4).trim());
+			}
+			headerLines.push(line);
+			i++;
+		}
+		const hunks: DiffHunk[] = [];
+		while (i < lines.length && HUNK_RE.test(lines[i])) {
+			const m = lines[i].match(HUNK_RE)!;
+			const header = lines[i];
+			const oldStart = Number(m[1]);
+			const oldCount = m[2] !== undefined ? Number(m[2]) : 1;
+			const newStart = Number(m[3]);
+			const newCount = m[4] !== undefined ? Number(m[4]) : 1;
+			i++;
+			const body: string[] = [];
+			while (i < lines.length && BODY_RE.test(lines[i])) {
+				body.push(lines[i]);
+				i++;
+			}
+			hunks.push({ header, oldStart, oldCount, newStart, newCount, body });
+		}
+		if (hunks.length > 0) {
+			files.push({ oldPath, newPath, headerLines, hunks });
+		}
+	}
+	return files;
+}
+
+/**
+ * 从 DiffFile 中选定的 hunk 重建一个合法 patch（供 `git apply --cached`）。
+ * selectedHunkIndices 为该文件 hunks 数组的下标。
+ */
+export function buildPatch(file: DiffFile, selectedHunkIndices: readonly number[]): string {
+	const out: string[] = [...file.headerLines];
+	for (const idx of selectedHunkIndices) {
+		const h = file.hunks[idx];
+		if (h) {
+			out.push(h.header);
+			out.push(...h.body);
+		}
+	}
+	return out.join('\n') + '\n';
+}
+
+/** 仅保留 hunk 体中的「新增」行（去前缀），用于预览/行级提交。 */
+export function addedLines(hunk: DiffHunk): readonly string[] {
+	return hunk.body.filter((l) => l.startsWith('+')).map((l) => l.slice(1));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,8 @@ import { LogTreeProvider } from './adapter/tree/log-tree';
 import { registerHistoryCommands } from './adapter/history-commands';
 import { registerStashCommands } from './adapter/stash-commands';
 import { registerGitCliCommands } from './adapter/git-cli-commands';
+import { registerPartialCommands } from './adapter/partial-commands';
+import { registerAdvancedCommands } from './adapter/advanced-commands';
 import { StashTreeProvider } from './adapter/tree/stash-tree';
 import { CommitWebviewProvider } from './adapter/webview/commit-webview';
 import { GraphWebview } from './adapter/webview/graph-webview';
@@ -80,6 +82,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		...registerChangesCommands(service, registry, tree),
 		...registerHistoryCommands(service, logTree, branchesTree),
 		...registerGitCliCommands(service, branchesTree),
+		...registerPartialCommands(service),
+		...registerAdvancedCommands(service, branchesTree),
 		...registerStashCommands(service, stashTree),
 		vscode.commands.registerCommand('hyperGit.commit', focusCommitView),
 		vscode.commands.registerCommand('hyperGit.commitAndPush', focusCommitView),

--- a/tests/suite/extension.test.js
+++ b/tests/suite/extension.test.js
@@ -54,6 +54,15 @@ suite('扩展冒烟测试', function () {
 			'hyperGit.rewordCommit',
 			'hyperGit.showGraph',
 			'hyperGit.showConsole',
+			'hyperGit.partialStage',
+			'hyperGit.partialUnstage',
+			'hyperGit.stageHunkAtCursor',
+			'hyperGit.undoLastCommit',
+			'hyperGit.dropCommit',
+			'hyperGit.fixupCommit',
+			'hyperGit.cleanupBranches',
+			'hyperGit.copyBranchRef',
+			'hyperGit.threeWayDiff',
 		]) {
 			assert.ok(commands.includes(cmd), `命令 ${cmd} 未注册`);
 		}

--- a/tests/unit/hunk-parser.test.ts
+++ b/tests/unit/hunk-parser.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { addedLines, buildPatch, parseUnifiedDiff } from '../../src/engine/diff/hunk-parser';
+
+const SAMPLE = `diff --git a/foo.txt b/foo.txt
+index 111..222 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,3 +1,4 @@
+ line1
+-old line
++new line
++added
+ line3
+@@ -10,2 +11,2 @@
+ line10
+-old10
++new10
+diff --git a/bar.bin b/bar.bin
+Binary files differ
+`;
+
+describe('parseUnifiedDiff', () => {
+	it('解析单文件多 hunk，跳过二进制文件', () => {
+		const files = parseUnifiedDiff(SAMPLE);
+		expect(files).toHaveLength(1);
+		const f = files[0];
+		expect(f.oldPath).toBe('foo.txt');
+		expect(f.newPath).toBe('foo.txt');
+		expect(f.hunks).toHaveLength(2);
+	});
+
+	it('正确解析 hunk 的行号与计数', () => {
+		const f = parseUnifiedDiff(SAMPLE)[0];
+		expect(f.hunks[0]).toMatchObject({ oldStart: 1, oldCount: 3, newStart: 1, newCount: 4 });
+		expect(f.hunks[1]).toMatchObject({ oldStart: 10, oldCount: 2, newStart: 11, newCount: 2 });
+	});
+
+	it('支持省略计数（@@ -1 +1 @@）', () => {
+		const files = parseUnifiedDiff('diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -5 +5 @@\n-a\n+b\n');
+		expect(files[0].hunks[0]).toMatchObject({ oldStart: 5, oldCount: 1, newStart: 5, newCount: 1 });
+	});
+
+	it('hunk body 不越界吞掉下一个文件/diff', () => {
+		const f = parseUnifiedDiff(SAMPLE)[0];
+		expect(f.hunks[1].body).toEqual([' line10', '-old10', '+new10']);
+	});
+});
+
+describe('buildPatch', () => {
+	it('仅含选中 hunk + 文件头', () => {
+		const f = parseUnifiedDiff(SAMPLE)[0];
+		const patch = buildPatch(f, [0]);
+		expect(patch).toContain('diff --git a/foo.txt b/foo.txt');
+		expect(patch).toContain('@@ -1,3 +1,4 @@');
+		expect(patch).toContain('+added');
+		expect(patch).not.toContain('@@ -10,2 +11,2 @@');
+		expect(patch).not.toContain('+new10');
+	});
+
+	it('选中多个 hunk', () => {
+		const f = parseUnifiedDiff(SAMPLE)[0];
+		const patch = buildPatch(f, [0, 1]);
+		expect(patch).toContain('@@ -1,3 +1,4 @@');
+		expect(patch).toContain('@@ -10,2 +11,2 @@');
+	});
+});
+
+describe('addedLines', () => {
+	it('提取新增行（去前缀）', () => {
+		const f = parseUnifiedDiff(SAMPLE)[0];
+		expect(addedLines(f.hunks[0])).toEqual(['new line', 'added']);
+	});
+});


### PR DESCRIPTION
## 交付（最硬核的 partial commit + 剩余高级操作）
- **partial / 行级提交**（IDEA PartialChangesUtil 等价）：`engine/diff/hunk-parser`（7 单测）+ hunk 选择暂存/取消暂存 + 光标处 hunk 暂存（patch 重建 + `git apply --cached`）。
- **undo commit**（soft reset）· **drop commit**（rebase --onto，重写历史确认）· **fixup**（autosquash rebase，env 注入 GIT_SEQUENCE_EDITOR）。
- **cleanup branches**（--merged 批量删）· **copy branch ref** · **3-way diff 概览**。
- `execGit` 支持 env（autosquash 铺路）。

## 验收
check-types/lint/package ✅ · test:unit **59/59**（+7 hunk 解析） · test:integration 3/3 ✅

## 唯一剩余硬骨头
Editor inline commit（gutter marker toolbar + 行级 tracker，#13）—— LineStatusTracker 级实现，是当前唯一未做的 IDEA 功能，需独立攻坚。

🤖 Generated with [Claude Code](https://github.com/claude)