### PR TITLE
fix(Log): CI Tooltip 各检查项状态图标按通过/失败/运行中上色

### DIFF
--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -459,7 +459,7 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #ci-tip .g-success { color: var(--vscode-testing-iconPassed, #3fb950); }
 #ci-tip .g-failure { color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground, #f85149)); }
 #ci-tip .g-pending { color: var(--vscode-testing-iconQueued, var(--vscode-editorWarning-foreground, #d29922)); }
-#ci-tip .g-skipped { color: var(--vscode-descriptionForeground, #8b949e); }
+#ci-tip .g-skipped, #ci-tip .g-unknown { color: var(--vscode-descriptionForeground, #8b949e); }
 </style>
 </head>
 <body>
@@ -628,10 +628,11 @@ function flushCiRequests() {
 
 // ── CI Tooltip（自定义浮层：列明细 + 失败原因 + 跳转链接，仿 IDEA / GitHub）──
 function tipGlyph(state) {
-  if (state === 'skipped' || state === 'unknown') {
-    return '<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path d="M4 8h8" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>';
-  }
-  return ciGlyph(state);
+  const svg = (state === 'unknown' || state === 'skipped')
+    ? '<svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true"><path d="M4 8h8" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>'
+    : ciGlyph(state);
+  // 必须包裹 .g-{state} 才能上色（绿=通过/红=失败/黄=运行中/灰=未知），否则继承前景色呈单色。
+  return '<span class="g g-' + state + '">' + svg + '</span>';
 }
 function buildTip(ci) {
   const headState = ci.state === 'success' ? 'success' : ci.state === 'failure' ? 'failure' : 'pending';


### PR DESCRIPTION
## 背景

PR #37 合入后，Log 视图 CI 状态 Tooltip 内**每项检查的状态图标呈单色**（灰色），无法区分通过/失败/运行中——如下图：失败的 Quality Gate 与通过的 Test Coverage / SonarQube 图标颜色一致，仅头部汇总图标有红色。

## 根因

`tipGlyph()` 返回的是裸 `<svg>`，缺少 `.g-{state}` 上色包裹。CSS 颜色规则（`#ci-tip .g-success/.g-failure/.g-pending`）作用于该包裹类，因此只有头部（包了 `<span class="g g-failure">`）上色，各检查行图标继承前景色呈灰色单色。

## 修复

`tipGlyph()` 统一包裹 `<span class="g g-{state}">`，每项检查图标按状态上色，与头部及 Log 主行图标语义一致：

| 状态 | 图标 | 颜色 |
|---|---|---|
| 通过 | ✓ | 绿（`testing.iconPassed`） |
| 未通过 | ✗ | 红（`testing.iconFailed`） |
| 运行中 | 旋转圆环 | 黄（`testing.iconQueued`） |
| 未知/跳过 | 短横 | 灰（`descriptionForeground`） |

并补充缺失的 `.g-unknown` CSS 类。运行中（pending）状态现在在 Tooltip 每行也以黄色旋转图标呈现，与 Log 主行一致。

## 变更

- 单文件 `src/adapter/webview/log-webview.ts`（+6 / −5），cherry-pick 自工作分支修复 commit，干净叠加于 base（含 #38 Checkpointer），无冲突。

## 验证

- `pnpm run check-types` + `pnpm run lint` + `pnpm run test:unit`（280 项）全绿。
- 基线为 `origin/feature/1.x.x` 最新（已含 PR #37 feat、PR #38 Checkpointer）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)