### PR TITLE
ci(Publish): 门控 VS Code Marketplace 自动发布以消除 deployments 报错

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
 
-  # 发布：仅 tag 触发，双市场（Marketplace + OpenVSX），生产环境审批门
+  # 发布：仅 tag 触发；OpenVSX 默认发布，VS Code Marketplace 由 ENABLE_MARKETPLACE_PUBLISH 变量门控（默认关闭）；生产环境审批门
   publish:
     name: Publish
     needs: package
@@ -112,7 +112,11 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: vsix
+      # VS Code Marketplace 发布：默认关闭（未配置 VSCE_PAT）。
+      # 配好 VSCE_PAT 后，在仓库 Settings → Secrets and variables → Actions → Variables
+      # 新增 ENABLE_MARKETPLACE_PUBLISH=true 即恢复，无需改代码或发 PR。
       - name: 发布到 VS Code Marketplace
+        if: ${{ vars.ENABLE_MARKETPLACE_PUBLISH == 'true' }}
         run: |
           PRE_FLAG=$([[ "${GITHUB_REF_NAME}" == *rc* ]] && echo "--pre-release" || echo "")
           pnpm dlx @vscode/vsce publish --packagePath *.vsix $PRE_FLAG

--- a/docs/research/04-publishing-cicd.md
+++ b/docs/research/04-publishing-cicd.md
@@ -188,6 +188,28 @@ jobs:
 - **最小权限**:仅 `github-release` 提权 `contents: write`,顶层 `permissions: contents: read` 不动;
 - **复用**:消费 `package` job 既有的 `vsix` artifact,零重复打包。
 
+### 3.2.2 VS Code Marketplace 发布门控（特性开关，本仓 `ci.yml` 现状）
+
+在尚未配置 `VSCE_PAT` 凭证期间,`publish` job 的「发布到 VS Code Marketplace」步骤(`vsce publish`)会因鉴权失败而中断整个 job;因该 job 挂 `environment: production`,会在仓库 `/deployments` 页持续产生 **error** 状态的 deployment 记录。为此,本仓用**仓库级特性开关变量** `ENABLE_MARKETPLACE_PUBLISH` 对该步骤做门控:
+
+```yaml
+      - name: 发布到 VS Code Marketplace
+        if: ${{ vars.ENABLE_MARKETPLACE_PUBLISH == 'true' }}   # 默认未设=跳过,零报错
+        run: |
+          PRE_FLAG=$([[ "${GITHUB_REF_NAME}" == *rc* ]] && echo "--pre-release" || echo "")
+          pnpm dlx @vscode/vsce publish --packagePath *.vsix $PRE_FLAG
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+```
+
+设计要点(契合 AGENTS.md「最小干预 / 演进式设计」):
+
+- **默认关闭**:变量未设置时其值为空串,`'' == 'true'` 为假 → 步骤显示 **skipped**(非 failed),不致 job 失败;job 继续执行其后的 OpenVSX 步骤。
+- **OpenVSX 不受影响**:`ovsx publish` 步骤保持无条件发布,Cursor/Windsurf 等 AI IDE 用户的安装来源不中断(前提:`OVSX_PAT` 已配置)。
+- **零代码恢复**:取得 Azure DevOps PAT 后,在仓库 `Settings → Secrets and variables → Actions` 配置 `VSCE_PAT`(Secret)并新增 `ENABLE_MARKETPLACE_PUBLISH=true`(Variable)即恢复 Marketplace 自动发布,无需改动 workflow 或再发 PR——这是特性开关相较「注释/删除步骤」的核心优势。
+
+> 注:本门控仅阻止「未来」的失败 deployment;`/deployments` 上已有的历史失败记录不会自动消失,如需清空可在 `Settings → Environments → production` 删除该环境(会一并清除其 deployment 历史,下次发布时按 `environment: production` 自动重建),或经 REST API 逐条删除。
+
 ### 3.3 关键 Action 版本
 - `actions/checkout@v4`、`actions/setup-node@v4`、`actions/upload-artifact@v4`、`actions/download-artifact@v4`;
 - `@vscode/test-electron`(或新版 VS Code Test CLI)驱动集成测试;


### PR DESCRIPTION
## 背景

仓库 [/deployments](https://github.com/ThreeFish-AI/hyper-git/deployments) 页面持续报错。由于 VS Code Marketplace 发布凭证（`VSCE_PAT`）尚未配置，每次推送 `v*` tag 触发的 `publish` job 会在 `vsce publish` 步骤鉴权失败，进而中断整个 job。该 job 声明了 `environment: production`，因此每次失败都会在 `/deployments` 页留下一条 **error** 状态的 deployment 记录。

## 根因

`.github/workflows/ci.yml` 的 `publish` job 中，「发布到 VS Code Marketplace」步骤排在「发布到 OpenVSX」之前且无 `continue-on-error`。Marketplace 步骤鉴权失败后整个 job 中止，OpenVSX 步骤也无从执行，`production` deployment 被标记为 error。

## 改动

- **门控 Marketplace 步骤**：为「发布到 VS Code Marketplace」步骤增加仓库级特性开关 `if: ${{ vars.ENABLE_MARKETPLACE_PUBLISH == 'true' }}`。变量未设置时其值为空串，条件为假 → 步骤显示为 **skipped**（而非 failed），不致 job 失败。
- **OpenVSX 保持不变**：`ovsx publish` 步骤继续无条件发布，Cursor / Windsurf 等 AI IDE 用户的安装来源不中断。
- **同步注释与文档**：更新 `publish` job 注释；在 `docs/research/04-publishing-cicd.md` 增设 §3.2.2，说明该特性开关、OpenVSX 不受影响及历史 deployment 清理方式。

## 效果

Marketplace 步骤被跳过后，job 直接执行 OpenVSX 步骤；只要 `OVSX_PAT` 已配置且发布成功，`production` deployment 即由红转绿，报错消除。`github-release`（附带 `.vsix` 供本地安装）不受影响，正常产出。

## 日后恢复（零代码）

取得 Azure DevOps PAT 后，在仓库 `Settings → Secrets and variables → Actions`：
1. 配置 Secret `VSCE_PAT`；
2. 新增 Variable `ENABLE_MARKETPLACE_PUBLISH=true`。

即恢复 Marketplace 自动发布，**无需改动 workflow 或再发 PR**。

## 前提与注意

- 本方案消除报错的前提是 **OpenVSX 步骤能成功**（`OVSX_PAT` 已配置且 open-vsx.org 命名空间有效）。若 `OVSX_PAT` 也未配置，OpenVSX 步骤会失败、`production` deployment 仍会标红——届时需改为在 job 层门控以整体跳过该 job。
- 本改动仅阻止「未来」的失败 deployment；`/deployments` 上已有的历史失败记录不会自动消失，如需清空可在 `Settings → Environments → production` 删除该环境（会一并清除其 deployment 历史，下次发布按 `environment: production` 自动重建），或经 REST API 逐条删除。

## 验证

- 已用 Ruby 内置 YAML 解析校验 `ci.yml` 语法合法；确认 Marketplace 步骤 `if` 条件生效、OpenVSX 步骤保持无条件执行。
- 端到端验证需在合入后、下次推送 `v*`（或测试性 `rc`）tag 时观察：Marketplace 步骤 skipped、OpenVSX 正常执行、`production` deployment 转绿。

🤖 Generated with [Claude Code](https://github.com/claude)
