### PR TITLE
feat(Log): 提交记录显示 GitHub CI 最终状态（绿勾/红叉 + 悬停 Tooltip 明细）

### DIFF
--- a/docs/.agents/knowledge-map.md
+++ b/docs/.agents/knowledge-map.md
@@ -16,6 +16,7 @@
 
 ## 项目文档（docs/）
 - [文档中心](../docs/README.md) — 文档与调研资产总索引。
+- [Log 视图 CI 状态](../docs/features/log-ci-status.md) — 按提交显示 GitHub CI 最终状态（绿勾/红叉 + Tooltip 明细）：认证、限流、懒加载、边界与配置。
 - [实施状态总览](../docs/milestones/implementation-status.md) — M0-M5 交付记录 + API 限制 + M5 AI 设计 + 验证/发布（**实施看板**）。
 - [工程实施方案](../docs/architecture/engineering-plan.md) — 路径 B 架构 + M0-M5 里程碑（**开发蓝图**）。
 - [IDEA 功能复刻矩阵](../docs/requirements/idea-feature-matrix.md) — 56 功能点 / 8 组（**验收基线**）。

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@
 - [工程实施方案](./architecture/engineering-plan.md) — 全链路调研结论 + 路径 B 架构 + M0-M5 里程碑路线图 + 风险与验证（**开发蓝图**）。
 - [IDEA 功能复刻矩阵](./requirements/idea-feature-matrix.md) — 56 个原子功能点 / 8 组 + CheckinHandler 生命周期（**验收基线**）。
 
+## 功能文档
+- [Log 视图 CI 状态](./features/log-ci-status.md) — 按提交显示 GitHub CI 最终状态（绿勾/红叉 + 悬停 Tooltip 明细）：认证、限流、懒加载、边界与配置。
+
 ## 发布说明
 - [Release Notes 目录](./releases/README.md) — 各正式版发布说明（GitHub Release 正文单一事实源）；最新：[v0.0.1 首个 MVP](./releases/v0.0.1.md)。
 

--- a/docs/features/log-ci-status.md
+++ b/docs/features/log-ci-status.md
@@ -1,0 +1,77 @@
+# Log 视图 CI 状态（GitHub Actions / Commit Status）
+
+> 在 Log 视图（`hyperGit.log`，IDEA 风格提交图）每条提交上显示其 **CI 最终状态**：绿勾=通过、红叉=失败、
+> 运行中=黄色旋转；悬停图标以浮层 Tooltip 展示「各项检查 + 未通过原因 + 运行链接」，效果对标 IntelliJ IDEA / GitHub。
+> 数据源为 GitHub（Checks API + Commit Status），按 origin 远程主机自动判定 github.com / GitHub Enterprise。
+
+## 数据流
+
+```mermaid
+flowchart LR
+  subgraph Git["本地"]
+    A["git log → GraphRowVM"] --> B["图先渲染（CI 不阻塞）"]
+  end
+  subgraph WV["Webview（可见行懒加载）"]
+    B --> C["滚动收集未知 hash"]
+    C -->|"防抖 200ms"| D["log/requestCi"]
+  end
+  subgraph Host["Extension Host"]
+    D --> E["解析 origin 远程\nowner/repo/host"]
+    E --> F["vscode.authentication\n取 token（repo 范围）"]
+    F --> G["GraphQL 批量 ≤100 oid\nstatusCheckRollup"]
+    G --> H["按 oid 缓存\n终态永久 / pending 30s"]
+  end
+  H -->|"log/ciData"| I["webview 就地重绘图标"]
+  I --> J["悬停 → Tooltip 明细"]
+  J -->|"log/openExternal"| K["host 校验主机后\nopenExternal"]
+  style A fill:#1f6feb,color:#fff
+  style G fill:#238636,color:#fff
+  style H fill:#8957e5,color:#fff
+  style J fill:#d29922,color:#fff
+```
+
+## 认证与安全
+
+- 复用 **VS Code 内置 GitHub 认证**（`vscode.authentication`），凭证由编辑器托管，**绝不经过 chat / 日志 / webview**。
+- 范围 `repo`：覆盖私有仓库的 Checks（Actions）+ Commit Status 读取（`repo:status` 不覆盖 Checks API）。
+- **静默优先**：加载时 `getSession({createIfNone:false})` 仅复用已有会话，**绝不自动弹窗**；仅当用户点击工具栏「登录 GitHub」
+  按钮时才以 `{createIfNone:true}` 触发原生授权 UI。未登录 → 显示登录提示、不渲染图标、不发请求。
+- **反 SSRF**：Tooltip 的跳转链接（`detailsUrl` / `targetUrl`，属「观察内容」）由 host 校验 `https` 且主机 ∈ {仓库主机、`*.github.com`} 后才 `openExternal`。
+
+## 限流与性能
+
+- **懒加载、仅取可见行**：webview 虚拟滚动只渲染 ~50 行，滚动时收集未知 hash（防抖 200ms）批量请求。1000 条提交永不触发 1000 次请求。
+- **批量 GraphQL**：单次最多 100 个 oid 的 `statusCheckRollup`（别名批量），并发上限 2。
+- **缓存**：终态（success/failure）整会话缓存（提交 CI 结果不可变）；pending/unknown 30s TTL，运行中构建会逐步刷新为终态。
+- **限流冷却**：读取响应 `rateLimit{remaining,resetAt}` 与 `Retry-After`；剩余点数 <100 或 403 时进入冷却，期间只走缓存并给出一次性提示。
+- **降级**：未推送提交（远程无此 object）/ 无 CI 配置 → 不渲染图标；网络错误不缓存、下次滚动重试；断网/限流不崩溃、建图正常。
+
+## 边界行为
+
+| 场景 | 表现 |
+|---|---|
+| 未推送 / 本地提交 | 无图标（远程无对应 object → unknown） |
+| 仓库无 CI 配置 | 无图标（rollup 为 null → unknown） |
+| 非 GitHub 远程（GitLab 等） | 功能隐藏（零图标、零请求） |
+| GitHub Enterprise | 按 origin 主机自动判定，使用 `github-enterprise` provider（需用户已配置 `github-enterprise.uri`） |
+| 窄屏（.narrow 隐藏 author/date） | CI 图标例外保留可见 |
+
+## 配置
+
+| 键 | 默认 | 说明 |
+|---|---|---|
+| `hyperGit.log.ci.enabled` | `true` | 总开关。关闭后零图标、零请求。 |
+| `hyperGit.log.ci.remote` | `""` | 查询用的远程名；留空=自动（优先 `origin`），多远程可指定如 `upstream`。 |
+| `hyperGit.log.ci.provider` | `auto` | `auto`（按主机判定）/ `github.com` / `github-enterprise`。 |
+
+## 实现
+
+- 引擎层（纯逻辑，Vitest 可测）：[`engine/ci/`](../../src/engine/ci) — `remote-parser.ts`（URL→坐标/端点）、`graphql-query.ts`（批量查询构造）、`rollup.ts`（状态归一化/聚合）、`model.ts`（响应解析）、`types.ts`。
+- 适配层（唯一触碰 vscode/网络）：[`adapter/ci/`](../../src/adapter/ci) — `github-auth.ts`（认证）、`github-ci-service.ts`（缓存/批量/限流/降级/openExternal）。
+- 协议：[`shared/protocol.ts`](../../src/shared/protocol.ts) — `log/requestCi`、`log/ciData`、`log/ciMeta`、`log/openExternal`、`log/ciSignIn`。
+- 渲染：[`adapter/webview/log-webview.ts`](../../src/adapter/webview/log-webview.ts) — 内联 JS 的懒加载、图标槽位（提交行最右侧）、自定义 Tooltip 浮层。
+
+## 验证
+
+1. `pnpm run check-types` + `pnpm run lint` + `pnpm run test:unit`（含 `tests/unit/ci-*.test.ts`）全绿。
+2. Extension Development Host（F5）在 GitHub 仓库：未登录见「登录 GitHub」提示 → 点击原生授权 → 可见行右侧渐次出现图标；悬停红叉见明细 + 链接；点击打开 run；未推送/非 GitHub → 无图标；断网/限流不崩溃。

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
       { "command": "hyperGit.commit", "title": "提交", "category": "Hyper Git", "icon": "$(check)" },
       { "command": "hyperGit.commitAndPush", "title": "提交并推送", "category": "Hyper Git", "icon": "$(cloud-upload)" },
       { "command": "hyperGit.refreshLog", "title": "刷新 Log", "category": "Hyper Git", "icon": "$(refresh)" },
+      { "command": "hyperGit.ci.signIn", "title": "登录 GitHub 查看 CI 状态", "category": "Hyper Git" },
       { "command": "hyperGit.refreshBranches", "title": "刷新 Branches", "category": "Hyper Git", "icon": "$(refresh)" },
       { "command": "hyperGit.logFilterAuthor", "title": "按作者过滤", "category": "Hyper Git" },
       { "command": "hyperGit.logFilterPath", "title": "按路径过滤", "category": "Hyper Git" },
@@ -344,6 +345,22 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "启用 AI 代理能力（M5，当前仅预留接缝，暂不生效）。"
+        },
+        "hyperGit.log.ci.enabled": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "在 Log 视图每条提交上显示 CI 最终状态（GitHub Actions + Commit Statuses）。绿勾=通过、红叉=失败、悬停查看各项检查与未通过原因。需远程为 GitHub。"
+        },
+        "hyperGit.log.ci.remote": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "查询 CI 状态使用的远程名（留空=自动，优先 `origin`）。多远程仓库可指定如 `upstream`。"
+        },
+        "hyperGit.log.ci.provider": {
+          "type": "string",
+          "enum": ["auto", "github.com", "github-enterprise"],
+          "default": "auto",
+          "markdownDescription": "CI 数据来源。`auto` 按 origin 主机判定（github.com → github.com，其余 → GitHub Enterprise）。"
         }
       }
     }

--- a/src/adapter/ci/github-auth.ts
+++ b/src/adapter/ci/github-auth.ts
@@ -1,0 +1,58 @@
+/**
+ * GitHub 认证（adapter 层，唯一触碰 vscode.authentication）。
+ *
+ * 复用 VS Code 内置 GitHub 认证 provider，凭证由编辑器托管，绝不经过 chat/日志。
+ * - `repo` 范围：覆盖私有仓库的 Checks（Actions）+ Commit Status 读取（`repo:status` 不覆盖 Checks）。
+ * - 静默 `peek`（createIfNone:false）：仅复用已存在会话，绝不弹窗；`signIn`（createIfNone:true）仅在
+ *   用户显式点击「登录」时由命令触发。provider id 随主机定（github.com→`github`，GHE→`github-enterprise`）。
+ */
+
+import * as vscode from 'vscode';
+
+export type GitHubAuthProviderId = 'github' | 'github-enterprise';
+
+/** 读 CI（私有仓库的 Checks + Statuses）所需范围。 */
+const GITHUB_SCOPES = ['repo'] as const;
+
+export class GitHubAuth {
+	/** 已缓存的会话（undefined 表示「已探测且无会话」；has() 区分「未探测」与「无会话」避免重复 getSession）。 */
+	private readonly cached = new Map<GitHubAuthProviderId, vscode.AuthenticationSession | undefined>();
+
+	constructor(disposables: vscode.Disposable[]) {
+		disposables.push(
+			vscode.authentication.onDidChangeSessions((e) => {
+				const id = e.provider.id;
+				if (id === 'github' || id === 'github-enterprise') {
+					this.cached.delete(id as GitHubAuthProviderId);
+				}
+			}),
+		);
+	}
+
+	/** 静默探测：仅返回已存在会话，永不弹窗。provider 未注册（GHE 未配置）时抛错，由调用方捕获。 */
+	async peek(provider: GitHubAuthProviderId): Promise<vscode.AuthenticationSession | undefined> {
+		if (this.cached.has(provider)) {
+			return this.cached.get(provider);
+		}
+		const session = await vscode.authentication.getSession(provider, [...GITHUB_SCOPES], { createIfNone: false });
+		this.cached.set(provider, session);
+		return session;
+	}
+
+	/** 交互式登录：显示原生授权 UI。仅在用户显式手势触发时调用。 */
+	async signIn(provider: GitHubAuthProviderId): Promise<vscode.AuthenticationSession | undefined> {
+		try {
+			const session = await vscode.authentication.getSession(provider, [...GITHUB_SCOPES], { createIfNone: true });
+			this.cached.set(provider, session);
+			return session;
+		} catch {
+			// 用户取消授权：保持未登录，不抛错。
+			return undefined;
+		}
+	}
+
+	/** 失效缓存（401 时调用，强制下次重新解析会话）。 */
+	invalidate(provider: GitHubAuthProviderId): void {
+		this.cached.delete(provider);
+	}
+}

--- a/src/adapter/ci/github-ci-service.ts
+++ b/src/adapter/ci/github-ci-service.ts
@@ -1,0 +1,416 @@
+/**
+ * GitHub CI 服务（adapter 层，唯一触碰 vscode/网络）。
+ *
+ * 编排：解析 origin 远程 → GitHub 坐标 → 取 token → GraphQL 批量取 `statusCheckRollup` →
+ * 按 oid 缓存（终态永久 / pending 30s TTL）→ 回填 webview。CI 懒加载、仅取可见行、终态整会话缓存，
+ * 从根本上规避 1000 提交触发 1000 请求的限流风暴。失败一律降级为「无图标 / 走缓存」，绝不阻塞建图。
+ *
+ * 安全：token 仅用于 Authorization 头，不入日志/webview；`openExternal` 校验主机属 GitHub（反 SSRF，
+ * detailsUrl 属观察内容不盲信）。
+ */
+
+import * as vscode from 'vscode';
+import type { GitRepositoryService } from '../git-repository-service';
+import type { Logger } from '../../infra/logger';
+import { GitHubAuth, type GitHubAuthProviderId } from './github-auth';
+import { buildCiQuery } from '../../engine/ci/graphql-query';
+import { extractRateLimit, parseCiResponse } from '../../engine/ci/model';
+import { authProviderId, graphqlEndpoint, parseGitHubRemote, type GitHubRemote } from '../../engine/ci/remote-parser';
+import type { CiStatusVM } from '../../engine/ci/types';
+
+/** 单次 GraphQL 拉取的 oid 上限（与可见窗口粒度对齐，文档体积与单点成本均衡）。 */
+const MAX_OIDS_PER_QUERY = 100;
+/** GraphQL 并发上限（滚动连发时保护 GitHub）。 */
+const MAX_CONCURRENT = 2;
+/** 单请求超时（ms）。 */
+const REQUEST_TIMEOUT_MS = 15_000;
+/** pending / unknown 缓存 TTL（ms）—— 运行中或未推送的提交短时刷新。 */
+const PENDING_TTL_MS = 30_000;
+/** 剩余点数低于此阈值进入限流冷却（直到 resetAt）。 */
+const RATE_FLOOR = 100;
+
+export interface CiServiceStatus {
+	/** 远程为 GitHub 且功能启用：可显示图标/发请求。 */
+	readonly available: boolean;
+	/** 远程是 GitHub 但未授权：webview 显示「登录」提示。 */
+	readonly needsAuth: boolean;
+	/** 软错误摘要（限流/运行时无 fetch）。 */
+	readonly error?: string;
+}
+
+interface RemoteCacheEntry {
+	readonly repoRoot: string;
+	readonly remote: GitHubRemote | null;
+}
+
+interface CacheEntry {
+	readonly vm: CiStatusVM;
+	readonly expires: number; // Infinity 表示整会话
+}
+
+/** 简易异步信号量（控制并发请求数）。 */
+class Semaphore {
+	private active = 0;
+	private readonly waiters: Array<() => void> = [];
+	constructor(private readonly max: number) {}
+	async acquire(): Promise<void> {
+		if (this.active < this.max) {
+			this.active++;
+			return;
+		}
+		await new Promise<void>((resolve) => this.waiters.push(resolve));
+	}
+	release(): void {
+		if (this.waiters.length > 0) {
+			this.waiters.shift()!(); // 直接把槽位移交给等待者，active 不变
+		} else {
+			this.active--;
+		}
+	}
+}
+
+export class GitHubCiService implements vscode.Disposable {
+	private remoteCache: RemoteCacheEntry | null = null;
+	private readonly cache = new Map<string, CacheEntry>();
+	private readonly inflight = new Map<string, Promise<CiStatusVM | undefined>>();
+	private cooldownUntil = 0;
+	private readonly semaphore = new Semaphore(MAX_CONCURRENT);
+	private readonly abortController = new AbortController();
+	private readonly disposables: vscode.Disposable[] = [];
+
+	constructor(
+		private readonly service: GitRepositoryService,
+		private readonly auth: GitHubAuth,
+		private readonly logger: Logger,
+	) {
+		this.disposables.push(
+			// 配置变更（开关/provider/远程）后重算可用性。
+			vscode.workspace.onDidChangeConfiguration((e) => {
+				if (e.affectsConfiguration('hyperGit.log.ci')) {
+					this.remoteCache = null;
+				}
+			}),
+		);
+	}
+
+	// ─── 对外能力 ────────────────────────────────────────────────────────────
+
+	/** 当前仓库的 CI 能力 + 授权态（廉价：复用缓存会话，不阻塞建图）。 */
+	async status(): Promise<CiServiceStatus> {
+		if (!this.enabled()) {
+			return { available: false, needsAuth: false };
+		}
+		const remote = this.resolveRemote();
+		const provider = remote ? this.providerIdFor(remote) : null;
+		if (!remote || !provider) {
+			return { available: false, needsAuth: false };
+		}
+		if (typeof globalThis.fetch !== 'function') {
+			return { available: false, needsAuth: false, error: '当前运行时无全局 fetch' };
+		}
+		try {
+			const session = await this.auth.peek(provider);
+			return { available: true, needsAuth: !session, error: this.cooldownError() };
+		} catch {
+			// provider 未注册（GHE 未配置 github-enterprise.uri）→ 功能休眠，不报错。
+			return { available: false, needsAuth: false };
+		}
+	}
+
+	/** 批量取 CI 状态（缓存优先 + in-flight 去重 + 批量 GraphQL）。 */
+	async getStatuses(hashes: readonly string[]): Promise<Map<string, CiStatusVM>> {
+		const result = new Map<string, CiStatusVM>();
+		if (hashes.length === 0 || !this.enabled()) {
+			return result;
+		}
+		const remote = this.resolveRemote();
+		const provider = remote ? this.providerIdFor(remote) : null;
+		if (!remote || !provider) {
+			return result;
+		}
+
+		const uniq = [...new Set(hashes)];
+		const toAwait: Array<[string, Promise<CiStatusVM | undefined>]> = [];
+		const toFetch: string[] = [];
+		for (const h of uniq) {
+			const cached = this.readCache(h);
+			if (cached) {
+				result.set(h, cached);
+				continue;
+			}
+			const existing = this.inflight.get(h);
+			if (existing) {
+				toAwait.push([h, existing]);
+			} else {
+				toFetch.push(h);
+			}
+		}
+
+		if (toFetch.length > 0 && !this.inCooldown()) {
+			for (const batch of this.chunk(toFetch, MAX_OIDS_PER_QUERY)) {
+				const batchPromise = this.runBatch(remote, provider, batch);
+				for (const h of batch) {
+					const p = batchPromise.then((m) => m.get(h));
+					this.inflight.set(h, p);
+					toAwait.push([h, p]);
+				}
+			}
+		}
+
+		if (toAwait.length === 0) {
+			return result;
+		}
+		const settled = await Promise.all(toAwait.map(async ([h, p]) => [h, (await p) as CiStatusVM | undefined] as const));
+		for (const [h, vm] of settled) {
+			this.inflight.delete(h);
+			if (vm) {
+				this.writeCache(h, vm);
+				result.set(h, vm);
+			}
+		}
+		return result;
+	}
+
+	/** 交互式登录（命令触发）。 */
+	async signIn(): Promise<boolean> {
+		const remote = this.resolveRemote();
+		const provider = remote ? this.providerIdFor(remote) : null;
+		if (!remote || !provider) {
+			return false;
+		}
+		try {
+			const session = await this.auth.signIn(provider);
+			return !!session;
+		} catch {
+			return false;
+		}
+	}
+
+	/** 校验后打开外部链接（反 SSRF：仅放行 GitHub 主机）。 */
+	async openExternal(rawUrl: string): Promise<void> {
+		let uri: vscode.Uri;
+		try {
+			uri = vscode.Uri.parse(rawUrl, true);
+		} catch {
+			return;
+		}
+		if (uri.scheme !== 'https') {
+			return;
+		}
+		const host = uri.authority.toLowerCase();
+		const remote = this.resolveRemote();
+		const allowed =
+			host === 'github.com' ||
+			host.endsWith('.github.com') ||
+			(!!remote && (host === remote.host || host === `api.${remote.host}`));
+		if (!allowed) {
+			this.logger.warn(`拒绝打开非 GitHub 链接：${rawUrl}`);
+			return;
+		}
+		await vscode.env.openExternal(uri);
+	}
+
+	dispose(): void {
+		this.abortController.abort();
+		this.inflight.clear();
+		this.disposables.forEach((d) => d.dispose());
+	}
+
+	// ─── 配置 / 远程解析 ──────────────────────────────────────────────────────
+
+	private enabled(): boolean {
+		return vscode.workspace.getConfiguration('hyperGit').get<boolean>('log.ci.enabled', true);
+	}
+
+	private providerConfig(): 'auto' | 'github.com' | 'github-enterprise' {
+		return vscode.workspace.getConfiguration('hyperGit').get<'auto' | 'github.com' | 'github-enterprise'>(
+			'log.ci.provider',
+			'auto',
+		);
+	}
+
+	private remoteNameConfig(): string {
+		return vscode.workspace.getConfiguration('hyperGit').get<string>('log.ci.remote', '') ?? '';
+	}
+
+	/** 远程 → 认证 provider（依据配置与主机；不匹配返回 null → 功能休眠）。 */
+	private providerIdFor(remote: GitHubRemote): GitHubAuthProviderId | null {
+		const cfg = this.providerConfig();
+		if (cfg === 'github.com') {
+			return remote.isGitHubDotCom ? 'github' : null;
+		}
+		if (cfg === 'github-enterprise') {
+			return remote.isGitHubDotCom ? null : 'github-enterprise';
+		}
+		// auto：信任远程主机探测（github.com → github，其余 → github-enterprise）。
+		return authProviderId(remote);
+	}
+
+	/** 解析当前仓库远程为 GitHub 坐标（按 repoRoot 缓存；优先配置名 → origin → 首个可解析）。 */
+	private resolveRemote(): GitHubRemote | null {
+		const repoRoot = this.service.repoRoot ?? '';
+		if (this.remoteCache && this.remoteCache.repoRoot === repoRoot) {
+			return this.remoteCache.remote;
+		}
+		let remote: GitHubRemote | null = null;
+		const remotes = this.service.repo?.state.remotes ?? [];
+		if (remotes.length > 0) {
+			const preferred = this.remoteNameConfig().trim();
+			const pick = (r: { fetchUrl?: string; pushUrl?: string }): string => r.pushUrl ?? r.fetchUrl ?? '';
+			const ordered: Array<{ fetchUrl?: string; pushUrl?: string }> = [];
+			if (preferred) {
+				const hit = remotes.find((r) => r.name === preferred);
+				if (hit) {
+					ordered.push(hit);
+				}
+			}
+			const origin = remotes.find((r) => r.name === 'origin');
+			if (origin) {
+				ordered.push(origin);
+			}
+			ordered.push(...remotes);
+			for (const cand of ordered) {
+				remote = parseGitHubRemote(pick(cand));
+				if (remote) {
+					break;
+				}
+			}
+		}
+		this.remoteCache = { repoRoot, remote };
+		return remote;
+	}
+
+	// ─── 缓存 / 限流 ─────────────────────────────────────────────────────────
+
+	private readCache(hash: string): CiStatusVM | undefined {
+		const entry = this.cache.get(hash);
+		if (!entry) {
+			return undefined;
+		}
+		if (entry.expires !== Infinity && Date.now() > entry.expires) {
+			this.cache.delete(hash);
+			return undefined;
+		}
+		return entry.vm;
+	}
+
+	private writeCache(hash: string, vm: CiStatusVM): void {
+		const terminal = vm.state === 'success' || vm.state === 'failure';
+		this.cache.set(hash, { vm, expires: terminal ? Infinity : Date.now() + PENDING_TTL_MS });
+	}
+
+	private inCooldown(): boolean {
+		return Date.now() < this.cooldownUntil;
+	}
+
+	private cooldownError(): string | undefined {
+		if (!this.inCooldown()) {
+			return undefined;
+		}
+		const secs = Math.ceil((this.cooldownUntil - Date.now()) / 1000);
+		return `GitHub 限流，约 ${secs}s 后恢复`;
+	}
+
+	// ─── 取数 ────────────────────────────────────────────────────────────────
+
+	private chunk<T>(arr: readonly T[], size: number): T[][] {
+		const out: T[][] = [];
+		for (let i = 0; i < arr.length; i += size) {
+			out.push(arr.slice(i, i + size));
+		}
+		return out;
+	}
+
+	/** 单批 GraphQL 取数（带并发闸、超时、401/403/限流处理）。失败返回空 Map（不缓存，留待重试）。 */
+	private async runBatch(remote: GitHubRemote, provider: GitHubAuthProviderId, oids: string[]): Promise<Map<string, CiStatusVM>> {
+		const map = new Map<string, CiStatusVM>();
+		if (oids.length === 0) {
+			return map;
+		}
+		const fetchImpl = globalThis.fetch;
+		if (typeof fetchImpl !== 'function') {
+			this.logger.warn('当前运行时无全局 fetch，CI 功能不可用');
+			return map;
+		}
+		const token = await this.acquireToken(provider);
+		if (!token) {
+			return map; // 未授权：不缓存，待登录后重试
+		}
+
+		const { query } = buildCiQuery({ owner: remote.owner, name: remote.repo, oids });
+		const endpoint = graphqlEndpoint(remote);
+		const body = JSON.stringify({ query, variables: { owner: remote.owner, name: remote.repo } });
+
+		await this.semaphore.acquire();
+		try {
+			const res = await this.fetchWithTimeout(fetchImpl, endpoint, {
+				method: 'POST',
+				headers: { Authorization: `bearer ${token}`, 'Content-Type': 'application/json', 'User-Agent': 'hyper-git-vscode' },
+				body,
+			});
+			if (res.status === 401) {
+				this.auth.invalidate(provider); // token 失效，强制下次重解析会话
+				return map;
+			}
+			if (res.status === 403) {
+				const retryAfter = res.headers.get('retry-after');
+				if (retryAfter) {
+					this.cooldownUntil = Math.max(this.cooldownUntil, Date.now() + Number(retryAfter) * 1000);
+				}
+				return map;
+			}
+			let json: unknown;
+			try {
+				json = await res.json();
+			} catch {
+				return map;
+			}
+			const errors = (json as { errors?: unknown[] })?.errors;
+			if (Array.isArray(errors) && errors.length > 0) {
+				this.logger.warn(`CI 查询返回错误：${JSON.stringify(errors[0])}`);
+			}
+			const rl = extractRateLimit(json);
+			if (rl && rl.remaining !== null && rl.remaining < RATE_FLOOR) {
+				const until = rl.resetAt ? Date.parse(rl.resetAt) : NaN;
+				this.cooldownUntil = Math.max(this.cooldownUntil, Number.isNaN(until) ? Date.now() + 60_000 : until);
+			}
+			for (const [h, vm] of parseCiResponse(json, oids)) {
+				map.set(h, vm);
+			}
+		} catch (e) {
+			if ((e as Error)?.name !== 'AbortError') {
+				this.logger.warn(`CI 请求失败：${(e as Error).message ?? e}`);
+			}
+		} finally {
+			this.semaphore.release();
+		}
+		return map;
+	}
+
+	/** fetch + 超时/销毁可中止（每个请求独立 AbortController，挂到全局 dispose 信号）。 */
+	private async fetchWithTimeout(
+		fetchImpl: typeof globalThis.fetch,
+		url: string,
+		init: RequestInit,
+	): Promise<Response> {
+		const reqAc = new AbortController();
+		const onDispose = (): void => reqAc.abort();
+		this.abortController.signal.addEventListener('abort', onDispose, { once: true });
+		const timer = setTimeout(() => reqAc.abort(), REQUEST_TIMEOUT_MS);
+		try {
+			return await fetchImpl(url, { ...init, signal: reqAc.signal });
+		} finally {
+			clearTimeout(timer);
+			this.abortController.signal.removeEventListener('abort', onDispose);
+		}
+	}
+
+	private async acquireToken(provider: GitHubAuthProviderId): Promise<string | null> {
+		try {
+			const session = await this.auth.peek(provider);
+			return session?.accessToken ?? null;
+		} catch {
+			return null;
+		}
+	}
+}

--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -7,7 +7,10 @@ import { DEFAULT_LANE_PALETTE } from '../../engine/log/graph-color';
 import { computeGraphLayout, maxLanes } from '../../engine/log/graph-layout';
 import { parseLogLines } from '../../engine/log/log-line';
 import { buildLogArgs, type LogScope } from '../../engine/log/log-query';
+import type { GitHubCiService } from '../ci/github-ci-service';
 import type {
+	CiMetaVM,
+	CiStatusVM,
 	GraphRowVM,
 	LogCommitFileItem,
 	LogGraphState,
@@ -84,7 +87,7 @@ export class LogWebviewProvider implements vscode.WebviewViewProvider, LogFilter
 	private refreshTimer: ReturnType<typeof setTimeout> | undefined;
 	private readonly disposables: vscode.Disposable[] = [];
 
-	constructor(private readonly service: GitRepositoryService) {
+	constructor(private readonly service: GitRepositoryService, private readonly ciService: GitHubCiService) {
 		// 兜底实时刷新：git 状态变化（commit/checkout 等）防抖重拉首页。
 		let t: ReturnType<typeof setTimeout> | undefined;
 		this.disposables.push(
@@ -162,6 +165,15 @@ export class LogWebviewProvider implements vscode.WebviewViewProvider, LogFilter
 					void this.handleCommitMenu(msg.payload.hash);
 				}
 				break;
+			case 'log/requestCi':
+				void this.handleRequestCi(msg.payload.hashes);
+				break;
+			case 'log/openExternal':
+				void this.ciService.openExternal(msg.payload.url);
+				break;
+			case 'log/ciSignIn':
+				void this.handleCiSignIn();
+				break;
 		}
 	}
 
@@ -189,6 +201,47 @@ export class LogWebviewProvider implements vscode.WebviewViewProvider, LogFilter
 			repoRoot: this.service.repoRoot ?? '',
 		};
 		this.post({ type: 'log/graphData', payload: state });
+		// CI 元信息异步随附（不阻塞建图）：远程为 GitHub 才启用，未授权则提示登录。
+		void this.pushCiMeta();
+	}
+
+	/** 推送 CI 能力/授权态（status() 廉价：复用缓存会话）。失败静默回退为不可用。 */
+	private async pushCiMeta(): Promise<void> {
+		if (!this.view) {
+			return;
+		}
+		let meta: CiMetaVM;
+		try {
+			const s = await this.ciService.status();
+			meta = { available: s.available, needsSignIn: s.needsAuth, error: s.error };
+		} catch {
+			meta = { available: false, needsSignIn: false };
+		}
+		if (this.view) {
+			this.post({ type: 'log/ciMeta', payload: meta });
+		}
+	}
+
+	/** 懒加载可见行 CI（webview 滚动按需请求），取数后守卫 view 仍存在再回填。 */
+	private async handleRequestCi(hashes: readonly string[]): Promise<void> {
+		if (hashes.length === 0) {
+			return;
+		}
+		const map = await this.ciService.getStatuses(hashes);
+		if (!this.view || map.size === 0) {
+			return;
+		}
+		const rec: Record<string, CiStatusVM> = {};
+		for (const [hash, vm] of map) {
+			rec[hash] = vm;
+		}
+		this.post({ type: 'log/ciData', payload: { map: rec } });
+	}
+
+	/** 用户点击「登录 GitHub 查看 CI」：走原生授权，完成后刷新 CI 元信息。 */
+	private async handleCiSignIn(): Promise<void> {
+		await this.ciService.signIn();
+		await this.pushCiMeta();
 	}
 
 	private async loadMore(cursor: number): Promise<void> {
@@ -373,6 +426,39 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #details .file .nm { overflow: hidden; text-overflow: ellipsis; }
 #empty { padding: 16px; text-align: center; opacity: 0.6; font-size: 12px; }
 #spinner { position: absolute; bottom: 6px; right: 8px; font-size: 11px; opacity: 0.6; display: none; }
+/* ── CI 状态图标（提交行最右侧，固定 16px 槽位，保证 author/date 列对齐）── */
+.ci { flex: 0 0 16px; width: 16px; display: inline-flex; align-items: center; justify-content: center; }
+.ci svg { display: block; shape-rendering: geometricPrecision; pointer-events: none; }
+.ci-success { color: var(--vscode-testing-iconPassed, #3fb950); }
+.ci-failure { color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground, #f85149)); }
+.ci-pending { color: var(--vscode-testing-iconQueued, var(--vscode-editorWarning-foreground, #d29922)); }
+.ci:not(.ci-empty):hover { filter: brightness(1.15); }
+.ci:not(.ci-empty):focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px; border-radius: 3px; }
+/* narrow 模式隐藏 author/date，但 CI 图标例外保留（核心信号）。 */
+#viewport.narrow .ci { display: inline-flex; }
+@keyframes ci-rot { to { transform: rotate(360deg); } }
+.ci-spin { transform-origin: 50% 50%; animation: ci-rot 1s linear infinite; }
+@media (prefers-reduced-motion: reduce) { .ci-spin { animation: none; } }
+.ci-signin { display: none; background: transparent; border: 1px solid var(--vscode-button-border, var(--vscode-input-border, transparent)); color: var(--vscode-textLink-foreground); font-size: 10px; padding: 1px 6px; border-radius: 3px; cursor: pointer; opacity: 0.85; }
+.ci-signin:hover { opacity: 1; background: var(--vscode-list-hoverBackground); }
+/* ── CI Tooltip（自定义浮层，置于 #rows 之外，虚拟滚动重写不销毁）── */
+#ci-tip { position: fixed; z-index: 50; display: none; max-width: 360px; min-width: 220px; max-height: 320px; overflow: hidden; background: var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background)); color: var(--vscode-editorHoverWidget-foreground, var(--vscode-foreground)); border: 1px solid var(--vscode-editorHoverWidget-border, var(--vscode-editorWidget-border, rgba(128,128,128,.3))); border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,.35); font-size: 12px; }
+#ci-tip.show { display: flex; flex-direction: column; }
+#ci-tip .tip-h { padding: 7px 10px; font-weight: 600; border-bottom: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); display: flex; align-items: center; gap: 6px; }
+#ci-tip .tip-h .g { flex: 0 0 14px; display: inline-flex; }
+#ci-tip .tip-list { overflow-y: auto; max-height: 240px; padding: 2px 0; }
+#ci-tip .tip-row { display: flex; align-items: flex-start; gap: 7px; padding: 4px 10px; cursor: pointer; }
+#ci-tip .tip-row:hover { background: var(--vscode-list-hoverBackground); }
+#ci-tip .tip-row .g { flex: 0 0 14px; display: inline-flex; margin-top: 1px; }
+#ci-tip .tip-row .nm { flex: 1 1 auto; min-width: 0; overflow: hidden; }
+#ci-tip .tip-row .nm .desc { display: block; font-size: 11px; opacity: 0.7; white-space: normal; word-break: break-word; margin-top: 1px; }
+#ci-tip .tip-foot { padding: 6px 10px; border-top: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); }
+#ci-tip .tip-foot a { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: none; }
+#ci-tip .tip-foot a:hover { text-decoration: underline; }
+#ci-tip .g-success { color: var(--vscode-testing-iconPassed, #3fb950); }
+#ci-tip .g-failure { color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground, #f85149)); }
+#ci-tip .g-pending { color: var(--vscode-testing-iconQueued, var(--vscode-editorWarning-foreground, #d29922)); }
+#ci-tip .g-skipped { color: var(--vscode-descriptionForeground, #8b949e); }
 </style>
 </head>
 <body>
@@ -382,6 +468,7 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
     <button id="scope-current">Current</button>
   </span>
   <span class="repo" id="repo"></span>
+  <button id="ci-signin" class="ci-signin" title="登录 GitHub 查看 CI 状态">登录 GitHub</button>
 </div>
 <div id="viewport" tabindex="0">
   <div id="spacer"><div id="rows"></div></div>
@@ -389,6 +476,7 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
   <div id="spinner">加载中…</div>
 </div>
 <div id="details"><div class="dh" id="details-head"></div><div id="details-list"></div></div>
+<div id="ci-tip" role="dialog" aria-label="CI 检查详情"></div>
 <script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
 const PALETTE = ${palette};
@@ -398,6 +486,15 @@ let selectedHash = persisted.selectedHash || null;
 let scope = persisted.scope || 'all';
 let model = { rows: [], maxLanes: 0, hasMore: false, repoRoot: '' };
 let renderedFirst = -1, renderedLast = -1, fetching = false;
+// ── CI 状态（懒加载、仅取可见行；ciByHash 缓存、ciRequested 去重、ciPending 防抖批量）──
+const ciByHash = Object.create(null);
+const ciRequested = new Set();
+const ciPending = new Set();
+let ciMeta = { available: false, needsSignIn: false, error: '' };
+let ciReqTimer = null;
+const ciTipEl = document.getElementById('ci-tip');
+const ciSignInEl = document.getElementById('ci-signin');
+let tipHash = null, tipShowT = null, tipHideT = null, overIcon = false, overTip = false;
 const viewport = document.getElementById('viewport');
 const spacer = document.getElementById('spacer');
 const rowsEl = document.getElementById('rows');
@@ -444,6 +541,27 @@ function chipsHtml(row) {
   return parts.join('');
 }
 
+function ciGlyph(state) {
+  if (state === 'success') return '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><circle cx="8" cy="8" r="6.6" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M4.8 8.2l2.1 2.1 4.3-4.5" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+  if (state === 'failure') return '<svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><circle cx="8" cy="8" r="6.6" fill="none" stroke="currentColor" stroke-width="1.4"/><path d="M5.6 5.6l4.8 4.8M10.4 5.6l-4.8 4.8" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>';
+  if (state === 'pending') return '<svg class="ci-spin" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><circle cx="8" cy="8" r="6.4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-dasharray="10 30"/></svg>';
+  return '';
+}
+
+/** 提交行最右侧的 CI 槽位（固定 16px 保列对齐；available=false 零宽；无数据=空槽不交互）。 */
+function ciSlotHtml(row) {
+  if (!ciMeta.available) return '';
+  const ci = ciByHash[row.hash];
+  if (!ci || ci.state === 'unknown') {
+    return '<span class="ci ci-empty" aria-hidden="true"></span>';
+  }
+  const failed = ci.total - ci.passed;
+  const a11y = ci.state === 'success' ? 'CI 通过 ' + ci.passed + '/' + ci.total
+    : ci.state === 'failure' ? 'CI 失败 ' + failed + '/' + ci.total + ' 项未通过'
+    : 'CI 运行中 ' + ci.passed + '/' + ci.total;
+  return '<span class="ci ci-' + ci.state + '" data-ci="' + esc(row.hash) + '" tabindex="0" role="button" aria-label="' + esc(a11y) + '">' + ciGlyph(ci.state) + '</span>';
+}
+
 function rowHtml(row, idx) {
   const sel = row.hash === selectedHash ? ' selected' : '';
   const merge = row.isMerge ? '<span class="merge" title="合并提交">⇠</span>' : '';
@@ -452,6 +570,7 @@ function rowHtml(row, idx) {
     + '<span class="subject">' + chipsHtml(row) + '<span class="msg">' + esc(row.subject) + '</span>' + merge + '</span>'
     + '<span class="author">' + esc(row.authorName) + '</span>'
     + '<span class="date">' + fmtDate(row.authorDate) + '</span>'
+    + ciSlotHtml(row)
     + '</div>';
 }
 
@@ -469,6 +588,7 @@ function render() {
     rowsEl.innerHTML = html.join('');
     rowsEl.style.transform = 'translateY(' + (f * ROW_H) + 'px)';
   }
+  collectCiRequests(f, l);
   spacer.style.height = (total * ROW_H) + 'px';
   emptyEl.style.display = total === 0 ? 'block' : 'none';
   document.getElementById('scope-all').classList.toggle('active', scope === 'all');
@@ -480,6 +600,91 @@ function render() {
 }
 
 function scheduleRender() { requestAnimationFrame(render); }
+
+/** 收集可见行中尚未取数的 hash（O(可见行)，幂等），防抖后批量请求，绝不重复请求已知项。 */
+function collectCiRequests(f, l) {
+  if (!ciMeta.available) return;
+  for (let i = f; i < l; i++) {
+    const h = model.rows[i] && model.rows[i].hash;
+    if (!h || (h in ciByHash) || ciRequested.has(h)) continue;
+    ciRequested.add(h);
+    ciPending.add(h);
+  }
+  if (ciPending.size === 0 || ciReqTimer) return;
+  ciReqTimer = setTimeout(flushCiRequests, 200);
+}
+function flushCiRequests() {
+  ciReqTimer = null;
+  if (ciPending.size === 0) return;
+  const hashes = Array.from(ciPending);
+  ciPending.clear();
+  vscode.postMessage({ type: 'log/requestCi', payload: { hashes: hashes } });
+}
+
+// ── CI Tooltip（自定义浮层：列明细 + 失败原因 + 跳转链接，仿 IDEA / GitHub）──
+function tipGlyph(state) {
+  if (state === 'skipped' || state === 'unknown') {
+    return '<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path d="M4 8h8" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>';
+  }
+  return ciGlyph(state);
+}
+function buildTip(ci) {
+  const headState = ci.state === 'success' ? 'success' : ci.state === 'failure' ? 'failure' : 'pending';
+  const headTxt = ci.state === 'success' ? ('全部 ' + ci.total + ' 项检查通过')
+    : ci.state === 'failure' ? ((ci.total - ci.passed) + ' / ' + ci.total + ' 项检查未通过')
+    : ci.state === 'pending' ? ('检查运行中 ' + ci.passed + ' / ' + ci.total) : 'CI 状态未知';
+  // 失败项前置，悬停即可见未通过原因。
+  const ordered = ci.checks.slice().sort(function (a, b) {
+    return (a.state === 'failure' ? 0 : 1) - (b.state === 'failure' ? 0 : 1);
+  });
+  const parts = ['<div class="tip-h"><span class="g g-', headState, '">', ciGlyph(headState), '</span>', esc(headTxt), '</div><div class="tip-list">'];
+  if (ordered.length === 0) parts.push('<div class="tip-row" style="opacity:.6;cursor:default">暂无检查明细</div>');
+  for (const c of ordered) {
+    const desc = (c.state === 'failure' && c.description) ? '<span class="desc">' + esc(c.description) + '</span>' : '';
+    parts.push('<div class="tip-row" data-url="', esc(c.url || ''), '" role="link" tabindex="0">', tipGlyph(c.state), '<span class="nm">', esc(c.name), desc, '</span></div>');
+  }
+  parts.push('</div>');
+  if (ci.url) parts.push('<div class="tip-foot"><a data-url="', esc(ci.url), '" role="link" tabindex="0">在 GitHub 上查看</a></div>');
+  ciTipEl.innerHTML = parts.join('');
+}
+function positionTip(rect) {
+  ciTipEl.style.display = 'flex';
+  const tw = ciTipEl.offsetWidth, th = ciTipEl.offsetHeight;
+  const vw = window.innerWidth, vh = window.innerHeight, pad = 6;
+  let left = rect.left;
+  if (left + tw > vw - pad) left = vw - pad - tw;
+  if (left < pad) left = pad;
+  let top = rect.bottom + 4;
+  if (top + th > vh - pad) top = rect.top - th - 4;
+  if (top < pad) top = pad;
+  ciTipEl.style.left = left + 'px';
+  ciTipEl.style.top = top + 'px';
+}
+function scheduleShow(hash, iconEl) {
+  clearTimeout(tipHideT);
+  if (tipHash === hash && ciTipEl.classList.contains('show')) return;
+  clearTimeout(tipShowT);
+  tipShowT = setTimeout(function () {
+    const ci = ciByHash[hash];
+    if (!ci || ci.state === 'unknown') return;
+    tipHash = hash;
+    buildTip(ci);
+    positionTip(iconEl.getBoundingClientRect());
+    ciTipEl.classList.add('show');
+  }, 350);
+}
+function scheduleHide() {
+  clearTimeout(tipShowT);
+  clearTimeout(tipHideT);
+  tipHideT = setTimeout(function () { if (!overIcon && !overTip) hideTip(); }, 220);
+}
+function hideTip() {
+  ciTipEl.classList.remove('show');
+  ciTipEl.style.display = 'none';
+  tipHash = null;
+}
+function openCiUrl(url) { if (url) vscode.postMessage({ type: 'log/openExternal', payload: { url: url } }); }
+function renderCiMeta() { ciSignInEl.style.display = ciMeta.needsSignIn ? 'inline-block' : 'none'; }
 
 function selectRow(hash) {
   selectedHash = hash;
@@ -504,9 +709,47 @@ function moveSel(delta) {
 }
 
 rowsEl.addEventListener('click', function (e) {
+  if (e.target.closest('.ci')) return; // 点击 CI 图标不选中提交行
   const r = e.target.closest('.row'); if (!r) return;
   selectRow(r.getAttribute('data-hash'));
 });
+rowsEl.addEventListener('mouseover', function (e) {
+  const icon = e.target.closest && e.target.closest('.ci');
+  if (!icon || icon.classList.contains('ci-empty')) return;
+  overIcon = true;
+  scheduleShow(icon.getAttribute('data-ci'), icon);
+});
+rowsEl.addEventListener('mouseout', function (e) {
+  const icon = e.target.closest && e.target.closest('.ci');
+  if (!icon) return;
+  overIcon = false;
+  scheduleHide();
+});
+rowsEl.addEventListener('keydown', function (e) {
+  const icon = e.target.closest && e.target.closest('.ci');
+  if (!icon || icon.classList.contains('ci-empty')) return;
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault(); e.stopPropagation(); // 阻止冒泡到 viewport 的 Enter→菜单
+    const ci = ciByHash[icon.getAttribute('data-ci')];
+    if (!ci || ci.state === 'unknown') return;
+    tipHash = icon.getAttribute('data-ci');
+    buildTip(ci);
+    positionTip(icon.getBoundingClientRect());
+    ciTipEl.classList.add('show');
+    const first = ciTipEl.querySelector('[data-url]'); if (first) first.focus();
+  }
+});
+ciTipEl.addEventListener('mouseenter', function () { overTip = true; clearTimeout(tipHideT); });
+ciTipEl.addEventListener('mouseleave', function () { overTip = false; scheduleHide(); });
+ciTipEl.addEventListener('click', function (e) {
+  const t = e.target.closest('[data-url]'); if (!t) return;
+  openCiUrl(t.getAttribute('data-url'));
+});
+ciTipEl.addEventListener('keydown', function (e) {
+  if (e.key === 'Escape') { hideTip(); }
+  else if (e.key === 'Enter') { const t = e.target.closest('[data-url]'); if (t) openCiUrl(t.getAttribute('data-url')); }
+});
+ciSignInEl.addEventListener('click', function () { vscode.postMessage({ type: 'log/ciSignIn' }); });
 rowsEl.addEventListener('dblclick', function (e) {
   const r = e.target.closest('.row'); if (!r) return;
   vscode.postMessage({ type: 'log/commitAction', payload: { op: 'menu', hash: r.getAttribute('data-hash') } });
@@ -519,6 +762,7 @@ rowsEl.addEventListener('contextmenu', function (e) {
 document.getElementById('scope-all').addEventListener('click', function () { if (scope !== 'all') { scope = 'all'; vscode.setState({ selectedHash: selectedHash, scope: scope }); vscode.postMessage({ type: 'log/setScope', payload: { scope: 'all' } }); } });
 document.getElementById('scope-current').addEventListener('click', function () { if (scope !== 'current') { scope = 'current'; vscode.setState({ selectedHash: selectedHash, scope: scope }); vscode.postMessage({ type: 'log/setScope', payload: { scope: 'current' } }); } });
 viewport.addEventListener('scroll', scheduleRender, { passive: true });
+viewport.addEventListener('scroll', function () { if (tipHash) hideTip(); }, { passive: true });
 viewport.addEventListener('keydown', function (e) {
   if (e.key === 'ArrowDown') { e.preventDefault(); moveSel(1); }
   else if (e.key === 'ArrowUp') { e.preventDefault(); moveSel(-1); }
@@ -550,6 +794,11 @@ window.addEventListener('message', function (e) {
   if (m.type === 'log/graphData') {
     model = { rows: m.payload.rows, maxLanes: m.payload.maxLanes, hasMore: m.payload.hasMore, repoRoot: m.payload.repoRoot };
     scope = m.payload.scope; repoEl.textContent = m.payload.repoRoot; repoEl.title = m.payload.repoRoot;
+    // 图全量重置 → CI 缓存随之失效（提交集合被替换）。
+    for (const k in ciByHash) delete ciByHash[k];
+    ciRequested.clear(); ciPending.clear();
+    if (ciReqTimer) { clearTimeout(ciReqTimer); ciReqTimer = null; }
+    hideTip();
     renderedFirst = -1; renderedLast = -1; viewport.scrollTop = 0; fetching = false; spinnerEl.style.display = 'none';
     if (!model.rows.some(function (r) { return r.hash === selectedHash; })) selectedHash = null;
     scheduleRender();
@@ -562,6 +811,26 @@ window.addEventListener('message', function (e) {
     renderDetails(m.payload.hash, m.payload.files);
   } else if (m.type === 'log/busy') {
     spinnerEl.style.display = m.payload.busy ? 'block' : 'none';
+  } else if (m.type === 'log/ciMeta') {
+    ciMeta = { available: !!m.payload.available, needsSignIn: !!m.payload.needsSignIn, error: m.payload.error || '' };
+    renderCiMeta();
+    renderedFirst = -1; // 强制重绘可见行（CI 槽位/登录提示出现或消失）
+    scheduleRender();
+  } else if (m.type === 'log/ciData') {
+    const map = m.payload.map;
+    let touched = false;
+    for (const h in map) { ciByHash[h] = map[h]; ciRequested.add(h); touched = true; }
+    if (touched) {
+      renderedFirst = -1; scheduleRender(); // 就地重绘可见行图标
+      // 数据到达后重锚开启中的 Tooltip（图标新增/pending→终态变化）。
+      requestAnimationFrame(function () {
+        if (tipHash && ciTipEl.classList.contains('show')) {
+          const el = rowsEl.querySelector('[data-ci="' + tipHash.replace(/[^a-f0-9]/gi, '') + '"]');
+          if (el) { buildTip(ciByHash[tipHash]); positionTip(el.getBoundingClientRect()); }
+          else hideTip();
+        }
+      });
+    }
   }
 });
 

--- a/src/engine/ci/graphql-query.ts
+++ b/src/engine/ci/graphql-query.ts
@@ -1,0 +1,80 @@
+/**
+ * CI 批量查询的 GraphQL 构造（纯逻辑，零 vscode/网络依赖）。
+ *
+ * 用别名（`c0: object(oid:…)`）在单次请求内拉取**多个**提交的 `statusCheckRollup`，避免
+ * N 个提交 = N 次 REST 往返（Log 一页可达 1000 提交）。`owner/name` 走 `$variables` 不插值
+ * （防注入）；oid 来自信任源（git log）但仍做 `/^[0-9a-f]{7,40}$/i` 防御性校验后再插值别名。
+ */
+
+/** oid 合法形态（git SHA-1：7~40 位十六进制）。非法 oid 直接抛错，杜绝构造畸形查询。 */
+const OID_RE = /^[0-9a-f]{7,40}$/i;
+
+/** 别名前缀（构造端与解析端共用此单一事实源，按序号映射回 oid）。 */
+export const CI_ALIAS_PREFIX = 'c';
+
+/** 每次查询拉取每个 commit 的 context 上限（极少 commit 超 50 项；超出按 total 已知、明细取首 50）。 */
+export const DEFAULT_CONTEXTS_PER_COMMIT = 50;
+
+/** buildCiQuery 入参。 */
+export interface CiQueryInput {
+	readonly owner: string;
+	readonly name: string;
+	/** 已去重、已切片至 ≤ 单次上限的 oid 列表。 */
+	readonly oids: readonly string[];
+	readonly contextsPerCommit?: number;
+}
+
+/** buildCiQuery 产出：查询串 + alias→oid 映射（解析端据序号回填 hash）。 */
+export interface CiQueryOutput {
+	readonly query: string;
+	/** 第 i 个 alias 对应第 i 个 oid（与入参 oids 同序）。 */
+	readonly aliases: readonly string[];
+}
+
+/**
+ * 构造批量 GraphQL 文档。所有 oid 经 {@link OID_RE} 校验（防御性）；owner/name 不插值，
+ * 经 `$variables` 传递。附带 `rateLimit{cost remaining resetAt}` 供 adapter 自适应限流冷却。
+ */
+export function buildCiQuery(input: CiQueryInput): CiQueryOutput {
+	const first = input.contextsPerCommit ?? DEFAULT_CONTEXTS_PER_COMMIT;
+	if (!Number.isInteger(first) || first <= 0) {
+		throw new Error(`contextsPerCommit 非法：${first}`);
+	}
+	const oids = input.oids;
+	if (oids.length === 0) {
+		throw new Error('oids 为空');
+	}
+	const aliases: string[] = [];
+	const fields: string[] = [];
+	for (let i = 0; i < oids.length; i++) {
+		const oid = oids[i];
+		if (typeof oid !== 'string' || !OID_RE.test(oid)) {
+			throw new Error(`非法 oid：${oid}`);
+		}
+		const alias = CI_ALIAS_PREFIX + i;
+		aliases.push(alias);
+		// oid 已校验为十六进制，安全插值。
+		fields.push(`${alias}: object(oid: "${oid}") { ...CiCommitRollup }`);
+	}
+	const query = `query CiBatch($owner: String!, $name: String!) {
+  rateLimit { cost remaining resetAt }
+  repository(owner: $owner, name: $name) {
+${fields.map((f) => '    ' + f).join('\n')}
+  }
+}
+fragment CiCommitRollup on Commit {
+  oid
+  statusCheckRollup {
+    state
+    contexts(first: ${first}) {
+      totalCount
+      nodes {
+        __typename
+        ... on CheckRun { name status conclusion detailsUrl }
+        ... on StatusContext { context state targetUrl description }
+      }
+    }
+  }
+}`;
+	return { query, aliases };
+}

--- a/src/engine/ci/model.ts
+++ b/src/engine/ci/model.ts
@@ -1,0 +1,100 @@
+/**
+ * GraphQL 响应 → {@link CiStatusVM} 解析（纯逻辑，零 vscode/网络依赖）。
+ *
+ * 按构造端约定的别名序号（{@link CI_ALIAS_PREFIX} + i）回填 oid → hash。响应形态宽容：
+ * 别名值为 null（提交未推送到远程，远程无此 object）→ unknown（不渲染图标）；rollup 缺失
+ * （无 CI 配置）→ unknown；缺 `data`/含 `errors` 时整批回退 unknown，不抛错（单次解析不中断）。
+ */
+
+import { CI_ALIAS_PREFIX } from './graphql-query';
+import { aggregateChecks, checkRunState, mapRollupState, statusContextState } from './rollup';
+import type { CiCheckVM, CiStatusVM } from './types';
+
+/** 空响应（无 CI / 未推送 / 解析失败）的统一 VM。 */
+export const UNKNOWN_CI: CiStatusVM = Object.freeze({
+	state: 'unknown',
+	checks: [],
+	passed: 0,
+	total: 0,
+});
+
+/** rateLimit 抽取（供 adapter 自适应限流冷却）。 */
+export interface RateLimitInfo {
+	readonly remaining: number | null;
+	readonly resetAt: string | null;
+}
+
+/** 从响应体抽取 rateLimit（缺失返回 null）。 */
+export function extractRateLimit(json: unknown): RateLimitInfo | null {
+	const rl = (json as { data?: { rateLimit?: { remaining?: unknown; resetAt?: unknown } } })?.data?.rateLimit;
+	if (!rl) {
+		return null;
+	}
+	return {
+		remaining: typeof rl.remaining === 'number' ? rl.remaining : null,
+		resetAt: typeof rl.resetAt === 'string' ? rl.resetAt : null,
+	};
+}
+
+type RawNode = Record<string, unknown> | null | undefined;
+
+/** 单个 context（CheckRun 或 StatusContext）归一为 {@link CiCheckVM}；不可识别返回 null。 */
+function normalizeContext(node: RawNode): CiCheckVM | null {
+	if (!node || typeof node !== 'object') {
+		return null;
+	}
+	const typename = node.__typename;
+	if (typename === 'CheckRun') {
+		const status = (node.status as string | null | undefined) ?? null;
+		const conclusion = (node.conclusion as string | null | undefined) ?? null;
+		return {
+			name: String(node.name ?? 'check'),
+			state: checkRunState(status, conclusion),
+			conclusion: conclusion ?? status ?? undefined,
+			url: (node.detailsUrl as string | undefined) || undefined,
+		};
+	}
+	if (typename === 'StatusContext') {
+		const raw = (node.state as string | null | undefined) ?? null;
+		return {
+			name: String(node.context ?? 'status'),
+			state: statusContextState(raw),
+			conclusion: raw ?? undefined,
+			description: (node.description as string | undefined) || undefined,
+			url: (node.targetUrl as string | undefined) || undefined,
+		};
+	}
+	return null;
+}
+
+/** 单个别名节点 → {@link CiStatusVM}。null/无 rollup/空 contexts 统一回退 {@link UNKNOWN_CI}。 */
+function parseCommitNode(node: RawNode): CiStatusVM {
+	if (!node) {
+		return UNKNOWN_CI;
+	}
+	const rollup = (node as { statusCheckRollup?: RawNode }).statusCheckRollup;
+	if (!rollup) {
+		return UNKNOWN_CI;
+	}
+	const rollupState = mapRollupState((rollup as { state?: unknown }).state as string | undefined);
+	const nodes = (rollup as { contexts?: { nodes?: RawNode[] } }).contexts?.nodes ?? [];
+	const checks = nodes
+		.map((n) => normalizeContext(n))
+		.filter((c): c is CiCheckVM => c !== null);
+	return aggregateChecks(rollupState, checks);
+}
+
+/**
+ * 解析整批响应为 `hash → CiStatusVM`。按别名序号与 `requestedOids` 同序映射；
+ * 缺 `data`/`repository` 时仍为每个 oid 回填 unknown（保序、不抛错）。
+ */
+export function parseCiResponse(json: unknown, requestedOids: readonly string[]): Map<string, CiStatusVM> {
+	const map = new Map<string, CiStatusVM>();
+	const repository = (json as { data?: { repository?: Record<string, RawNode> } })?.data?.repository;
+	for (let i = 0; i < requestedOids.length; i++) {
+		const alias = CI_ALIAS_PREFIX + i;
+		const node = repository ? repository[alias] : undefined;
+		map.set(requestedOids[i], parseCommitNode(node));
+	}
+	return map;
+}

--- a/src/engine/ci/remote-parser.ts
+++ b/src/engine/ci/remote-parser.ts
@@ -1,0 +1,92 @@
+/**
+ * Git 远程 URL → GitHub 坐标解析（纯逻辑，零 vscode/网络依赖）。
+ *
+ * Log 视图的 CI 数据只存在于 GitHub，需先把仓库远程映射为 `{host, owner, repo}` 才能
+ * 调用 GraphQL。本模块只回答「这个 URL 是否长得像 GitHub 坐标」——不硬编码 github.com，
+ * GHE 主机亦接受；「是否真的去访问该主机」是策略，交由 adapter 层（机制/策略分离），
+ * 使 GHE 支持无需改解析器。
+ */
+
+/** 解析出的 GitHub 坐标。 */
+export interface GitHubRemote {
+	/** 主机（小写，github.com 或 GHE 主机，如 ghe.acme.com）。 */
+	readonly host: string;
+	readonly owner: string;
+	/** 仓库名（已去除尾部 `.git`）。 */
+	readonly repo: string;
+	readonly isGitHubDotCom: boolean;
+}
+
+/** scp 式 SSH：`git@github.com:owner/repo`（无 `://` 方案时方按此形态匹配）。 */
+const SCP_RE = /^[^/:]+:([^?#]+)$/;
+
+/** owner / repo 合法字符（GitHub 限制：字母数字 `_` `-` `.`）。 */
+const NAME_RE = /^[\w.-]+$/;
+
+/**
+ * 解析 git 远程 URL 为 GitHub 坐标，非可识别形态返回 null。
+ * 覆盖：https / `git@host:o/r` scp 式 / `ssh://[user@]host[:port]/` / 带/不带 `.git` / GHE 主机。
+ */
+export function parseGitHubRemote(input: string): GitHubRemote | null {
+	const url = input?.trim();
+	if (!url) {
+		return null;
+	}
+	let host = '';
+	let path = '';
+	const hasScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(url);
+	if (hasScheme) {
+		let parsed: URL;
+		try {
+			parsed = new URL(url);
+		} catch {
+			return null;
+		}
+		host = parsed.hostname.toLowerCase();
+		path = parsed.pathname;
+	} else {
+		// scp 形态：`git@host:path` —— hostname 由 URL 不可靠，手动提取首个 `:` 前的部分。
+		const scp = url.match(SCP_RE);
+		if (!scp) {
+			return null;
+		}
+		const colon = url.indexOf(':');
+		const head = url.slice(0, colon);
+		const at = head.lastIndexOf('@');
+		host = (at >= 0 ? head.slice(at + 1) : head).toLowerCase();
+		path = scp[1];
+	}
+
+	let p = decodeURIComponent(path).replace(/^\/+/, '').replace(/\/+$/, '');
+	if (/\.git$/i.test(p)) {
+		p = p.slice(0, -4);
+	}
+	// 去尾部 query/fragment 残片（防御性）。
+	p = p.split(/[?#]/)[0];
+	const seg = p.split('/');
+	if (seg.length < 2) {
+		return null;
+	}
+	const owner = seg[0];
+	const repo = seg[1];
+	if (!owner || !repo || !NAME_RE.test(owner) || !NAME_RE.test(repo)) {
+		return null;
+	}
+	if (!host) {
+		return null;
+	}
+	return { host, owner, repo, isGitHubDotCom: host === 'github.com' };
+}
+
+/**
+ * 推导 GraphQL 端点。github.com → api.github.com；GHE → `<host>/api/graphql`
+ * （**非** `/api/v3/graphql`，后者是 REST 路径——GHE GraphQL 为 `/api/graphql`）。一律 https。
+ */
+export function graphqlEndpoint(remote: GitHubRemote): string {
+	return remote.isGitHubDotCom ? 'https://api.github.com/graphql' : `https://${remote.host}/api/graphql`;
+}
+
+/** 该主机对应的 VS Code 认证 provider id（github.com→`github`，其余→`github-enterprise`）。 */
+export function authProviderId(remote: GitHubRemote): 'github' | 'github-enterprise' {
+	return remote.isGitHubDotCom ? 'github' : 'github-enterprise';
+}

--- a/src/engine/ci/rollup.ts
+++ b/src/engine/ci/rollup.ts
@@ -1,0 +1,100 @@
+/**
+ * CI 状态归一化与聚合（纯逻辑，零 vscode/网络依赖）。
+ *
+ * GitHub 一颗 commit 的 CI 由两类来源混合：**CheckRun**（GitHub Actions 等 Checks API）与
+ * **StatusContext**（旧 Commit Status，外部 CI）。二者字段名不同（conclusion vs state），需归一为
+ * 单一 {@link CiState} 供渲染。rollup 的 `state` 字段是 GitHub 已聚合好的「最终状态」，作为权威
+ * 图标状态优先采用；明细项各自归一用于 Tooltip。
+ */
+
+import type { CiCheckVM, CiState, CiStatusVM } from './types';
+
+/** rollup `state`（StatusState）→ {@link CiState}。EXPECTED 视为 pending（有待报告的检查）。 */
+export function mapRollupState(state: string | null | undefined): CiState {
+	if (!state) {
+		return 'unknown';
+	}
+	switch (state) {
+		case 'SUCCESS':
+			return 'success';
+		case 'FAILURE':
+		case 'ERROR':
+			return 'failure';
+		case 'PENDING':
+		case 'EXPECTED':
+			return 'pending';
+		default:
+			return 'unknown';
+	}
+}
+
+/**
+ * CheckRun → {@link CiState}。未完成一律 pending；非阻塞结论（NEUTRAL/SKIPPED）算通过
+ * （IDEA 语义：跳过的检查不视为失败）。
+ */
+export function checkRunState(status: string | null | undefined, conclusion: string | null | undefined): CiState {
+	// 未完成（QUEUED/IN_PROGRESS/WAITING/PENDING/REQUESTED/null）一律 pending。
+	if (status !== 'COMPLETED') {
+		return 'pending';
+	}
+	switch (conclusion ?? null) {
+		case 'SUCCESS':
+		case 'NEUTRAL':
+		case 'SKIPPED':
+			return 'success';
+		case 'FAILURE':
+		case 'ERROR':
+		case 'CANCELLED':
+		case 'TIMED_OUT':
+		case 'ACTION_REQUIRED':
+		case 'STARTUP_FAILURE':
+		case 'STALE':
+			return 'failure';
+		default:
+			// COMPLETED 但结论缺失/未知：保守视为运行中。
+			return 'pending';
+	}
+}
+
+/** StatusContext → {@link CiState}（复用 rollup 映射）。 */
+export function statusContextState(state: string | null | undefined): CiState {
+	return mapRollupState(state);
+}
+
+/** 选择 Tooltip 的最佳跳转链接：首个失败项 → 否则首个有链接项 → 否则 undefined。 */
+export function pickPrimaryUrl(checks: readonly CiCheckVM[]): string | undefined {
+	const failed = checks.find((c) => c.state === 'failure' && c.url);
+	if (failed?.url) {
+		return failed.url;
+	}
+	return checks.find((c) => c.url)?.url;
+}
+
+/** 权威状态缺失时据已归一明细兜底重算（任一 failure→failure；任一 pending→pending；全通过→success）。 */
+export function recomputeState(checks: readonly CiCheckVM[]): CiState {
+	if (checks.length === 0) {
+		return 'unknown';
+	}
+	if (checks.some((c) => c.state === 'failure')) {
+		return 'failure';
+	}
+	if (checks.some((c) => c.state === 'pending')) {
+		return 'pending';
+	}
+	return 'success';
+}
+
+/**
+ * 汇总已归一明细为 {@link CiStatusVM}。`rollupState` 为权威图标状态；若为 unknown 但存在明细，
+ * 则用 {@link recomputeState} 兜底（防御性，应对个别 rollup 缺失）。
+ */
+export function aggregateChecks(rollupState: CiState, checks: readonly CiCheckVM[]): CiStatusVM {
+	const state = rollupState !== 'unknown' ? rollupState : recomputeState(checks);
+	return {
+		state,
+		checks,
+		passed: checks.filter((c) => c.state === 'success').length,
+		total: checks.length,
+		url: pickPrimaryUrl(checks),
+	};
+}

--- a/src/engine/ci/types.ts
+++ b/src/engine/ci/types.ts
@@ -1,0 +1,42 @@
+/**
+ * CI 状态视图模型（纯逻辑，零 vscode/网络依赖）。
+ *
+ * 汇总 GitHub「Commit Status（旧）+ Check Runs（GitHub Actions）」为单一语义状态，
+ * 供 Log 视图按提交渲染绿勾/红叉/运行中图标与悬停明细。状态语义（{@link CiState}）与展示
+ * 解耦：引擎只产出归一化状态 + 原始 conclusion 文案，渲染器（webview）据 state 决定图标与主题色。
+ */
+
+/**
+ * 提交的 CI 归一化状态：
+ * - `success` 全部检查通过（含 NEUTRAL/SKIPPED 等非阻塞结论）；
+ * - `failure` 至少一项失败（FAILURE/ERROR/TIMED_OUT/CANCELLED/ACTION_REQUIRED…）；
+ * - `pending` 至少一项进行中且无失败（PENDING/EXPECTED/QUEUED/IN_PROGRESS…）；
+ * - `unknown` 无 CI 配置 / 提交未推送到远程 / 非 Commit 对象（不渲染图标）。
+ */
+export type CiState = 'success' | 'failure' | 'pending' | 'unknown';
+
+/** 单条检查项（一个 CheckRun 或一个 StatusContext）的视图模型。 */
+export interface CiCheckVM {
+	/** 检查名（CheckRun.name 或 StatusContext.context）。 */
+	readonly name: string;
+	/** 归一化状态 → 决定 Tooltip 内的图标。 */
+	readonly state: CiState;
+	/** 原始结论/状态文案（如 `TIMED_OUT` / `FAILURE`），供 Tooltip 直显，便于定位「未通过原因」。 */
+	readonly conclusion?: string;
+	/** 描述（StatusContext.description，外部 CI 常在此给出失败摘要）。 */
+	readonly description?: string;
+	/** 该检查的运行详情链接（CheckRun.detailsUrl / StatusContext.targetUrl）。 */
+	readonly url?: string;
+}
+
+/** 单个提交的 CI 汇总。`state` 为权威图标状态（直接取自 GitHub rollup，覆盖全部 context）。 */
+export interface CiStatusVM {
+	readonly state: CiState;
+	readonly checks: readonly CiCheckVM[];
+	/** 已通过检查数（基于已取回的 checks 统计）。 */
+	readonly passed: number;
+	/** 检查总数（基于已取回的 checks 统计）。 */
+	readonly total: number;
+	/** 最佳跳转链接（优先首个失败项，其次首个有链接项）—— Tooltip「在 GitHub 查看」。 */
+	readonly url?: string;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,8 @@ import { registerMergeCommands } from './adapter/webview/merge-editor';
 import { registerMiscCommands } from './adapter/misc-commands';
 import { getGitApi } from './adapter/git-api';
 import { GitRepositoryService } from './adapter/git-repository-service';
+import { GitHubAuth } from './adapter/ci/github-auth';
+import { GitHubCiService } from './adapter/ci/github-ci-service';
 import { createLogger } from './infra/logger';
 
 /**
@@ -63,6 +65,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const service = new GitRepositoryService(api);
 	const registry = new ChangelistRegistry(context.workspaceState, service.repoRoot ?? workspaceRoot);
 	const favorites = new BranchFavorites(context.workspaceState, service.repoRoot ?? workspaceRoot);
+	const githubAuth = new GitHubAuth(context.subscriptions);
+	const ciService = new GitHubCiService(service, githubAuth, logger);
 	const tree = new ChangesTreeProvider(service, registry);
 	// createTreeView（registerTreeDataProvider 的超集）以获取 TreeView 句柄承载 .badge；
 	// 活动栏容器图标的数字角标 = 容器内各视图 badge.value 之和，故此处点亮即映射到 Hyper Git 图标。
@@ -77,7 +81,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		conflict: new NullConflictResolver(),
 	});
 	const commitView = new CommitWebviewProvider(service, registry, commit);
-	const logTree = new LogWebviewProvider(service);
+	const logTree = new LogWebviewProvider(service, ciService);
 	const branchesTree = new BranchesTreeProvider(service, favorites);
 	// Branches 视图启用多选（canSelectMany 仅 createTreeView 支持，registerTreeDataProvider 不支持）；
 	// 多选后批量操作（删除分支/标签、复制引用、收藏）作用于整个选区。
@@ -100,6 +104,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		registry,
 		favorites,
 		commit,
+		ciService,
 		logTree,
 		branchesTree,
 		stashTree,
@@ -127,6 +132,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		...registerWorktreeCommands(service, worktreeTree),
 		vscode.commands.registerCommand('hyperGit.commit', focusCommitView),
 		vscode.commands.registerCommand('hyperGit.commitAndPush', focusCommitView),
+		vscode.commands.registerCommand('hyperGit.ci.signIn', () => ciService.signIn()),
 		vscode.commands.registerCommand('hyperGit.showConsole', () => showGitConsole()),
 		vscode.commands.registerCommand('hyperGit.startRebase', () => RebaseWebview.open(service)),
 		vscode.languages.registerCodeLensProvider({ scheme: 'file' }, inlineLens),

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -6,10 +6,13 @@
  */
 
 import type { ConventionalValidation, ConventionalSeverity } from '../engine/commit/conventional-linter';
+import type { CiCheckVM, CiState, CiStatusVM } from '../engine/ci/types';
 import type { GraphLayoutRow } from '../engine/log/graph-types';
 import type { LogScope } from '../engine/log/log-query';
 
 export type { ConventionalValidation, ConventionalSeverity };
+// CI 状态 VM 从 engine 复用并 re-export（指针非副本，单一事实源）。
+export type { CiCheckVM, CiState, CiStatusVM };
 
 /** Commit 视图中的文件条目（选中态由 webview 端管理，host 不回写以避免覆盖用户操作）。 */
 export interface CommitFileItem {
@@ -110,6 +113,16 @@ export type LogCommitOp =
 	| 'reset'
 	| 'menu';
 
+/** CI 功能元信息（graphData 后即发；登录完成/会话撤销/限流时再发，避免整图重传重置滚动/选中）。 */
+export interface CiMetaVM {
+	/** 远程为 GitHub 且功能启用时为 true；否则整列隐藏、不发起任何请求。 */
+	readonly available: boolean;
+	/** 远程是 GitHub 但尚未授权：webview 显示「登录 GitHub 查看 CI」提示。 */
+	readonly needsSignIn: boolean;
+	/** 软错误（限流/网络）摘要，供 webview 给出一次性提示；为空表示正常。 */
+	readonly error?: string;
+}
+
 /** Host → Webview（Log Graph）。 */
 export type LogHostToWebviewMessage =
 	| { readonly type: 'log/graphData'; readonly payload: LogGraphState }
@@ -118,7 +131,9 @@ export type LogHostToWebviewMessage =
 		readonly payload: { readonly rows: readonly GraphRowVM[]; readonly maxLanes: number; readonly hasMore: boolean };
 	}
 	| { readonly type: 'log/commitFiles'; readonly payload: { readonly hash: string; readonly files: readonly LogCommitFileItem[] } }
-	| { readonly type: 'log/busy'; readonly payload: { readonly busy: boolean } };
+	| { readonly type: 'log/busy'; readonly payload: { readonly busy: boolean } }
+	| { readonly type: 'log/ciMeta'; readonly payload: CiMetaVM }
+	| { readonly type: 'log/ciData'; readonly payload: { readonly map: Readonly<Record<string, CiStatusVM>> } };
 
 /** Webview → Host（Log Graph）。 */
 export type LogWebviewToHostMessage =
@@ -127,4 +142,7 @@ export type LogWebviewToHostMessage =
 	| { readonly type: 'log/selectCommit'; readonly payload: { readonly hash: string } }
 	| { readonly type: 'log/commitAction'; readonly payload: { readonly op: LogCommitOp; readonly hash: string } }
 	| { readonly type: 'log/setScope'; readonly payload: { readonly scope: LogScope } }
-	| { readonly type: 'log/openFile'; readonly payload: { readonly hash: string; readonly path: string; readonly hasParent: boolean } };
+	| { readonly type: 'log/openFile'; readonly payload: { readonly hash: string; readonly path: string; readonly hasParent: boolean } }
+	| { readonly type: 'log/requestCi'; readonly payload: { readonly hashes: readonly string[] } }
+	| { readonly type: 'log/ciSignIn' }
+	| { readonly type: 'log/openExternal'; readonly payload: { readonly url: string } };

--- a/tests/unit/ci-graphql-query.test.ts
+++ b/tests/unit/ci-graphql-query.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { buildCiQuery, CI_ALIAS_PREFIX, DEFAULT_CONTEXTS_PER_COMMIT } from '../../src/engine/ci/graphql-query';
+
+const OIDS = ['a1b2c3d4e5f6', '0123456789abcdef0123456789abcdef01234567', 'fedcba9876543210'];
+
+describe('buildCiQuery', () => {
+	it('生成与 oid 等量的别名（c0..cN）', () => {
+		const { aliases } = buildCiQuery({ owner: 'o', name: 'r', oids: OIDS });
+		expect(aliases).toEqual(['c0', 'c1', 'c2']);
+		expect(aliases[0]).toBe(CI_ALIAS_PREFIX + 0);
+	});
+
+	it('owner/name 走 $variables，不插值进文档', () => {
+		const { query } = buildCiQuery({ owner: 'Own/er', name: 'r/evil', oids: OIDS });
+		expect(query).toContain('$owner');
+		expect(query).toContain('$name');
+		// 危险字符不应出现在文档里（防注入）。
+		expect(query).not.toContain('Own/er');
+		expect(query).not.toContain('r/evil');
+	});
+
+	it('oid 经校验后插值别名', () => {
+		const { query } = buildCiQuery({ owner: 'o', name: 'r', oids: ['abcdef0', '1234567'] });
+		expect(query).toContain('c0: object(oid: "abcdef0")');
+		expect(query).toContain('c1: object(oid: "1234567")');
+	});
+
+	it('复用 fragment（statusCheckRollup + 两种 inline fragment）', () => {
+		const { query } = buildCiQuery({ owner: 'o', name: 'r', oids: ['abcdef0'] });
+		expect(query).toContain('fragment CiCommitRollup on Commit');
+		expect(query).toContain('statusCheckRollup');
+		expect(query).toContain('... on CheckRun');
+		expect(query).toContain('... on StatusContext');
+		expect(query).toContain('rateLimit { cost remaining resetAt }');
+	});
+
+	it('默认 contexts(first) 取 DEFAULT_CONTEXTS_PER_COMMIT', () => {
+		const { query } = buildCiQuery({ owner: 'o', name: 'r', oids: ['abcdef0'] });
+		expect(query).toContain(`contexts(first: ${DEFAULT_CONTEXTS_PER_COMMIT})`);
+	});
+
+	it('非法 oid 抛错（防构造畸形查询）', () => {
+		expect(() => buildCiQuery({ owner: 'o', name: 'r', oids: ['ZZZZZZ'] })).toThrow();
+		expect(() => buildCiQuery({ owner: 'o', name: 'r', oids: ['"; DROP--'] })).toThrow();
+	});
+
+	it('空 oids 抛错', () => {
+		expect(() => buildCiQuery({ owner: 'o', name: 'r', oids: [] })).toThrow();
+	});
+
+	it('非法 contextsPerCommit 抛错', () => {
+		expect(() => buildCiQuery({ owner: 'o', name: 'r', oids: ['abcdef0'], contextsPerCommit: 0 })).toThrow();
+		expect(() => buildCiQuery({ owner: 'o', name: 'r', oids: ['abcdef0'], contextsPerCommit: -5 })).toThrow();
+	});
+});

--- a/tests/unit/ci-model.test.ts
+++ b/tests/unit/ci-model.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { extractRateLimit, parseCiResponse, UNKNOWN_CI } from '../../src/engine/ci/model';
+
+const repo = (entries: Record<string, unknown>): unknown => ({ data: { repository: entries } });
+const oid = (i: number): string => i.toString(16).padStart(40, '0');
+
+describe('parseCiResponse', () => {
+	it('别名值为 null（未推送本地提交）→ unknown', () => {
+		const map = parseCiResponse(repo({ c0: null }), [oid(0)]);
+		expect(map.get(oid(0))).toEqual(UNKNOWN_CI);
+		expect(map.get(oid(0))?.state).toBe('unknown');
+	});
+
+	it('rollup 缺失（无 CI 配置）→ unknown', () => {
+		const map = parseCiResponse(repo({ c0: { statusCheckRollup: null } }), [oid(0)]);
+		expect(map.get(oid(0))?.state).toBe('unknown');
+	});
+
+	it('rollup.state 权威映射（SUCCESS）', () => {
+		const json = repo({
+			c0: { statusCheckRollup: { state: 'SUCCESS', contexts: { totalCount: 1, nodes: [
+				{ __typename: 'CheckRun', name: 'CI', status: 'COMPLETED', conclusion: 'SUCCESS', detailsUrl: 'https://github.com/o/r/runs/1' },
+			] } } },
+		});
+		const map = parseCiResponse(json, [oid(0)]);
+		const vm = map.get(oid(0))!;
+		expect(vm.state).toBe('success');
+		expect(vm.passed).toBe(1);
+		expect(vm.total).toBe(1);
+		expect(vm.url).toBe('https://github.com/o/r/runs/1');
+	});
+
+	it('混合 CheckRun + StatusContext，rollup=FAILURE → failure，失败项 url 优先', () => {
+		const json = repo({
+			c0: { statusCheckRollup: { state: 'FAILURE', contexts: { totalCount: 3, nodes: [
+				{ __typename: 'CheckRun', name: 'Build', status: 'COMPLETED', conclusion: 'SUCCESS', detailsUrl: 'https://github.com/o/r/runs/2' },
+				{ __typename: 'CheckRun', name: 'Test', status: 'COMPLETED', conclusion: 'FAILURE', detailsUrl: 'https://github.com/o/r/runs/3' },
+				{ __typename: 'StatusContext', context: 'external-ci', state: 'SUCCESS', targetUrl: 'https://ci.example.com/1', description: 'ok' },
+			] } } },
+		});
+		const map = parseCiResponse(json, [oid(0)]);
+		const vm = map.get(oid(0))!;
+		expect(vm.state).toBe('failure');
+		expect(vm.total).toBe(3);
+		expect(vm.checks).toHaveLength(3);
+		// 首个失败项（Test）的 url 优先。
+		expect(vm.url).toBe('https://github.com/o/r/runs/3');
+		// StatusContext 归一与 description 透传。
+		const ext = vm.checks.find((c) => c.name === 'external-ci')!;
+		expect(ext.state).toBe('success');
+		expect(ext.description).toBe('ok');
+	});
+
+	it('rollup=FAILURE 但无任何 context 节点 → 仍 failure（rollup 权威），checks 空', () => {
+		const json = repo({ c0: { statusCheckRollup: { state: 'FAILURE', contexts: { totalCount: 0, nodes: [] } } } });
+		const map = parseCiResponse(json, [oid(0)]);
+		const vm = map.get(oid(0))!;
+		expect(vm.state).toBe('failure');
+		expect(vm.checks).toHaveLength(0);
+		expect(vm.total).toBe(0);
+	});
+
+	it('按别名序号映射多个 oid', () => {
+		const json = repo({
+			c0: { statusCheckRollup: { state: 'SUCCESS', contexts: { totalCount: 0, nodes: [] } } },
+			c1: null,
+			c2: { statusCheckRollup: { state: 'PENDING', contexts: { totalCount: 1, nodes: [
+				{ __typename: 'CheckRun', name: 'X', status: 'IN_PROGRESS', conclusion: null },
+			] } } },
+		});
+		const map = parseCiResponse(json, [oid(0), oid(1), oid(2)]);
+		expect(map.get(oid(0))?.state).toBe('success');
+		expect(map.get(oid(1))?.state).toBe('unknown');
+		expect(map.get(oid(2))?.state).toBe('pending');
+	});
+
+	it('缺 data/repository → 整批回退 unknown（不抛错）', () => {
+		const map = parseCiResponse({ errors: [{ message: 'boom' }] }, [oid(0), oid(1)]);
+		expect(map.get(oid(0))?.state).toBe('unknown');
+		expect(map.get(oid(1))?.state).toBe('unknown');
+	});
+
+	it('不可识别的 __typename 节点被过滤', () => {
+		const json = repo({
+			c0: { statusCheckRollup: { state: 'SUCCESS', contexts: { totalCount: 2, nodes: [
+				{ __typename: 'CheckRun', name: 'A', status: 'COMPLETED', conclusion: 'SUCCESS' },
+				{ __typename: 'SomethingElse', name: 'B' },
+			] } } },
+		});
+		const vm = parseCiResponse(json, [oid(0)]).get(oid(0))!;
+		expect(vm.checks).toHaveLength(1);
+		expect(vm.checks[0].name).toBe('A');
+	});
+});
+
+describe('extractRateLimit', () => {
+	it('抽取 remaining / resetAt', () => {
+		const rl = extractRateLimit({ data: { rateLimit: { cost: 1, remaining: 42, resetAt: '2026-01-01T00:00:00Z' } } });
+		expect(rl?.remaining).toBe(42);
+		expect(rl?.resetAt).toBe('2026-01-01T00:00:00Z');
+	});
+	it('缺失返回 null', () => {
+		expect(extractRateLimit({ data: {} })).toBeNull();
+		expect(extractRateLimit({})).toBeNull();
+	});
+});

--- a/tests/unit/ci-remote-parser.test.ts
+++ b/tests/unit/ci-remote-parser.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { authProviderId, graphqlEndpoint, parseGitHubRemote } from '../../src/engine/ci/remote-parser';
+
+describe('parseGitHubRemote — 合法形态', () => {
+	it('https（带 .git）', () => {
+		expect(parseGitHubRemote('https://github.com/owner/repo.git')).toEqual({
+			host: 'github.com',
+			owner: 'owner',
+			repo: 'repo',
+			isGitHubDotCom: true,
+		});
+	});
+	it('https（不带 .git）', () => {
+		const r = parseGitHubRemote('https://github.com/ThreeFish-AI/hyper-git');
+		expect(r).toMatchObject({ owner: 'ThreeFish-AI', repo: 'hyper-git', isGitHubDotCom: true });
+	});
+	it('https 带用户名', () => {
+		expect(parseGitHubRemote('https://user@github.com/o/r.git')).toMatchObject({ owner: 'o', repo: 'r' });
+	});
+	it('scp 式 ssh（git@host:o/r）', () => {
+		expect(parseGitHubRemote('git@github.com:owner/repo.git')).toMatchObject({ host: 'github.com', owner: 'owner', repo: 'repo' });
+	});
+	it('ssh:// 带端口', () => {
+		expect(parseGitHubRemote('ssh://git@github.com:22/o/r.git')).toMatchObject({ host: 'github.com', owner: 'o', repo: 'r' });
+	});
+	it('ssh:// 不带端口', () => {
+		expect(parseGitHubRemote('ssh://git@github.com/o/r')).toMatchObject({ owner: 'o', repo: 'r' });
+	});
+	it('GitHub Enterprise 主机', () => {
+		const r = parseGitHubRemote('https://ghe.acme.com/team/proj.git');
+		expect(r).toMatchObject({ host: 'ghe.acme.com', owner: 'team', repo: 'proj', isGitHubDotCom: false });
+	});
+	it('GHE scp 形态', () => {
+		expect(parseGitHubRemote('git@ghe.acme.com:team/proj.git')).toMatchObject({ host: 'ghe.acme.com', owner: 'team', repo: 'proj' });
+	});
+	it('大小写主机归一', () => {
+		expect(parseGitHubRemote('https://GitHub.Com/O/R.git')?.host).toBe('github.com');
+	});
+});
+
+describe('parseGitHubRemote — 非法形态返回 null', () => {
+	it('空串', () => {
+		expect(parseGitHubRemote('')).toBeNull();
+	});
+	it('只有 owner 无 repo', () => {
+		expect(parseGitHubRemote('https://github.com/owner')).toBeNull();
+	});
+	it('多段 path（wiki 等非仓库路径）', () => {
+		expect(parseGitHubRemote('https://github.com/o/r/wiki')).toMatchObject({ owner: 'o', repo: 'r' });
+	});
+	it('乱码（非 URL）', () => {
+		expect(parseGitHubRemote('not a url at all')).toBeNull();
+	});
+	it('非 GitHub 风格（纯文件路径）', () => {
+		expect(parseGitHubRemote('/usr/local/bin')).toBeNull();
+	});
+});
+
+describe('graphqlEndpoint', () => {
+	it('github.com → api.github.com/graphql', () => {
+		const r = parseGitHubRemote('https://github.com/o/r.git')!;
+		expect(graphqlEndpoint(r)).toBe('https://api.github.com/graphql');
+	});
+	it('GHE → <host>/api/graphql（非 /api/v3/graphql）', () => {
+		const r = parseGitHubRemote('https://ghe.acme.com/o/r.git')!;
+		expect(graphqlEndpoint(r)).toBe('https://ghe.acme.com/api/graphql');
+	});
+});
+
+describe('authProviderId', () => {
+	it('github.com → github', () => {
+		expect(authProviderId(parseGitHubRemote('https://github.com/o/r.git')!)).toBe('github');
+	});
+	it('GHE → github-enterprise', () => {
+		expect(authProviderId(parseGitHubRemote('https://ghe.acme.com/o/r.git')!)).toBe('github-enterprise');
+	});
+});

--- a/tests/unit/ci-rollup.test.ts
+++ b/tests/unit/ci-rollup.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import {
+	aggregateChecks,
+	checkRunState,
+	mapRollupState,
+	pickPrimaryUrl,
+	recomputeState,
+	statusContextState,
+} from '../../src/engine/ci/rollup';
+import type { CiCheckVM } from '../../src/engine/ci/types';
+
+describe('mapRollupState（rollup StatusState → CiState）', () => {
+	it('SUCCESS → success', () => {
+		expect(mapRollupState('SUCCESS')).toBe('success');
+	});
+	it('FAILURE/ERROR → failure', () => {
+		expect(mapRollupState('FAILURE')).toBe('failure');
+		expect(mapRollupState('ERROR')).toBe('failure');
+	});
+	it('PENDING/EXPECTED → pending', () => {
+		expect(mapRollupState('PENDING')).toBe('pending');
+		expect(mapRollupState('EXPECTED')).toBe('pending');
+	});
+	it('空/未知 → unknown', () => {
+		expect(mapRollupState(null)).toBe('unknown');
+		expect(mapRollupState(undefined)).toBe('unknown');
+		expect(mapRollupState('')).toBe('unknown');
+	});
+});
+
+describe('checkRunState（CheckRun status+conclusion → CiState）', () => {
+	it('未完成一律 pending', () => {
+		expect(checkRunState('IN_PROGRESS', null)).toBe('pending');
+		expect(checkRunState('QUEUED', null)).toBe('pending');
+		expect(checkRunState('WAITING', null)).toBe('pending');
+	});
+	it('COMPLETED + SUCCESS → success', () => {
+		expect(checkRunState('COMPLETED', 'SUCCESS')).toBe('success');
+	});
+	it('COMPLETED + 非阻塞结论 → success', () => {
+		expect(checkRunState('COMPLETED', 'NEUTRAL')).toBe('success');
+		expect(checkRunState('COMPLETED', 'SKIPPED')).toBe('success');
+	});
+	it('COMPLETED + 失败结论 → failure', () => {
+		for (const c of ['FAILURE', 'ERROR', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE']) {
+			expect(checkRunState('COMPLETED', c)).toBe('failure');
+		}
+	});
+	it('COMPLETED + 未知结论 → pending（保守）', () => {
+		expect(checkRunState('COMPLETED', null)).toBe('pending');
+	});
+});
+
+describe('statusContextState（复用 rollup 映射）', () => {
+	it('与 mapRollupState 一致', () => {
+		expect(statusContextState('SUCCESS')).toBe('success');
+		expect(statusContextState('FAILURE')).toBe('failure');
+		expect(statusContextState('PENDING')).toBe('pending');
+	});
+});
+
+describe('pickPrimaryUrl', () => {
+	const ck = (over: Partial<CiCheckVM>): CiCheckVM => ({ name: 'n', state: 'success', ...over });
+	it('优先首个失败项的 url', () => {
+		const checks = [ck({ state: 'success', url: 'a' }), ck({ state: 'failure', url: 'b' }), ck({ state: 'failure', url: 'c' })];
+		expect(pickPrimaryUrl(checks)).toBe('b');
+	});
+	it('无失败项时取首个有 url 项', () => {
+		const checks = [ck({ url: 'a' }), ck({ url: 'b' })];
+		expect(pickPrimaryUrl(checks)).toBe('a');
+	});
+	it('全无 url → undefined', () => {
+		expect(pickPrimaryUrl([ck({})])).toBeUndefined();
+	});
+});
+
+describe('recomputeState / aggregateChecks', () => {
+	const ck = (state: CiCheckVM['state']): CiCheckVM => ({ name: 'n', state });
+	it('recompute：任一 failure→failure；否则任一 pending→pending；否则 success；空→unknown', () => {
+		expect(recomputeState([ck('success'), ck('failure')])).toBe('failure');
+		expect(recomputeState([ck('success'), ck('pending')])).toBe('pending');
+		expect(recomputeState([ck('success'), ck('success')])).toBe('success');
+		expect(recomputeState([])).toBe('unknown');
+	});
+	it('aggregate：rollupState 权威优先', () => {
+		const vm = aggregateChecks('failure', [ck('success'), ck('success')]);
+		expect(vm.state).toBe('failure');
+		expect(vm.passed).toBe(2);
+		expect(vm.total).toBe(2);
+	});
+	it('aggregate：rollupState=unknown 时据 checks 兜底重算', () => {
+		const vm = aggregateChecks('unknown', [ck('success'), ck('pending')]);
+		expect(vm.state).toBe('pending');
+	});
+	it('aggregate：空 checks → unknown', () => {
+		expect(aggregateChecks('unknown', []).state).toBe('unknown');
+	});
+});


### PR DESCRIPTION
## 背景

需求：在 Log 视图（IDEA 风格提交图）每条提交记录上显示其 **CI 最终状态** —— 绿勾=通过、红叉=未通过；鼠标悬停图标以 Tooltip 展示「未通过原因 + 各项 Actions/检查（含运行链接）」，效果对标 IntelliJ IDEA / GitHub 提交列表。

现状：Log 视图纯由本地 `git log` 驱动，此前**完全没有 GitHub/CI 集成**。CI（GitHub Actions + Commit Status）数据只存在于 GitHub，需经其 API 拉取。

## 设计要点

- **认证**：复用 VS Code 内置 GitHub 登录（`repo` 范围，支持私有+公开仓库），凭证不经过 chat/日志；**静默复用已有会话，绝不自动弹窗**，仅用户点击「登录 GitHub」按钮时才触发原生授权。
- **平台**：GitHub.com + GitHub Enterprise，按 `origin` 远程主机自动判定。
- **懒加载**：仅取可见行（约 50 行/次），终态整会话缓存、pending 30s TTL；GraphQL 批量 ≤100 oid/次、并发上限 2、限流冷却。1000 提交永不触发 1000 次请求，从根本上规避限流。
- **图标位置**：提交行最右侧（日期之后）；`.narrow` 窄屏隐藏 author/date 时 CI 图标例外保留可见。
- **Tooltip**：自定义 HTML 浮层（置于 `#rows` 之外，虚拟滚动重写不销毁），列出各项 check + 失败原因 + 运行链接，悬停意图（show 350ms / hide 220ms）+ 键盘可达 + 滚动/重绘重锚。
- **安全**：`openExternal` 校验 `https` 且主机属 GitHub（反 SSRF，detailsUrl 属观察内容不盲信）。
- **零新增运行时依赖**：使用 Node 全局 `fetch`，不引入 octokit。

## 架构（分层）

| 层 | 文件 | 职责 |
|---|---|---|
| Engine（纯逻辑，Vitest 可测） | `src/engine/ci/{types,remote-parser,graphql-query,rollup,model}.ts` | 远程解析、查询构造、状态归一化、响应解析 |
| Adapter（唯一触碰 vscode/网络） | `src/adapter/ci/{github-auth,github-ci-service}.ts` | 认证、缓存、批量、限流、openExternal |
| 协议 | `src/shared/protocol.ts` | `log/requestCi`、`log/ciData`、`log/ciMeta`、`log/openExternal`、`log/ciSignIn` |
| 渲染 | `src/adapter/webview/log-webview.ts` | host 接线 + webview 图标/Tooltip/懒加载 |
| 配置/命令 | `package.json` | `hyperGit.log.ci.{enabled,remote,provider}`、`hyperGit.ci.signIn` |

## 验证

- `pnpm run check-types` + `pnpm run lint` + `pnpm run compile`（esbuild）通过。
- `pnpm run test:unit` 全绿（271 项，含新增 **53 项** CI 单测：`ci-remote-parser`/`ci-graphql-query`/`ci-rollup`/`ci-model`）。
- 边界：未推送/无 CI → 无图标；非 GitHub 远程 → 功能隐藏；断网/限流 → 不崩溃、建图正常；GHE 自动判定。
- 文档：新增 [docs/features/log-ci-status.md](docs/features/log-ci-status.md)，并同步知识索引。

## 待人工验证（Extension Development Host）

OAuth/SSO 认证遵循协议由用户在 VS Code 原生 UI 完成，Agent 不代登录/不绕过。请在 F5 启动的 EH 中打开 GitHub 仓库复测：登录提示 → 授权 → 图标渐次出现 → 悬停红叉见明细与链接 → 点击打开 run。

🤖 Generated with [Claude Code](https://claude.com/claude-code)