### PR TITLE
chore(Release): 发布 v0.0.10-rc.1 — 打通 VS Code Marketplace 发布链路并走通完整 release 流程

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 > 面向用户的发布说明（含完整特性叙述与安装指引）见 [`docs/releases/`](./docs/releases/README.md)。
 
+## [0.0.10-rc.1] - 2026-07-04 — Graph 视图对齐官方 · 浮层与角标修复 · 发布链路验证
+
+面向 0.0.10 的首个预发布（RC）。在 v0.0.9 基础上将提交图视图更名为 **Graph** 并视觉对齐 VS Code 官方 Source Control GRAPH 视图，修复提交/CI 悬浮浮层被侧边栏 iframe 裁剪失效、活动栏未提交数角标更新不及时两处缺陷，并完成 README 真实性校准与中英双语重构。本版亦作为 **VS Code Marketplace 发布链路打通**的验证版（首次以官方预发布模型 `--pre-release` 发布 `0.0.10`）。完整用户视角叙述见 [Release Note v0.0.10-rc.1](./docs/releases/v0.0.10-rc.1.md)。
+
+### Changed
+- **Log 视图更名为 Graph 并对齐官方 Source Control GRAPH**：泳道连线由直线改三次贝塞尔平滑曲线（同列自动退化直线）；当前 HEAD 行渲染为空心环 + 内点（双环高亮）；引用胶囊移至 message 右侧后缀、底色跟随本行泳道色、改全圆角实心 pill + 分支/云/tag 内联 SVG 图标前缀；工具栏 seg 按钮间距 / 圆角 / hover 态贴近官方。视图名与 Refresh / Filter / Clear Graph Filter 命令标题、CI 配置描述、aria-label 统一为 Graph（`viewType hyperGit.log`、`log/*` 消息前缀等内部标识符不动，不改底层数据 / 协议 / 布局算法 / CI 逻辑）。(#53)
+
+### Fixed
+- **提交 / CI 悬浮浮层被侧边栏 iframe 裁剪失效**：#48 的浮层定位将横向定位改为 `left = window.innerWidth + 8`，误以为 webview `position:fixed` 可越界渲染到编辑器；实则侧边栏 WebviewView 是沙箱 iframe，坐标系为自身视口，该值落到右边界外被裁剪不可见。抽出共用 `positionFloat`（锚触发元素右侧 → 越界翻左 → 再越界收进视口），彻底修复 CI 与提交两处浮层。(#53)
+- **活动栏未提交变更数角标更新不及时**：角标原挂 Commit `WebviewView`，VS Code 在 `resolveWebviewView`（用户打开过面板）前无法显示 webview 角标（vscode#164974 / #146330），致面板未打开时新变更不点亮、提交 / 撤销后不清除。改由隐藏 TreeView（`hyperGit.changesBadge`，`when:false`）承载，`activate` 即实例化、无论面板是否打开都可靠聚合到容器图标；新增 engine 纯函数 [`change-count`](./src/engine/scm-mapping/change-count.ts)（`toRelKey` / `countUniqueChanges`）与 `GitRepositoryService.getChangeCount()` 作单一事实源（`getChanges` 复用同一去重逻辑），角标走独立 40ms 微防抖快路径、与 150ms 重刷新解耦；移除 Commit webview 死代码（`updateBadge` / `pendingBadge`）杜绝容器 2× 计数，并补 change-count 单元测试锁定计数不变式。(#52)
+
+### Docs
+- **README 真实性校准 + 中英双语重构**：经 3 路只读核验 + 单测实跑取证修正——移除不存在的 `ui/` 层（改述 `engine/` → `adapter/`）、单元测试计数 280 → **324**、行级提交 CodeLens 标签校准为 "Commit this Hunk"、publisher 占位符落实为真实 `ThreeFish-AI`；根 `README.md` 改写为地道英文版，中文版迁入 [`docs/i18n/zh-CN/README.md`](./docs/i18n/zh-CN/README.md) 并互加语言切换、补入 CHANGELOG 链接。同步校正文档中心「最新」发布指针与知识索引 agent 接缝清单。(#51)
+- 补充 `vsce` 发布用法说明并重构 README 底部 footer，修复链接渲染与协议措辞。
+
+> 规模实证（README 校准后）：**6 视图 / 97 命令 / 6 配置项 / 324 单元测试**（32 文件全绿）+ 集成测试，CI 三平台（Ubuntu / macOS / Windows）矩阵全程 GREEN。
+
 ## [0.0.9] - 2026-07-04 — 视图整合 · UI 系统化 · 分支与 CI 增强
 
 自上一个正式版 0.0.6 以来的首个公开版本，聚合 0.0.7 / 0.0.8 / 0.0.9 三轮迭代：提交/日志视图内聚重构、UI/UX 全局系统化、分支与 CI 能力增强，以及一批工程修复。完整用户视角叙述见 [Release Note v0.0.9](./docs/releases/v0.0.9.md)。

--- a/docs/releases/v0.0.10-rc.1.md
+++ b/docs/releases/v0.0.10-rc.1.md
@@ -1,0 +1,71 @@
+# Hyper Git - Agentic Git v0.0.10-rc.1 — Graph 视图对齐官方 · 浮层与角标修复
+
+> **预发布（Release Candidate）**，面向下一正式版 `0.0.10`。本版在 [v0.0.9](./v0.0.9.md) 基础上把提交图视图更名为 **Graph** 并逐像素对齐 VS Code 官方 Source Control GRAPH 视图，修复两处交互缺陷（悬浮浮层被侧边栏 iframe 裁剪、活动栏未提交数角标更新不及时），并完成 README 真实性校准与中英双语重构。
+
+> 本版同时是 **VS Code Marketplace 发布链路打通**的验证版：首次以官方预发布模型（`vsce publish --pre-release`）将扩展推送至 Marketplace 预发布通道，与 OpenVSX、GitHub Release 三渠道并发发布。
+
+---
+
+## ✨ 亮点速览
+
+- **提交图更名 Graph 并对齐官方**：视图更名为「Graph」，泳道连线改三次贝塞尔平滑曲线、HEAD 空心双环高亮、引用胶囊改全圆角实心 pill 并跟随泳道色，整体贴近 VS Code 官方 Source Control GRAPH 视图。
+- **修复悬浮浮层失效**：提交详情 / CI 状态浮层此前被侧边栏 iframe 裁剪到视口外而不可见，现抽出统一的 `positionFloat` 定位彻底修复。
+- **修复活动栏角标不及时**：未提交变更数角标改由隐藏 TreeView 承载，无论 Commit 面板是否打开都能可靠、及时地点亮与清除。
+- **README 真实性校准 + 中英双语**：以实跑取证修正过时陈述，根英文、中文迁入 i18n，双向语言切换。
+
+---
+
+## 🧩 完整能力
+
+### Graph 视图更名与官方对齐（原 Log 视图）
+面向用户的「Log」视图更名为 **「Graph」**，并在渲染层视觉对齐 VS Code 官方 Source Control GRAPH 视图，**不改动底层数据 / 消息协议 / 布局算法 / CI 逻辑**：
+
+- **泳道连线**：由直线 `<line>` 改为三次贝塞尔 `<path>` 平滑曲线（同列 `fromCol === toCol` 时自动退化为直线）。
+- **HEAD 高亮**：当前 HEAD 行节点渲染为空心环 + 内点（双环高亮），普通行保持实心点。
+- **引用胶囊**：从 message 左侧前缀移至右侧后缀（列序 泳道图 → message → chips → author → date → CI）；底色跟随本行泳道色（类型靠图标区分而非颜色，同名 origin 远程分支随所在行泳道呈多色），按底色亮度自适应深 / 白字保可读；由半透明小圆角矩形改为实心全圆角 pill，保留分支 / 云 / tag 内联 SVG 图标前缀。`#commit-tip` 浮层内胶囊同步同款样式。
+- **工具栏**：seg 按钮间距 / 圆角 / hover 态贴近官方。
+- **命名统一**：视图名与 Refresh / Filter / Clear Graph Filter 命令标题、CI 配置描述、aria-label 统一为 Graph；`viewType hyperGit.log`、`log/*` 消息前缀、类名等内部标识符保持不变，零协议破坏。
+
+### 未提交变更数角标可靠化（承载迁移）
+活动栏未提交变更数角标改由**隐藏 TreeView**（`hyperGit.changesBadge`，`when:false`）承载：
+
+- **承载迁移**：角标原挂在 Commit `WebviewView` 上，VS Code 在 `resolveWebviewView`（即用户至少打开过一次面板）之前无法显示 webview 角标，导致面板未打开时新变更不点亮、提交 / 撤销后不清除。改由 `activate` 阶段即实例化的隐藏 TreeView 承载，其 `badge` 无论面板是否打开都可靠聚合到容器图标。
+- **单一事实源**：新增 engine 纯函数 [`change-count`](../../src/engine/scm-mapping/change-count.ts)（`toRelKey` / `countUniqueChanges`）与 `GitRepositoryService.getChangeCount()`，`getChanges` 复用同一去重逻辑，杜绝双实现漂移。
+- **及时且高效**：角标走独立 40ms 微防抖快路径，与 150ms 重刷新解耦、合并事件风暴；释放期清理悬挂定时器。
+- **熵减**：移除 Commit webview 中的死代码（`updateBadge` / `pendingBadge`）杜绝容器求和 2× 计数；补充 change-count 单元测试锁定计数等值不变式。
+
+---
+
+## 🐛 改进与修复
+
+- **提交 / CI 悬浮浮层被侧边栏 iframe 裁剪失效**：上一版 (#48) 的浮层定位将横向定位改为 `left = window.innerWidth + 8`，误以为 webview `position:fixed` 可越界渲染到编辑器区；实则侧边栏 WebviewView 是沙箱 iframe，坐标系为 iframe 自身视口，该值落到右边界外被裁剪、浮层不可见。本版抽出共用 `positionFloat`（锚定触发元素右侧 → 越界则翻至左侧 → 再越界则收进视口），彻底修复 CI 状态与提交详情两处浮层。(#53)
+- **README / 文档真实性校准**：经 3 路只读核验 + 单测实跑取证修正——移除不存在的 `ui/` 层描述（改述为 `engine/` → `adapter/`）、单元测试计数由 280 校正为 **324**、行级提交 CodeLens 标签校准为运行时英文 "Commit this Hunk"、`vsce` 段落理顺、publisher 占位符落实为真实 `ThreeFish-AI`；同步校正文档中心「最新」发布指针（v0.0.6 → v0.0.9）与知识索引 agent 接缝清单。(#51)
+- **README 双语重构**：根 `README.md` 改写为地道英文版，中文版迁入 [`docs/i18n/zh-CN/README.md`](../i18n/zh-CN/README.md) 并重算相对链接、两版顶部互加语言切换；补入既有但未引用的 CHANGELOG 链接。补充 `vsce` 发布用法说明并重构底部 footer。(#51)
+
+> 规模实证（README 校准后）：**6 视图 / 97 命令 / 6 配置项 / 324 单元测试**（32 文件全绿）+ 集成测试，CI 三平台（Ubuntu / macOS / Windows）矩阵全程 GREEN。
+
+---
+
+## ⚙️ 升级与兼容
+
+- **无破坏性变更**：Graph 更名仅为面向用户的视图名与命令标题层面调整，`viewType`、消息协议、`setState` 形状、配置项（`hyperGit.log.*` / `hyperGit.commit.*`）均保持不变，旧状态无需迁移。
+- **未新增配置项**：现有配置一律沿用。
+- **预发布通道**：本版为 RC 预发布，安装后请留意行为反馈；正式版将以更高版本号（`0.0.11`）发布（VS Code 官方规则：同一版本号不可既作预发布又作正式版）。
+
+---
+
+## 📦 安装
+
+- **VS Code Marketplace（预发布通道）**：搜索 `Hyper Git - Agentic Git`，在扩展页选择「Switch to Pre-Release Version」安装本 RC。
+- **OpenVSX**（Cursor / Windsurf / Gitpod / VSCodium）：搜索 `Hyper Git - Agentic Git` 安装。
+- **手动**：从 [Releases](https://github.com/ThreeFish-AI/hyper-git/releases/tag/v0.0.10-rc.1) 下载 `hyper-git-agentic-git-0.0.10.vsix` → 命令面板 `Extensions: Install from VSIX`。
+
+**系统要求**：VS Code ≥ 1.85.0，且启用内置 Git 扩展（`vscode.git`，默认随附）。仅支持本地 git 仓库，不支持虚拟 / Web 工作区。
+
+---
+
+## 💬 反馈
+
+欢迎在 [GitHub Issues](https://github.com/ThreeFish-AI/hyper-git/issues) 反馈问题与建议。完整工程视角变更记录见 [CHANGELOG](../../CHANGELOG.md)。
+
+许可证：[MIT](https://github.com/ThreeFish-AI/hyper-git/blob/master/LICENSE)。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"theme": "dark"
 	},
 	"description": "Hyper Git brings IntelliJ IDEA's powerful Git & Commit modules to VS Code, enhanced with AI-powered autonomous agents for intelligent repository management. Experience Git in a higher dimension.",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"publisher": "ThreeFish-AI",
 	"license": "MIT",
 	"preview": true,


### PR DESCRIPTION
## 背景与诊断

排查「已配置 \`OVSX_PAT\` 但 GitHub Release 仍不往 VS Code Marketplace 发布」，定位到**三层根因**（均以只读证据坐实）：

1. **\`OVSX_PAT\` ≠ \`VSCE_PAT\`，是两个不同注册中心**。\`OVSX_PAT\` 服务 Open VSX（open-vsx.org，供 Cursor/Windsurf/VSCodium）；VS Code Marketplace 用 \`VSCE_PAT\`（Azure DevOps PAT）。仓库当前**只有 \`OVSX_PAT\`，无 \`VSCE_PAT\`**。
2. **Marketplace 步骤被变量门控且默认关闭**。\`ci.yml\` 的 \`if: \${{ vars.ENABLE_MARKETPLACE_PUBLISH == 'true' }}\`，而仓库 variables **完全为空**，该步骤被整段跳过。
3. **rc 版本号格式与 Marketplace 不兼容**。历史 rc 写 \`0.0.9-rc.2\`（带 semver 后缀）；VS Code 官方明确「仅支持 major.minor.patch，不接受 semver 预发布后缀」，故带 \`-rc.N\` 的版本会被 Marketplace 拒收。

> 工作流设计本身合理（双市场解耦、变量门控、审批门无阻）；问题在缺凭证/变量 + rc 版本格式。历史 rc 的 CI「全绿」仅证明 GitHub Release + \`vsce package\` 打包成功——Marketplace 从未真正发过（被跳过），OpenVSX 又被 \`continue-on-error\` 掩盖真实结果。

## 本 PR 变更（发布物料）

- **\`package.json\`**：\`version\` \`0.0.9\` → \`0.0.10\`（**方案 A**：纯 major.minor.patch，由 \`--pre-release\` 标志发预发布，规避 Marketplace 版本格式限制）。
- **\`CHANGELOG.md\`**：新增 \`[0.0.10-rc.1]\` 段（遵循 Keep a Changelog）。
- **新增 \`docs/releases/v0.0.10-rc.1.md\`**：文件名精确匹配 tag \`ref_name\`（\`ci.yml\` 的 \`body_path\`），作 GitHub Release 正文单一事实源。

归纳 v0.0.9→HEAD 的真实变更：Graph 视图更名并对齐官方 Source Control GRAPH (#53)、悬浮浮层被侧边栏 iframe 裁剪修复 (#53)、未提交角标承载迁移至隐藏 TreeView (#52)、README 真实性校准 + 中英双语 (#51)。

## 发布方案（合并后执行）

- **版本方案 A**：package.json 用纯 \`0.0.10\`，tag \`v0.0.10-rc.1\`，靠 \`--pre-release\` 发预发布通道。代价：\`0.0.10\` 版位被预发布占用，正式版须用 \`0.0.11\`。
- **三渠道全发**：GitHub Release + VS Code Marketplace（预发布）+ OpenVSX。
- **触发**：本 PR 合并入 \`feature/1.x.x\` 后，在其上打 \`v0.0.10-rc.1\` tag 推送触发 CI。

## 前置条件（需仓库管理员在打 tag 前完成）

1. 确认/创建 Marketplace publisher \`ThreeFish-AI\`；
2. 创建 Azure DevOps PAT（scope: Marketplace → Manage）；
3. 新增仓库 Secret \`VSCE_PAT\`；
4. 新增仓库 Variable \`ENABLE_MARKETPLACE_PUBLISH=true\`；
5. 核实 OpenVSX \`ThreeFish-AI\` namespace 已 claim + \`OVSX_PAT\` 有效。

## 验证

tag 推送后确认：\`package\` 产出 \`hyper-git-agentic-git-0.0.10.vsix\`；\`github-release\` 建 prerelease 并附 vsix、正文取自本 Release Note；\`publish\` 的 Marketplace 步骤不再跳过且以 \`--pre-release\` 成功；显式查 OpenVSX 步骤日志确认真发布。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)