### PR TITLE
fix(GitToolWindow): 修复活动栏未提交角标缺失与 Branches Push 失败

### DIFF
--- a/src/adapter/history-commands.ts
+++ b/src/adapter/history-commands.ts
@@ -16,7 +16,20 @@ export function registerHistoryCommands(
 	favorites: BranchFavorites,
 ): vscode.Disposable[] {
 	const subs: vscode.Disposable[] = [];
-	const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+	// vscode.git 在 git 非零退出时抛出 GitError，其 .message 为通用串「Failed to execute git」，
+	// 真实原因落在 .stderr。优先暴露 stderr，使「无上游」「non-fast-forward」等失败可读。
+	const errMsg = (e: unknown): string => {
+		if (e && typeof e === 'object') {
+			const ge = e as { stderr?: unknown; message?: unknown };
+			if (typeof ge.stderr === 'string' && ge.stderr.trim()) {
+				return ge.stderr.trim();
+			}
+			if (typeof ge.message === 'string' && ge.message) {
+				return ge.message;
+			}
+		}
+		return String(e);
+	};
 
 	subs.push(vscode.commands.registerCommand('hyperGit.refreshLog', () => logTree.refresh()));
 	subs.push(vscode.commands.registerCommand('hyperGit.refreshBranches', () => branchesTree.refresh()));
@@ -212,9 +225,35 @@ export function registerHistoryCommands(
 			if (!repo) {
 				return;
 			}
+			const head = repo.state.HEAD;
+			if (!head?.name) {
+				void vscode.window.showWarningMessage('当前处于 detached HEAD，无法推送当前分支');
+				return;
+			}
 			try {
-				await repo.push();
+				if (head.upstream) {
+					// 已配置上游：按 push.default 推送到追踪分支（正确处理本地名/上游名不一致）。
+					await repo.push();
+				} else {
+					// 无上游：选定 remote 并以 -u 建立追踪（修复「Failed to execute git」根因）。
+					const remotes = repo.state.remotes.map((r) => r.name);
+					if (remotes.length === 0) {
+						void vscode.window.showWarningMessage('未配置远程仓库（remote），无法推送');
+						return;
+					}
+					const remote =
+						remotes.length === 1
+							? remotes[0]
+							: await vscode.window.showQuickPick(remotes, {
+								placeHolder: `为「${head.name}」选择推送目标 remote（将建立上游追踪 -u）`,
+							});
+					if (!remote) {
+						return;
+					}
+					await repo.push(remote, head.name, true);
+				}
 				branchesTree.refresh();
+				void vscode.window.showInformationMessage(`已推送 ${head.name}`);
 			} catch (e) {
 				void vscode.window.showErrorMessage(`Push 失败：${errMsg(e)}`);
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const registry = new ChangelistRegistry(context.workspaceState, service.repoRoot ?? workspaceRoot);
 	const favorites = new BranchFavorites(context.workspaceState, service.repoRoot ?? workspaceRoot);
 	const tree = new ChangesTreeProvider(service, registry);
+	// createTreeView（registerTreeDataProvider 的超集）以获取 TreeView 句柄承载 .badge；
+	// 活动栏容器图标的数字角标 = 容器内各视图 badge.value 之和，故此处点亮即映射到 Hyper Git 图标。
+	const changesView = vscode.window.createTreeView('hyperGit.changes', { treeDataProvider: tree });
 
 	// AI 接缝注入（Null 实现，M5 替换为真实 provider）
 	const commit = new CommitService(context, service, context.workspaceState, {
@@ -90,7 +93,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		stashTree,
 		shelfTree,
 		blame,
-		vscode.window.registerTreeDataProvider('hyperGit.changes', tree),
+		changesView,
 		vscode.window.registerWebviewViewProvider(CommitWebviewProvider.viewType, commitView),
 		vscode.window.registerTreeDataProvider('hyperGit.log', logTree),
 		vscode.window.registerTreeDataProvider('hyperGit.branches', branchesTree),
@@ -116,12 +119,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		registerInlineCommitCommand(service, inlineLens),
 	);
 
+	// 活动栏角标：复用 service.getChanges() 计数（index+工作区+未跟踪去重），与 Changes 视图内容一致；
+	// 计数为 0 时清空，对齐原生 SCM 行为。
+	const updateChangesBadge = (): void => {
+		const count = service.getChanges().length;
+		changesView.badge = count > 0 ? { value: count, tooltip: `${count} 个未提交变更` } : undefined;
+	};
+
 	// git 状态变化频繁（add/checkout/diff 缓存失效均触发），防抖合并避免 log/stash 高频重拉。
 	let refreshTimer: ReturnType<typeof setTimeout> | undefined;
 	const refreshAll = (): void => {
 		clearTimeout(refreshTimer);
 		refreshTimer = setTimeout(() => {
 			tree.refresh();
+			updateChangesBadge();
 			commitView.refresh();
 			logTree.refresh();
 			branchesTree.refresh();
@@ -142,6 +153,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	setTimeout(() => {
 		branchesTree.refresh();
 		logTree.refresh();
+		updateChangesBadge();
 	}, 500);
 }
 


### PR DESCRIPTION
## 背景

v0.0.3 中用户截图反馈两处缺陷：

1. **活动栏图标无角标**：原生 Source Control 会显示「待提交文件数」，Hyper Git 图标却空白。
2. **Branches 栏 Push 失败**：点击「Push」(↑) 报「Push 失败：Failed to execute git」。

## 根因

- **角标**：`hyperGit.changes` 经 `registerTreeDataProvider` 注册，该 API 返回 `Disposable` 而非 `TreeView`，无对象可承载 `.badge`，全仓不存在角标代码。
- **Push**：`hyperGit.push` 以**零参数**调 `repo.push()`；当前活动分支**无上游**时 `git push`（`push.default=simple`）必然失败，vscode.git 将其包装为 `GitError`，其 `.message` 恰为通用串「Failed to execute git」，真实 stderr 被 `errMsg` 吞没。

## 修复

- **角标**（`src/extension.ts`）：改用 `createTreeView` 获取 `TreeView` 句柄；新增 `updateChangesBadge()`，计数复用 `service.getChanges()`（index+工作区+未跟踪去重），接入既有 `refreshAll` 防抖链路与首帧保险，计数为 0 时清空，对齐原生 SCM。活动栏容器图标角标 = 容器内各视图 `badge.value` 之和。
- **Push**（`src/adapter/history-commands.ts`）：以 `HEAD.upstream` 是否存在分流——有上游沿用 `repo.push()`；无上游选定 remote（单个直用 / 多个弹选）并以 `repo.push(remote, branch, true)` 建立 `-u` 追踪。增强 `errMsg` 优先暴露 `GitError.stderr`，使「无上游」「non-fast-forward」等失败可读（push/pull/fetch 等同享）。

## 验证

- ✅ `check-types` / `lint` / `package`（esbuild）/ `test:unit`（**166/166**）本地全绿。
- ⚠️ 活动栏角标与无上游 Push 属 VS Code 集成路径，需 F5 扩展宿主实机确认。

## 影响面

- 仅触及 2 个文件；不改 `package.json` 命令/菜单（`hyperGit.push` 仍注册）；对「有上游」分支 Push 行为不变；不引入强推/危险操作（force 仍仅在 `pushDialog` 提供）。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>
