### PR TITLE
feat(Parity-Batch4): 忠实 Shelf + 交互式 Rebase UI + Move Hunk to Changelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+### Added — Parity Batch 4（忠实 Shelf + 交互式 Rebase + Line→CL，0.0.6）
+
+- **忠实 Shelf**（IDEA patch-based，#27-28）：Shelve（`git diff` → patch 存扩展存储 → `git checkout --` 移除工作区）+ Unshelve silently / with 3-way merge + Delete + Shelf TreeView。与 Stash 独立并存。
+- **交互式 Rebase UI**（Webview，#44）：commit 列表 + pick/squash/fixup/drop 动作 → 非交互 rebase（`GIT_SEQUENCE_EDITOR=cp <tempfile>` + `GIT_EDITOR=:`）。
+- **Move Hunk to Changelist**（#25）：编辑器内光标处 hunk → QuickPick changelist → ChangelistRegistry 持久化 hunk→CL 归属。
+
 ### Added — Editor Inline Commit（#13，0.0.5）
 
 > IDEA editor inline commit 的 VS Code 等价（补齐最后一块主要拼图）。

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Hyper Git",
   "icon": "media/icon.png",
   "description": "在 VS Code 上完整复刻 IntelliJ IDEA 的 Git 工具窗口与 Commit 提交窗口，并为未来 AI Agent 自主代理预留架构接缝。",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "threefish-ai",
   "license": "MIT",
   "preview": true,
@@ -79,6 +79,11 @@
           "id": "hyperGit.stash",
           "name": "Stash",
           "visibility": "visible"
+        },
+        {
+          "id": "hyperGit.shelf",
+          "name": "Shelf",
+          "visibility": "visible"
         }
       ]
     },
@@ -142,7 +147,13 @@
       { "command": "hyperGit.cleanupBranches", "title": "清理已合并分支", "category": "Hyper Git" },
       { "command": "hyperGit.copyBranchRef", "title": "复制分支引用", "category": "Hyper Git" },
       { "command": "hyperGit.threeWayDiff", "title": "3-way Diff 概览", "category": "Hyper Git" },
-      { "command": "hyperGit.inlineCommitHunk", "title": "行内提交 Hunk", "category": "Hyper Git" }
+      { "command": "hyperGit.inlineCommitHunk", "title": "行内提交 Hunk", "category": "Hyper Git" },
+      { "command": "hyperGit.shelveChanges", "title": "Shelve Changes…", "category": "Hyper Git", "icon": "$(inbox)" },
+      { "command": "hyperGit.unshelveSilently", "title": "Unshelve Silently", "category": "Hyper Git" },
+      { "command": "hyperGit.unshelveWithMerge", "title": "Unshelve with Merge", "category": "Hyper Git" },
+      { "command": "hyperGit.deleteShelf", "title": "Delete Shelf", "category": "Hyper Git" },
+      { "command": "hyperGit.startRebase", "title": "Interactive Rebase…", "category": "Hyper Git" },
+      { "command": "hyperGit.moveHunkToChangelist", "title": "Move Hunk to Changelist", "category": "Hyper Git" }
     ],
     "menus": {
       "view/title": [
@@ -157,7 +168,8 @@
         { "command": "hyperGit.branchCreate", "when": "view == hyperGit.branches", "group": "navigation" },
         { "command": "hyperGit.pull", "when": "view == hyperGit.branches", "group": "navigation" },
         { "command": "hyperGit.push", "when": "view == hyperGit.branches", "group": "navigation" },
-        { "command": "hyperGit.stashCreate", "when": "view == hyperGit.stash", "group": "navigation" }
+        { "command": "hyperGit.stashCreate", "when": "view == hyperGit.stash", "group": "navigation" },
+        { "command": "hyperGit.shelveChanges", "when": "view == hyperGit.shelf", "group": "navigation" }
       ],
       "view/item/context": [
         { "command": "hyperGit.setActiveChangelist", "when": "view == hyperGit.changes && viewItem == hyperGit.changelist", "group": "1_changelist@1" },
@@ -184,7 +196,10 @@
         { "command": "hyperGit.partialUnstage", "when": "view == hyperGit.changes && viewItem == hyperGit.fileChange", "group": "1_file@6" },
         { "command": "hyperGit.stashApply", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@1" },
         { "command": "hyperGit.stashPop", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@2" },
-        { "command": "hyperGit.stashDrop", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@3" }
+        { "command": "hyperGit.stashDrop", "when": "view == hyperGit.stash && viewItem == hyperGit.stash", "group": "1_stash@3" },
+        { "command": "hyperGit.unshelveSilently", "when": "view == hyperGit.shelf && viewItem == hyperGit.shelf", "group": "1_shelf@1" },
+        { "command": "hyperGit.unshelveWithMerge", "when": "view == hyperGit.shelf && viewItem == hyperGit.shelf", "group": "1_shelf@2" },
+        { "command": "hyperGit.deleteShelf", "when": "view == hyperGit.shelf && viewItem == hyperGit.shelf", "group": "1_shelf@3" }
       ],
       "commandPalette": [
         { "command": "hyperGit.openDiff", "when": "false" },
@@ -208,7 +223,11 @@
         { "command": "hyperGit.compareBranches", "when": "false" },
         { "command": "hyperGit.ignorePath", "when": "false" },
         { "command": "hyperGit.copyBranchRef", "when": "false" },
-        { "command": "hyperGit.inlineCommitHunk", "when": "false" }
+        { "command": "hyperGit.inlineCommitHunk", "when": "false" },
+        { "command": "hyperGit.unshelveSilently", "when": "false" },
+        { "command": "hyperGit.unshelveWithMerge", "when": "false" },
+        { "command": "hyperGit.deleteShelf", "when": "false" },
+        { "command": "hyperGit.moveHunkToChangelist", "when": "false" }
       ]
     },
     "configuration": {

--- a/src/adapter/changelist-registry.ts
+++ b/src/adapter/changelist-registry.ts
@@ -123,6 +123,30 @@ export class ChangelistRegistry implements vscode.Disposable {
 		this.persist();
 	}
 
+	/** 将某个 hunk 分配到指定 changelist（#25 Move Lines to Changelist）。 */
+	moveHunk(fileKey: string, hunkIndex: number, targetId: string): void {
+		if (!this.defs.some((d) => d.id === targetId)) {
+			return;
+		}
+		this.assignments = { ...this.assignments, [`${fileKey}:${hunkIndex}`]: targetId };
+		this.persist();
+	}
+
+	/** 查询某文件的 hunk 级归属（返回 hunkIndex → changelistId 映射）。 */
+	getHunkAssignments(fileKey: string): Map<number, string> {
+		const result = new Map<number, string>();
+		const prefix = `${fileKey}:`;
+		for (const [key, clId] of Object.entries(this.assignments)) {
+			if (key.startsWith(prefix)) {
+				const idx = Number(key.slice(prefix.length));
+				if (!Number.isNaN(idx)) {
+					result.set(idx, clId);
+				}
+			}
+		}
+		return result;
+	}
+
 	dispose(): void {
 		this._onDidChange.dispose();
 	}

--- a/src/adapter/partial-commands.ts
+++ b/src/adapter/partial-commands.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { buildPatch, parseUnifiedDiff } from '../engine/diff/hunk-parser';
+import type { ChangelistRegistry } from './changelist-registry';
 import type { ChangeItem, GitRepositoryService } from './git-repository-service';
 
 const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
@@ -13,7 +14,7 @@ const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(
  * hunk 选择暂存：解析 `git diff` 为 hunks，QuickPick 勾选 → 重建 patch → `git apply --cached`。
  * 光标处 hunk 暂存：定位光标所在 hunk → 暂存该 hunk。
  */
-export function registerPartialCommands(service: GitRepositoryService): vscode.Disposable[] {
+export function registerPartialCommands(service: GitRepositoryService, registry: ChangelistRegistry): vscode.Disposable[] {
 	const subs: vscode.Disposable[] = [];
 
 	/** 把 patch 经临时文件应用到 index（reverse=true 时为取消暂存）。 */
@@ -146,6 +147,48 @@ export function registerPartialCommands(service: GitRepositoryService): vscode.D
 				void vscode.window.showInformationMessage('已暂存光标处 hunk');
 			} catch (e) {
 				void vscode.window.showErrorMessage(`暂存失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.moveHunkToChangelist', async () => {
+			const editor = vscode.window.activeTextEditor;
+			const repo = service.repo;
+			if (!editor || !repo) {
+				return;
+			}
+			const rel = repoRelative(repo.rootUri.fsPath, editor.document.uri.fsPath);
+			if (!rel) {
+				void vscode.window.showWarningMessage('文件不在当前仓库内');
+				return;
+			}
+			const cursorLine = editor.selection.active.line + 1;
+			try {
+				const diff = await service.execGit(['diff', '--', rel]);
+				const files = parseUnifiedDiff(diff);
+				if (files.length === 0) {
+					return;
+				}
+				const file = files[0];
+				const overlapping = file.hunks
+					.map((h, i) => ({ h, i }))
+					.filter(({ h }) => cursorLine >= h.newStart && cursorLine < h.newStart + Math.max(h.newCount, 1));
+				if (overlapping.length === 0) {
+					void vscode.window.showInformationMessage('光标不在改动 hunk 内');
+					return;
+				}
+				const hunkIdx = overlapping[0].i;
+				const defs = registry.listDefs();
+				const active = registry.activeChangelistId;
+				const picks = defs.map((d) => ({ label: d.name, id: d.id, description: d.id === active ? 'active' : undefined }));
+				const pick = await vscode.window.showQuickPick(picks, { placeHolder: `将 Hunk ${hunkIdx + 1} 移至 Changelist` });
+				if (pick) {
+					registry.moveHunk(rel, hunkIdx, pick.id);
+					void vscode.window.showInformationMessage(`已将 Hunk ${hunkIdx + 1}（${rel}）分配到「${pick.label}」`);
+				}
+			} catch (e) {
+				void vscode.window.showErrorMessage(`分配失败：${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/shelf.ts
+++ b/src/adapter/shelf.ts
@@ -1,0 +1,236 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { GitRepositoryService } from './git-repository-service';
+
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+function sanitize(name: string): string {
+	return name.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64) || 'unnamed';
+}
+
+interface ShelfEntry {
+	readonly name: string;
+	readonly paths: readonly string[];
+	readonly timestamp: string;
+	readonly patch: string;
+}
+
+/** ShelfTreeProvider 节点。 */
+export interface ShelfNode {
+	readonly kind: 'shelf';
+	readonly name: string;
+	readonly paths: readonly string[];
+	readonly timestamp: string;
+}
+
+/**
+ * ShelfService：IDEA 忠实 Shelf 实现。
+ *
+ * - Shelve：`git diff -- <paths>` → 存 patch 到扩展存储 → `git checkout --` 移除工作区改动（变更保留在 patch）。
+ * - Unshelve：读取 patch → `git apply`（静默）或 `git apply --3way`（三方合并冲突解决）。
+ * - Drop：删除 patch 文件。
+ *
+ * 与 git stash 的区别：Shelf 是命名 patch 序列（扩展存储），不占用 git stash 栈；可同时保留多个独立 shelf。
+ */
+export class ShelfService {
+	private readonly shelvesDir: string;
+
+	constructor(private readonly service: GitRepositoryService, storageDir: string) {
+		this.shelvesDir = path.join(storageDir, 'shelves');
+	}
+
+	async shelve(name: string, paths: readonly string[], timestamp: string): Promise<void> {
+		const repo = this.service.repo;
+		if (!repo) {
+			throw new Error('未找到 Git 仓库');
+		}
+		const patch = await this.service.execGit(['diff', '--', ...paths]);
+		if (!patch.trim()) {
+			throw new Error('所选文件无改动（或为未跟踪文件）');
+		}
+		fs.mkdirSync(this.shelvesDir, { recursive: true });
+		const entry: ShelfEntry = { name, paths, timestamp, patch };
+		fs.writeFileSync(path.join(this.shelvesDir, `${sanitize(name)}.json`), JSON.stringify(entry, null, 2));
+		// 移除工作区改动（变更已保存在 patch）
+		await this.service.execGit(['checkout', '--', ...paths]);
+	}
+
+	async unshelve(name: string, threeWay: boolean): Promise<void> {
+		const entry = this.readEntry(name);
+		if (!entry) {
+			throw new Error(`Shelf「${name}」不存在`);
+		}
+		const tmp = path.join(os.tmpdir(), `hg-unshelve-${Date.now()}.patch`);
+		fs.writeFileSync(tmp, entry.patch);
+		try {
+			const args = ['apply'];
+			if (threeWay) {
+				args.push('--3way');
+			}
+			args.push(tmp);
+			await this.service.execGit(args);
+		} finally {
+			try {
+				fs.unlinkSync(tmp);
+			} catch {
+				/* ignore */
+			}
+		}
+	}
+
+	async unshelveAndDrop(name: string, threeWay: boolean): Promise<void> {
+		await this.unshelve(name, threeWay);
+		this.drop(name);
+	}
+
+	drop(name: string): void {
+		const file = path.join(this.shelvesDir, `${sanitize(name)}.json`);
+		if (fs.existsSync(file)) {
+			fs.unlinkSync(file);
+		}
+	}
+
+	listShelves(): ShelfNode[] {
+		if (!fs.existsSync(this.shelvesDir)) {
+			return [];
+		}
+		return fs
+			.readdirSync(this.shelvesDir)
+			.filter((f) => f.endsWith('.json'))
+			.map((f) => {
+				try {
+					const entry = JSON.parse(fs.readFileSync(path.join(this.shelvesDir, f), 'utf8')) as ShelfEntry;
+					return { kind: 'shelf' as const, name: entry.name, paths: entry.paths, timestamp: entry.timestamp };
+				} catch {
+					return null;
+				}
+			})
+			.filter((n): n is ShelfNode => n !== null);
+	}
+
+	private readEntry(name: string): ShelfEntry | null {
+		const file = path.join(this.shelvesDir, `${sanitize(name)}.json`);
+		if (!fs.existsSync(file)) {
+			return null;
+		}
+		try {
+			return JSON.parse(fs.readFileSync(file, 'utf8')) as ShelfEntry;
+		} catch {
+			return null;
+		}
+	}
+}
+
+/** Shelf TreeView：显示已存储的 shelf 条目。 */
+export class ShelfTreeProvider implements vscode.TreeDataProvider<ShelfNode>, vscode.Disposable {
+	private readonly _onDidChange = new vscode.EventEmitter<ShelfNode | undefined>();
+	readonly onDidChangeTreeData = this._onDidChange.event;
+
+	constructor(private readonly shelfService: ShelfService) {}
+
+	refresh(): void {
+		this._onDidChange.fire(undefined);
+	}
+
+	getChildren(): ShelfNode[] {
+		return this.shelfService.listShelves();
+	}
+
+	getTreeItem(node: ShelfNode): vscode.TreeItem {
+		const item = new vscode.TreeItem(node.name, vscode.TreeItemCollapsibleState.None);
+		item.id = `shelf:${node.name}`;
+		item.description = `${node.paths.length} files · ${node.timestamp}`;
+		item.tooltip = `${node.name}\n${node.paths.length} files\nShelved: ${node.timestamp}`;
+		item.contextValue = 'hyperGit.shelf';
+		item.iconPath = new vscode.ThemeIcon('inbox');
+		return item;
+	}
+
+	dispose(): void {
+		this._onDidChange.dispose();
+	}
+}
+
+/** 注册 Shelf 命令。 */
+export function registerShelfCommands(service: GitRepositoryService, shelfService: ShelfService, shelfTree: ShelfTreeProvider): vscode.Disposable[] {
+	const subs: vscode.Disposable[] = [];
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.shelveChanges', async () => {
+			const repo = service.repo;
+			if (!repo) {
+				return;
+			}
+			const changes = service.getChanges().filter((c) => !c.staged);
+			if (changes.length === 0) {
+				void vscode.window.showInformationMessage('无未暂存改动可 shelve');
+				return;
+			}
+			const name = await vscode.window.showInputBox({ prompt: 'Shelf 名称', placeHolder: '例如 feature-x-wip' });
+			if (!name || !name.trim()) {
+				return;
+			}
+			const picks = await vscode.window.showQuickPick(
+				changes.map((c) => ({ label: c.relativePath, picked: true })),
+				{ canPickMany: true, title: '选择要 shelve 的文件' },
+			);
+			if (!picks || picks.length === 0) {
+				return;
+			}
+			try {
+				await shelfService.shelve(name.trim(), picks.map((p) => p.label), new Date().toISOString());
+				shelfTree.refresh();
+				void vscode.window.showInformationMessage(`已 shelve「${name.trim()}」(${picks.length} files)`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`Shelve 失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.unshelveSilently', async (node?: ShelfNode) => {
+			if (!node) {
+				return;
+			}
+			try {
+				await shelfService.unshelveAndDrop(node.name, false);
+				shelfTree.refresh();
+				void vscode.window.showInformationMessage(`已 unshelve「${node.name}」`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`Unshelve 失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.unshelveWithMerge', async (node?: ShelfNode) => {
+			if (!node) {
+				return;
+			}
+			try {
+				await shelfService.unshelveAndDrop(node.name, true);
+				shelfTree.refresh();
+				void vscode.window.showInformationMessage(`已 unshelve（3-way）「${node.name}」`);
+			} catch (e) {
+				void vscode.window.showErrorMessage(`Unshelve 失败：${errMsg(e)}`);
+			}
+		}),
+	);
+
+	subs.push(
+		vscode.commands.registerCommand('hyperGit.deleteShelf', async (node?: ShelfNode) => {
+			if (!node) {
+				return;
+			}
+			const ok = await vscode.window.showWarningMessage(`删除 Shelf「${node.name}」？`, { modal: true }, '删除');
+			if (ok === '删除') {
+				shelfService.drop(node.name);
+				shelfTree.refresh();
+			}
+		}),
+	);
+
+	return subs;
+}

--- a/src/adapter/webview/rebase-webview.ts
+++ b/src/adapter/webview/rebase-webview.ts
@@ -1,0 +1,153 @@
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { GitRepositoryService } from '../git-repository-service';
+
+interface RebaseCommit {
+	readonly hash: string;
+	readonly subject: string;
+}
+
+const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+/**
+ * 交互式 Rebase Webview（IDEA Git Log → rebase 等价）。
+ *
+ * 展示 base..HEAD 的提交列表，每条可设 pick/squash/fixup/drop 动作。
+ * 「Start Rebase」→ 构造 todo 序列 → 写临时文件 → `GIT_SEQUENCE_EDITOR=cp <tempfile>` 非交互触发 rebase。
+ * 重排序（drag/drop）作为后续增强；当前覆盖 squash/fixup/drop（最常见场景）。
+ */
+export class RebaseWebview {
+	static async open(service: GitRepositoryService): Promise<void> {
+		const repo = service.repo;
+		if (!repo) {
+			void vscode.window.showWarningMessage('未找到 Git 仓库');
+			return;
+		}
+		// 选择 base
+		const baseOptions = ['HEAD~5', 'HEAD~10', 'HEAD~20', 'HEAD~3', 'HEAD~2'];
+		const commits = await repo.log({ maxEntries: 30 });
+		const basePick = await vscode.window.showQuickPick(
+			[
+				...baseOptions.map((b) => ({ label: b, description: `从 ${b} 开始 rebase` })),
+				...commits.slice(1).map((c) => ({ label: c.hash.slice(0, 7), description: (c.message.split('\n', 1)[0] ?? '').slice(0, 60) })),
+			],
+			{ placeHolder: '选择 rebase 起点（base）' },
+		);
+		if (!basePick) {
+			return;
+		}
+		const base = basePick.label;
+
+		// 获取 base..HEAD 提交（逆序 → 正序）
+		let rebaseCommits: RebaseCommit[] = [];
+		try {
+			const out = await service.execGit(['log', '--reverse', '--format=%h|%s', `${base}..HEAD`]);
+			rebaseCommits = out
+				.trim()
+				.split('\n')
+				.filter((l) => l.trim())
+				.map((l) => {
+					const [hash, ...subj] = l.split('|');
+					return { hash, subject: subj.join('|') };
+				});
+		} catch (e) {
+			void vscode.window.showErrorMessage(`获取提交列表失败：${errMsg(e)}`);
+			return;
+		}
+		if (rebaseCommits.length === 0) {
+			void vscode.window.showInformationMessage(`${base}..HEAD 无提交`);
+			return;
+		}
+
+		const panel = vscode.window.createWebviewPanel('hyperGit.rebase', 'Interactive Rebase — Hyper Git', vscode.ViewColumn.Active, { enableScripts: true });
+		panel.webview.html = RebaseWebview.renderHtml(rebaseCommits);
+
+		panel.webview.onDidReceiveMessage(async (msg) => {
+			if (msg.type === 'rebase') {
+				await RebaseWebview.executeRebase(service, base, msg.actions as Array<{ hash: string; action: string; subject: string }>, panel);
+			}
+		});
+	}
+
+	private static async executeRebase(service: GitRepositoryService, base: string, actions: Array<{ hash: string; action: string; subject: string }>, panel: vscode.WebviewPanel): Promise<void> {
+		const todo = actions.map((a) => `${a.action} ${a.hash} ${a.subject}`).join('\n') + '\n';
+		const tmpTodo = path.join(os.tmpdir(), `hg-rebase-todo-${crypto.randomBytes(4).toString('hex')}.txt`);
+		fs.writeFileSync(tmpTodo, todo);
+		try {
+			await service.execGit(['rebase', '-i', base], {
+				env: { ...process.env, GIT_SEQUENCE_EDITOR: `cp ${tmpTodo}`, GIT_EDITOR: ':' },
+			});
+			void vscode.window.showInformationMessage('Rebase 完成');
+			panel.dispose();
+		} catch (e) {
+			void vscode.window.showErrorMessage(`Rebase 失败（可能需手动解冲突）：${errMsg(e)}`);
+		} finally {
+			try {
+				fs.unlinkSync(tmpTodo);
+			} catch {
+				/* ignore */
+			}
+		}
+	}
+
+	private static renderHtml(commits: RebaseCommit[]): string {
+		const nonce = crypto.randomBytes(16).toString('base64');
+		const rows = commits
+			.map(
+				(c, i) => `<tr data-hash="${c.hash}" data-subject="${escapeHtml(c.subject)}">
+<td><select class="action" data-index="${i}">
+<option value="pick">pick</option>
+<option value="squash">squash</option>
+<option value="fixup">fixup</option>
+<option value="drop">drop</option>
+</select></td>
+<td class="hash">${c.hash.slice(0, 7)}</td>
+<td class="subject">${escapeHtml(c.subject)}</td>
+</tr>`,
+			)
+			.join('\n');
+		return `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'">
+<style>
+body { margin: 0; padding: 12px 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground); font-size: var(--vscode-font-size); background: var(--vscode-editor-background); }
+h3 { margin: 0 0 8px; font-weight: 600; }
+table { width: 100%; border-collapse: collapse; }
+td { padding: 4px 6px; border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.2)); }
+td.hash { color: var(--vscode-editorWarning-foreground, #d29922); font-family: var(--vscode-editor-font-family); font-size: 12px; }
+td.subject { max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+select { background: var(--vscode-dropdown-background); color: var(--vscode-dropdown-foreground); border: 1px solid var(--vscode-dropdown-border, transparent); padding: 2px 4px; font-size: 12px; }
+button { margin-top: 12px; padding: 6px 16px; background: var(--vscode-button-background); color: var(--vscode-button-foreground); border: none; border-radius: 2px; cursor: pointer; font-size: 13px; }
+button:hover { opacity: 0.9; }
+</style>
+</head>
+<body>
+<h3>Interactive Rebase</h3>
+<table><thead><tr><th>Action</th><th>Hash</th><th>Subject</th></tr></thead>
+<tbody>${rows}</tbody></table>
+<button id="rebase-btn">Start Rebase</button>
+<script nonce="${nonce}">
+document.getElementById('rebase-btn').addEventListener('click', function() {
+  var rows = document.querySelectorAll('tbody tr');
+  var actions = [];
+  rows.forEach(function(row) {
+    var select = row.querySelector('.action');
+    actions.push({ hash: row.dataset.hash, action: select.value, subject: row.dataset.subject });
+  });
+  var vscode = acquireVsCodeApi();
+  vscode.postMessage({ type: 'rebase', actions: actions });
+});
+</script>
+</body>
+</html>`;
+	}
+}
+
+function escapeHtml(s: string): string {
+	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,8 @@ import { CommitWebviewProvider } from './adapter/webview/commit-webview';
 import { GraphWebview } from './adapter/webview/graph-webview';
 import { showGitConsole } from './infra/git-console';
 import { InlineCommitCodeLensProvider, registerInlineCommitCommand } from './adapter/editor/inline-commit-codelens';
+import { ShelfService, ShelfTreeProvider, registerShelfCommands } from './adapter/shelf';
+import { RebaseWebview } from './adapter/webview/rebase-webview';
 import { getGitApi } from './adapter/git-api';
 import { GitRepositoryService } from './adapter/git-repository-service';
 import { createLogger } from './infra/logger';
@@ -65,6 +67,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const branchesTree = new BranchesTreeProvider(service);
 	const stashTree = new StashTreeProvider(service);
 	const inlineLens = new InlineCommitCodeLensProvider(service);
+	const shelfService = new ShelfService(service, context.globalStorageUri.fsPath);
+	const shelfTree = new ShelfTreeProvider(shelfService);
 	const focusCommitView = (): void => {
 		void vscode.commands.executeCommand('hyperGit.commit.focus');
 	};
@@ -76,21 +80,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		logTree,
 		branchesTree,
 		stashTree,
+		shelfTree,
 		vscode.window.registerTreeDataProvider('hyperGit.changes', tree),
 		vscode.window.registerWebviewViewProvider(CommitWebviewProvider.viewType, commitView),
 		vscode.window.registerTreeDataProvider('hyperGit.log', logTree),
 		vscode.window.registerTreeDataProvider('hyperGit.branches', branchesTree),
 		vscode.window.registerTreeDataProvider('hyperGit.stash', stashTree),
+		vscode.window.registerTreeDataProvider('hyperGit.shelf', shelfTree),
 		...registerChangesCommands(service, registry, tree),
 		...registerHistoryCommands(service, logTree, branchesTree),
 		...registerGitCliCommands(service, branchesTree),
-		...registerPartialCommands(service),
+		...registerPartialCommands(service, registry),
 		...registerAdvancedCommands(service, branchesTree),
 		...registerStashCommands(service, stashTree),
+		...registerShelfCommands(service, shelfService, shelfTree),
 		vscode.commands.registerCommand('hyperGit.commit', focusCommitView),
 		vscode.commands.registerCommand('hyperGit.commitAndPush', focusCommitView),
 		vscode.commands.registerCommand('hyperGit.showGraph', () => GraphWebview.open(service)),
 		vscode.commands.registerCommand('hyperGit.showConsole', () => showGitConsole()),
+		vscode.commands.registerCommand('hyperGit.startRebase', () => RebaseWebview.open(service)),
 		vscode.languages.registerCodeLensProvider({ scheme: 'file' }, inlineLens),
 		registerInlineCommitCommand(service, inlineLens),
 	);
@@ -105,6 +113,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 			logTree.refresh();
 			branchesTree.refresh();
 			stashTree.refresh();
+			shelfTree.refresh();
 			inlineLens.refresh();
 		}, 150);
 	};

--- a/tests/suite/extension.test.js
+++ b/tests/suite/extension.test.js
@@ -64,6 +64,12 @@ suite('扩展冒烟测试', function () {
 			'hyperGit.copyBranchRef',
 			'hyperGit.threeWayDiff',
 			'hyperGit.inlineCommitHunk',
+			'hyperGit.shelveChanges',
+			'hyperGit.unshelveSilently',
+			'hyperGit.unshelveWithMerge',
+			'hyperGit.deleteShelf',
+			'hyperGit.startRebase',
+			'hyperGit.moveHunkToChangelist',
 		]) {
 			assert.ok(commands.includes(cmd), `命令 ${cmd} 未注册`);
 		}


### PR DESCRIPTION
## 交付
- **忠实 Shelf**（#27-28）：patch 存储（`git diff` → 扩展存储 JSON → `git checkout --`）+ unshelve silently / 3-way merge + delete + Shelf TreeView。与 Stash 独立。
- **交互式 Rebase UI**（#44）：Webview commit 列表 + pick/squash/fixup/drop → `GIT_SEQUENCE_EDITOR=cp` 非交互触发。
- **Move Hunk to Changelist**（#25）：编辑器光标 hunk → QuickPick CL → ChangelistRegistry `moveHunk` 持久化 hunk→CL 归属。

## 验收
check-types/lint/package ✅ · test:unit **64/64** · test:integration **3/3**（全命令注册含 shelf/rebase/moveHunkCL）

🤖 Generated with [Claude Code](https://github.com/claude)