### PR TITLE
fix(Log): Graph 后文字自适应贴近以消除留白

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - **品牌图标统一**：将活动栏图标（`media/hyper-git-icon.svg`）、Marketplace 市场徽标（`media/icon.png`）与 README 头图统一为辨识度更高的「Git Pull Request」造型（字形改编自 Tabler Icons，MIT）；市场徽标基于新字形重新栅格化为 256×256 RGBA 蓝→紫渐变图，设计源沉淀至 `media-src/icon.svg`；README 头部重构为居中布局（徽标 + 标题 + 一句话定位 + License 徽章）。
 
+### Fixed
+
+- **Log Graph 文字与节点间留白**：原实现每行 Graph SVG 宽度取「已加载全部提交」的全局 `maxLanes`，分支型仓库中仅用 1–2 条 lane 的行仍预留整宽，导致节点与文字间大片留白。改为按「本行实际绘制的最右列」自适应行宽，文字随即向左贴近本行 Graph（lane x 坐标仍全局一致，竖线跨行衔接不变），对齐 IDEA「文字紧随 Graph」观感。
+
 ## [0.0.1-rc.4] - 2026-06-29 — 第四个预发布候选
 
 > 修复用户截图反馈的两处工具窗口缺陷：活动栏图标缺失「未提交文件数」角标、Branches「Push」对无上游分支失败。

--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -411,13 +411,14 @@ const detailsList = document.getElementById('details-list');
 function esc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;'); }
 function laneColor(i) { return PALETTE[((i % PALETTE.length) + PALETTE.length) % PALETTE.length]; }
 function colX(c) { return c * LANE_W + LANE_W / 2; }
-function graphPx() { return model.maxLanes * LANE_W + GUTTER; }
+/** 本行实际绘制的最右列号（node + 各边 from/to 的最大值）——行宽据此自适应，消除「全局 maxLanes 撑宽」的留白。 */
+function rowMaxCol(row) { const L = row.layout; let m = L.node.col; for (const e of L.incoming) { if (e.fromCol > m) m = e.fromCol; if (e.toCol > m) m = e.toCol; } for (const e of L.outgoing) { if (e.fromCol > m) m = e.fromCol; if (e.toCol > m) m = e.toCol; } for (const e of L.passThrough) { if (e.fromCol > m) m = e.fromCol; if (e.toCol > m) m = e.toCol; } return m; }
 function fmtDate(iso) { if (!iso) return ''; const d = new Date(iso); if (isNaN(d)) return ''; const m = String(d.getMonth() + 1).padStart(2, '0'); const da = String(d.getDate()).padStart(2, '0'); return d.getFullYear() + '-' + m + '-' + da; }
 
 function rowSvg(row) {
   const L = row.layout;
   const cy = ROW_H / 2;
-  const W = graphPx();
+  const W = (rowMaxCol(row) + 1) * LANE_W + GUTTER;
   const p = ['<svg class="graph" width="', W, '" height="', ROW_H, '" viewBox="0 0 ', W, ' ', ROW_H, '" xmlns="http://www.w3.org/2000/svg">'];
   const seg = (e) => 'stroke="' + laneColor(e.colorIdx) + '" stroke-width="1.6" stroke-linecap="round"';
   for (const e of L.passThrough) p.push('<line x1="', colX(e.fromCol), '" y1="0" x2="', colX(e.toCol), '" y2="', ROW_H, '" ', seg(e), '/>');


### PR DESCRIPTION
## 背景

#34 将 Log 视图升级为 IDEA 风格提交图（Graph DAG）并已合入 `feature/1.x.x`。用户实测反馈（截图红框标注）：**Graph 节点与后面的提交文字之间存在大片留白**，文字离 Graph 太远，不符合 IDEA「文字紧随 Graph」的观感。

## 根因

`log-webview.ts` 渲染时，每行 Graph SVG 的宽度取自「已加载全部提交（1000 条）」的**全局 `maxLanes`**：

```js
const W = graphPx(); // = model.maxLanes * LANE_W + GUTTER
```

分支型仓库中，`maxLanes` 被历史中某处的宽分叉（多 feature 并存）撑大（如 6–8 条 lane），而绝大多数行只占用 1–2 条 lane。这些行仍预留整宽，于是节点（位于 col 0）与文字（位于 graphPx）之间出现大片空白。

## 修复

按**本行实际绘制的最右列**自适应计算行宽，文字随即向左贴近本行 Graph：

```js
function rowMaxCol(row) { /* node.col + 各 incoming/outgoing/passThrough 的 fromCol/toCol 最大值 */ }
const W = (rowMaxCol(row) + 1) * LANE_W + GUTTER;
```

- lane 的 x 坐标仍为全局一致（`colX(c) = c*LANE_W + LANE_W/2`），故竖线跨行衔接、分支拓扑完全不变；
- 仅消去「右侧未被本行占用的预留宽度」，文字按各行实际 Graph 宽度左移贴近；
- 单 lane 行文字最靠左，分叉活跃区文字相应右移——视觉上自然传达分支深度。

## 验证

- ✅ `pnpm run compile`（tsc + eslint + esbuild）全绿
- ✅ `pnpm test:unit` **218/218 通过**（engine 未改，仅 webview 内联 JS 行宽计算）
- 改动范围：`src/adapter/webview/log-webview.ts`（+3/-2，内联 JS）+ `CHANGELOG.md`

> 说明：本环境无 GUI，无法本地 F5 实跑 webview 渲染；改动为内联 JS 的纯行宽计算，且 lane x 坐标全局一致，竖线衔接不变，CI（Lint & Build + Test）覆盖类型/单测/集成冒烟。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>