### PR TITLE
fix(CI): 修复 Marketplace 预发布 publish 失败（package job 对 rc tag 补 --pre-release），补 v0.0.10-rc.2 物料

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,13 @@ jobs:
           node-version: 22
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm dlx @vscode/vsce package --no-yarn
+      # rc tag 以 --pre-release 打包：VS Code 要求「预发布 VSIX」在打包时即标记，
+      # 否则 publish job 的 `vsce publish --pre-release` 会报「未以 pre-release 打包」而失败。
+      # 与 publish/OpenVSX 步骤同款 PRE_FLAG 判定，保证同一枚 VSIX 贯穿三渠道。
+      - name: 打包 vsix（rc tag 自动带 --pre-release）
+        run: |
+          PRE_FLAG=$([[ "${GITHUB_REF_NAME}" == *rc* ]] && echo "--pre-release" || echo "")
+          pnpm dlx @vscode/vsce package --no-yarn $PRE_FLAG
       - uses: actions/upload-artifact@v7
         with:
           name: vsix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 > 面向用户的发布说明（含完整特性叙述与安装指引）见 [`docs/releases/`](./docs/releases/README.md)。
 
+## [0.0.10-rc.2] - 2026-07-04 — 修复发布流水线预发布打包缺陷
+
+rc.1 因 CI `package` job 未以 `--pre-release` 打包，致 `publish` job 的 Marketplace 步骤报「VSIX 未以 pre-release 打包」而失败（OpenVSX 步骤随之被 skipped），三渠道仅 GitHub Release 成功、Marketplace/OpenVSX 未发出。rc.2 修复该流水线缺陷后重新走通；产品内容与 rc.1 一致。完整叙述见 [Release Note v0.0.10-rc.2](./docs/releases/v0.0.10-rc.2.md)。
+
+### Fixed
+- **CI `package` job 对 rc tag 以 `--pre-release` 打包**：VS Code 要求「以预发布方式发布的 VSIX 必须在打包时即带 `--pre-release` 标记」，否则 `vsce publish --pre-release` 报 `Cannot use '--pre-release' flag with a package that was not packaged as pre-release`。`package` 步骤改为与 publish / OpenVSX 同款 `PRE_FLAG` 判定（`GITHUB_REF_NAME` 含 `rc` 即追加 `--pre-release`），令同一枚预发布 VSIX 贯穿 GitHub Release / Marketplace / OpenVSX 三渠道；正式版 tag 与分支 / PR CI 行为不变。详见 [issue #11](./docs/.agents/issue.md)。
+
 ## [0.0.10-rc.1] - 2026-07-04 — Graph 视图对齐官方 · 浮层与角标修复 · 发布链路验证
 
 面向 0.0.10 的首个预发布（RC）。在 v0.0.9 基础上将提交图视图更名为 **Graph** 并视觉对齐 VS Code 官方 Source Control GRAPH 视图，修复提交/CI 悬浮浮层被侧边栏 iframe 裁剪失效、活动栏未提交数角标更新不及时两处缺陷，并完成 README 真实性校准与中英双语重构。本版亦作为 **VS Code Marketplace 发布链路打通**的验证版（首次以官方预发布模型 `--pre-release` 发布 `0.0.10`）。完整用户视角叙述见 [Release Note v0.0.10-rc.1](./docs/releases/v0.0.10-rc.1.md)。

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -86,4 +86,12 @@
 - **后续防范**：① 需要「面板未打开也持续显示」的活动栏计数角标，**必须**承载于 `createTreeView` 建立的 TreeView（可用 `when:false` 隐藏视图专职承载），**不可**依赖 `WebviewView.badge`——其 resolve 前不显示是 VS Code 已知限制而非本仓 bug；这与 #8「`.badge` TreeView/WebviewView 均支持」并行：「支持置 badge」≠「未 resolve 也上屏」。② 容器角标为**各视图 badge 之和**，全仓须保证**唯一承载者**，迁移承载时务必删除旧承载，否则重复计数。③ 计数与文件列表去重须共用单一事实源（`toRelKey`），避免「列表条目数 ≠ 角标数」漂移。④ `when:false` 承载视图的实机角标渲染需在 EDH 回归确认（跨 VS Code 版本聚合行为），失败则回退为 `visibility:collapsed` 的空视图。
 - **同类问题影响**：所有以 `WebviewView.badge` 承载活动栏/视图角标的自定义视图容器扩展；凡角标承载迁移未清理旧承载导致的重复计数；以及把「支持 badge 属性」误判为「隐藏态也能显示 badge」的时序类误区。
 
+## #11 VS Code Marketplace 预发布 publish 失败（VSIX 未以 `--pre-release` 打包）
+
+- **表因**：以 rc tag（`v0.0.10-rc.1`）触发发布时，`publish` job 的「发布到 VS Code Marketplace」步骤报错 `Cannot use '--pre-release' flag with a package that was not packaged as pre-release. Please package it using the '--pre-release' flag and publish again.`，job 失败；其后的 OpenVSX 步骤（虽 `continue-on-error`）因前序步骤失败被 skipped，致三渠道仅 `github-release` 成功、Marketplace/OpenVSX 均未发出。
+- **根因**：`package` job 以 `vsce package --no-yarn`（**不带** `--pre-release`）打出「正式版」VSIX 作为 artifact；`publish` job 却对 rc tag 用 `vsce publish --packagePath *.vsix --pre-release`。vsce 强约束——以 `--pre-release` 发布的 VSIX 必须在**打包时**即带 `--pre-release`（预发布标志写入 VSIX manifest），否则拒绝发布。打包端与发布端的 `--pre-release` 判定不对称即致此错。历史 rc（0.0.9-rc.*）从未真正发到市场（Marketplace 步骤因缺 `VSCE_PAT`/变量被跳过），故该缺陷此前从未被触发暴露。
+- **处理方式**：`package` job 打包步骤改为与 publish/OpenVSX 同款 `PRE_FLAG` 判定——`GITHUB_REF_NAME` 含 `rc` 时追加 `--pre-release`，使同一枚「预发布 VSIX」贯穿 `github-release` / Marketplace / OpenVSX 三渠道（单一产物、零重复打包）。正式版 tag（无 `rc`）与分支/PR CI 仍打普通 VSIX，行为不变。
+- **后续防范**：① VS Code 预发布模型下，**打包与发布两端的 `--pre-release` 必须成对出现**；凡「先 package 成 artifact、后 publish 复用同一枚 VSIX」的流水线，预发布判定要在 package 端就落地，不能只在 publish 端加 flag。② 预发布版本号仍须纯 `major.minor.patch`（Marketplace 不接受 `-rc.N` semver 后缀），预发布语义由 `--pre-release` 标志 + tag 命名承载；`0.0.10` 作预发布后正式版须用更高版本（如 `0.0.11`），同一版本号不可既预发布又正式发布。③ OpenVSX 步骤的 `continue-on-error` 只隔离其自身失败——前序 Marketplace 步骤失败仍会使其 skipped；排障时勿因「OpenVSX 未报错」误判其已发布，须查其步骤实际状态与日志。④ Marketplace 发布链路的双凭证不可混淆：`VSCE_PAT`（Azure DevOps PAT，scope Marketplace→Manage）与 `OVSX_PAT`（open-vsx.org token）是不同服务的两个不同 token，且 Marketplace 发布还受仓库变量 `ENABLE_MARKETPLACE_PUBLISH` 门控。
+- **同类问题影响**：所有「package 出 artifact → publish 复用」且需发布预发布通道的 VS Code 扩展 CI；凡打包端与发布端 flag 判定不对称（`--pre-release`、平台化 `--target` 等同理）的流水线均会踩。
+
 

--- a/docs/releases/v0.0.10-rc.2.md
+++ b/docs/releases/v0.0.10-rc.2.md
@@ -1,0 +1,77 @@
+# Hyper Git - Agentic Git v0.0.10-rc.2 — Graph 视图对齐官方 · 浮层与角标修复（发布流水线修复重切）
+
+> **预发布（Release Candidate）**，面向下一正式版 `0.0.10`。产品内容与 [v0.0.10-rc.1](./v0.0.10-rc.1.md) 一致——将提交图视图更名为 **Graph** 并对齐 VS Code 官方 Source Control GRAPH 视图，修复悬浮浮层被侧边栏 iframe 裁剪、活动栏未提交数角标更新不及时两处缺陷，并完成 README 真实性校准与中英双语重构。
+
+> **为何是 rc.2**：rc.1 因发布流水线的**预发布打包缺陷**——`package` job 未以 `--pre-release` 打包，致 `publish` job 的 Marketplace 步骤报 `Cannot use '--pre-release' flag with a package that was not packaged as pre-release` 而失败、OpenVSX 步骤随之被跳过，最终仅 GitHub Release 成功。rc.2 修复该缺陷（打包端与发布端 `--pre-release` 对齐，同一枚预发布 VSIX 贯穿三渠道）后重新走通 **GitHub Release + VS Code Marketplace（预发布通道）+ OpenVSX** 三渠道。详见 [issue #11](../.agents/issue.md)。
+
+---
+
+## 🔧 本次修复（rc.1 → rc.2）
+
+- **CI `package` job 对 rc tag 以 `--pre-release` 打包**：VS Code 要求以预发布方式发布的 VSIX 必须在**打包时**即带 `--pre-release` 标记（写入 manifest），否则 `vsce publish --pre-release` 拒绝发布。`package` 步骤改为与 `publish` / OpenVSX 同款 `PRE_FLAG` 判定（tag 名含 `rc` 即追加 `--pre-release`），保证单一枚预发布 VSIX 贯穿三渠道、零重复打包；正式版 tag 与分支 / PR CI 行为不变。
+
+---
+
+## ✨ 亮点速览
+
+- **提交图更名 Graph 并对齐官方**：视图更名为「Graph」，泳道连线改三次贝塞尔平滑曲线、HEAD 空心双环高亮、引用胶囊改全圆角实心 pill 并跟随泳道色，整体贴近 VS Code 官方 Source Control GRAPH 视图。
+- **修复悬浮浮层失效**：提交详情 / CI 状态浮层此前被侧边栏 iframe 裁剪到视口外而不可见，现抽出统一的 `positionFloat` 定位彻底修复。
+- **修复活动栏角标不及时**：未提交变更数角标改由隐藏 TreeView 承载，无论 Commit 面板是否打开都能可靠、及时地点亮与清除。
+- **README 真实性校准 + 中英双语**：以实跑取证修正过时陈述，根英文、中文迁入 i18n，双向语言切换。
+
+---
+
+## 🧩 完整能力
+
+### Graph 视图更名与官方对齐（原 Log 视图）
+面向用户的「Log」视图更名为 **「Graph」**，并在渲染层视觉对齐 VS Code 官方 Source Control GRAPH 视图，**不改动底层数据 / 消息协议 / 布局算法 / CI 逻辑**：
+
+- **泳道连线**：由直线 `<line>` 改为三次贝塞尔 `<path>` 平滑曲线（同列 `fromCol === toCol` 时自动退化为直线）。
+- **HEAD 高亮**：当前 HEAD 行节点渲染为空心环 + 内点（双环高亮），普通行保持实心点。
+- **引用胶囊**：从 message 左侧前缀移至右侧后缀（列序 泳道图 → message → chips → author → date → CI）；底色跟随本行泳道色（类型靠图标区分而非颜色，同名 origin 远程分支随所在行泳道呈多色），按底色亮度自适应深 / 白字保可读；由半透明小圆角矩形改为实心全圆角 pill，保留分支 / 云 / tag 内联 SVG 图标前缀。`#commit-tip` 浮层内胶囊同步同款样式。
+- **工具栏**：seg 按钮间距 / 圆角 / hover 态贴近官方。
+- **命名统一**：视图名与 Refresh / Filter / Clear Graph Filter 命令标题、CI 配置描述、aria-label 统一为 Graph；`viewType hyperGit.log`、`log/*` 消息前缀、类名等内部标识符保持不变，零协议破坏。
+
+### 未提交变更数角标可靠化（承载迁移）
+活动栏未提交变更数角标改由**隐藏 TreeView**（`hyperGit.changesBadge`，`when:false`）承载：
+
+- **承载迁移**：角标原挂在 Commit `WebviewView` 上，VS Code 在 `resolveWebviewView`（即用户至少打开过一次面板）之前无法显示 webview 角标，导致面板未打开时新变更不点亮、提交 / 撤销后不清除。改由 `activate` 阶段即实例化的隐藏 TreeView 承载，其 `badge` 无论面板是否打开都可靠聚合到容器图标。
+- **单一事实源**：新增 engine 纯函数 [`change-count`](../../src/engine/scm-mapping/change-count.ts)（`toRelKey` / `countUniqueChanges`）与 `GitRepositoryService.getChangeCount()`，`getChanges` 复用同一去重逻辑，杜绝双实现漂移。
+- **及时且高效**：角标走独立 40ms 微防抖快路径，与 150ms 重刷新解耦、合并事件风暴；释放期清理悬挂定时器。
+- **熵减**：移除 Commit webview 中的死代码（`updateBadge` / `pendingBadge`）杜绝容器求和 2× 计数；补充 change-count 单元测试锁定计数等值不变式。
+
+---
+
+## 🐛 改进与修复
+
+- **提交 / CI 悬浮浮层被侧边栏 iframe 裁剪失效**：上一版 (#48) 的浮层定位将横向定位改为 `left = window.innerWidth + 8`，误以为 webview `position:fixed` 可越界渲染到编辑器区；实则侧边栏 WebviewView 是沙箱 iframe，坐标系为 iframe 自身视口，该值落到右边界外被裁剪、浮层不可见。本版抽出共用 `positionFloat`（锚定触发元素右侧 → 越界则翻至左侧 → 再越界则收进视口），彻底修复 CI 状态与提交详情两处浮层。(#53)
+- **README / 文档真实性校准**：经 3 路只读核验 + 单测实跑取证修正——移除不存在的 `ui/` 层描述（改述为 `engine/` → `adapter/`）、单元测试计数由 280 校正为 **324**、行级提交 CodeLens 标签校准为运行时英文 "Commit this Hunk"、`vsce` 段落理顺、publisher 占位符落实为真实 `ThreeFish-AI`；同步校正文档中心「最新」发布指针（v0.0.6 → v0.0.9）与知识索引 agent 接缝清单。(#51)
+- **README 双语重构**：根 `README.md` 改写为地道英文版，中文版迁入 [`docs/i18n/zh-CN/README.md`](../i18n/zh-CN/README.md) 并重算相对链接、两版顶部互加语言切换；补入既有但未引用的 CHANGELOG 链接。补充 `vsce` 发布用法说明并重构底部 footer。(#51)
+
+> 规模实证（README 校准后）：**6 视图 / 97 命令 / 6 配置项 / 324 单元测试**（32 文件全绿）+ 集成测试，CI 三平台（Ubuntu / macOS / Windows）矩阵全程 GREEN。
+
+---
+
+## ⚙️ 升级与兼容
+
+- **无破坏性变更**：Graph 更名仅为面向用户的视图名与命令标题层面调整，`viewType`、消息协议、`setState` 形状、配置项（`hyperGit.log.*` / `hyperGit.commit.*`）均保持不变，旧状态无需迁移。
+- **未新增配置项**：现有配置一律沿用。
+- **预发布通道**：本版为 RC 预发布，安装后请留意行为反馈；正式版将以更高版本号（`0.0.11`）发布（VS Code 官方规则：同一版本号不可既作预发布又作正式版）。
+
+---
+
+## 📦 安装
+
+- **VS Code Marketplace（预发布通道）**：搜索 `Hyper Git - Agentic Git`，在扩展页选择「Switch to Pre-Release Version」安装本 RC。
+- **OpenVSX**（Cursor / Windsurf / Gitpod / VSCodium）：搜索 `Hyper Git - Agentic Git` 安装。
+- **手动**：从 [Releases](https://github.com/ThreeFish-AI/hyper-git/releases/tag/v0.0.10-rc.2) 下载 `hyper-git-agentic-git-0.0.10.vsix` → 命令面板 `Extensions: Install from VSIX`。
+
+**系统要求**：VS Code ≥ 1.85.0，且启用内置 Git 扩展（`vscode.git`，默认随附）。仅支持本地 git 仓库，不支持虚拟 / Web 工作区。
+
+---
+
+## 💬 反馈
+
+欢迎在 [GitHub Issues](https://github.com/ThreeFish-AI/hyper-git/issues) 反馈问题与建议。完整工程视角变更记录见 [CHANGELOG](../../CHANGELOG.md)。
+
+许可证：[MIT](https://github.com/ThreeFish-AI/hyper-git/blob/master/LICENSE)。


### PR DESCRIPTION
## 背景

`v0.0.10-rc.1` 发布流水线在最后一步失败——`publish` job 的「发布到 VS Code Marketplace」步骤报错：

\`\`\`
Cannot use '--pre-release' flag with a package that was not packaged as pre-release.
Please package it using the '--pre-release' flag and publish again.
\`\`\`

其余全部成功（三平台测试、打包、**GitHub Release `v0.0.10-rc.1` prerelease 已附 .vsix**）。Marketplace/OpenVSX 本轮**未发出任何东西**，`0.0.10` 版位在两市场仍干净可用。

## 根因

- `package` job 以 `vsce package --no-yarn`（**不带** `--pre-release`）打出「正式版」VSIX 作为 artifact；
- `publish` job 却对 rc tag 用 `vsce publish --packagePath *.vsix --pre-release`；
- vsce 强约束：以 `--pre-release` 发布的 VSIX 必须在**打包时**即带 `--pre-release` 标记，否则拒绝发布。打包端与发布端 flag 判定不对称即致此错。
- 历史 rc（0.0.9-rc.*）从未真正发到市场（Marketplace 步骤因缺 \`VSCE_PAT\`/变量被跳过），故该缺陷此前从未被暴露。

## 修复

- **`ci.yml` `package` job**：打包步骤改为与 `publish` / OpenVSX 同款 \`PRE_FLAG\` 判定（\`GITHUB_REF_NAME\` 含 \`rc\` 即追加 \`--pre-release\`），令同一枚**预发布 VSIX** 贯穿 \`github-release\` / Marketplace / OpenVSX 三渠道（单一产物、零重复打包）。正式版 tag（无 \`rc\`）与分支/PR CI 仍打普通 VSIX，行为不变。
- **知识沉淀**：新增 [issue #11](../.agents/issue.md)。
- **rc.2 物料**：新增 \`docs/releases/v0.0.10-rc.2.md\` + CHANGELOG \`[0.0.10-rc.2]\` 条目，供合并后打 \`v0.0.10-rc.2\` 重跑（不 force-push tag，审计清晰：rc.1=CI 缺陷失败、rc.2=修复后走通）。

> \`package.json\` 版本仍为 \`0.0.10\`（预发布语义由 \`--pre-release\` + tag 命名承载，不改版本号）。

## 验证

合并后打 \`v0.0.10-rc.2\` tag，确认：\`Package vsix\` 以 \`--pre-release\` 打包成功 → \`github-release\` 建 prerelease 附 vsix → \`publish\` 的 Marketplace 步骤（\`--pre-release\`）成功 → OpenVSX 步骤成功（显式查日志，因其 \`continue-on-error\`）；到 Marketplace / OpenVSX 页面确认 \`0.0.10\` 预发布上架。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)