### PR TITLE
fix(Graph): CI 与提交详情 Tooltip 互斥 + 引用胶囊完整显示，并合入 #75 依赖升级

### DIFF
--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -558,6 +558,9 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #commit-tip .ct-sec .ct-k { flex: 0 0 66px; color: var(--vscode-descriptionForeground); font-size: 10px; text-transform: uppercase; letter-spacing: .3px; }
 #commit-tip .ct-sec .ct-v { flex: 1 1 auto; min-width: 0; word-break: break-word; }
 #commit-tip .ct-refs { display: flex; flex-wrap: wrap; gap: 4px; }
+/* 浮层内引用胶囊完整显示（覆盖行内 .chip 的 max-width/省略号截断）：换行不截断，空间由浮层承载。 */
+#commit-tip .chip { max-width: none; }
+#commit-tip .chip .chip-nm { overflow: visible; text-overflow: clip; white-space: normal; word-break: break-all; }
 #commit-tip .ct-dim { color: var(--vscode-descriptionForeground); }
 #commit-tip .ct-stat { display: flex; gap: 12px; padding: 8px 0; border-top: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); border-bottom: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); font-size: 12px; font-variant-numeric: tabular-nums; }
 #commit-tip .ct-stat .files { color: var(--vscode-descriptionForeground); }
@@ -1000,6 +1003,7 @@ rowsEl.addEventListener('mouseover', function (e) {
   const icon = e.target.closest && e.target.closest('.ci');
   if (!icon || icon.classList.contains('ci-empty')) return;
   overIcon = true;
+  hideCommitTip(); // 进入 CI 图标：立即隐藏提交浮层并取消在途，二者互斥。
   scheduleShow(icon.getAttribute('data-ci'), icon);
 });
 rowsEl.addEventListener('mouseout', function (e) {
@@ -1007,6 +1011,10 @@ rowsEl.addEventListener('mouseout', function (e) {
   if (!icon) return;
   overIcon = false;
   scheduleHide();
+  // 离开 CI 图标但仍在同一行内（移回行体）：切回提交详情浮层。
+  const to = e.relatedTarget;
+  const r = to && to.closest && to.closest('.row');
+  if (r && !(to.closest && to.closest('.ci'))) scheduleShowCommit(r.getAttribute('data-hash'));
 });
 rowsEl.addEventListener('keydown', function (e) {
   const icon = e.target.closest && e.target.closest('.ci');
@@ -1207,7 +1215,7 @@ function scheduleHideCommit() {
 }
 rowsEl.addEventListener('mouseover', function (e) {
   const ci = e.target.closest && e.target.closest('.ci');
-  if (ci && !ci.classList.contains('ci-empty')) return; // CI 图标区归 CI 浮层。
+  if (ci && !ci.classList.contains('ci-empty')) { hideCommitTip(); return; } // 进入 CI 图标区：即时隐藏提交浮层并取消在途，二者互斥。
   const r = e.target.closest && e.target.closest('.row');
   if (!r) return;
   scheduleShowCommit(r.getAttribute('data-hash'));


### PR DESCRIPTION
## 背景

承接已合并的 #74（修复 Tooltip 两处回归）。#74 合并后发现 CI 与提交详情两个浮层在 CI 图标上叠加、且引用胶囊被截断，本 PR 修复；并合入 feature 基线新增的 #75 依赖升级。

## 变更（本 PR 净增量）

### 1. `fix(Graph)` — CI 与提交详情 Tooltip 严格互斥 + 引用胶囊完整显示（`7558feb`）

**问题1：两浮层叠加。** 鼠标在 CI 状态图标上时，CI 详情浮层与提交详情浮层同时显示、后者覆盖前者。
- 根因：commit 的 mouseover 命中 CI 图标时仅 `return`，未隐藏已显示/在途的提交浮层；CI 的 mouseover 也未隐藏提交浮层。
- 修复（二者严格互斥）：
  - commit mouseover 命中 CI 图标 → 即时 `hideCommitTip()`（含取消在途 400ms 定时器）；
  - CI mouseover → 先 `hideCommitTip()` 再 `scheduleShow(CI)`；
  - CI mouseout 回落到同行行体（非 CI 区）→ `scheduleShowCommit` 切回提交浮层。
- 经 Playwright 模拟 hover 序列验证：行体→仅提交浮层；CI 图标→仅 CI 浮层；移回行体→仅提交浮层。

**问题2：引用胶囊截断。** 提交浮层内 Branches/Tags 胶囊沿用行内 `.chip` 的 `max-width:160px` + 省略号，长名被截断（`…`）。
- 修复：`#commit-tip` 内覆盖为 `max-width:none` + 名称换行不截断（refs 区已 `flex-wrap` 承载），完整显示。

### 2. 合入 feature 基线（merge commit）
- feature 在 merge-base 后新增 #75（4 项依赖升级 + dependabot `target-branch: feature/1.x.x` 锚定）。
- merge 零冲突（ort 策略自动合并）：`package.json`/`pnpm-lock.yaml`（含 vite 8.1.3 等）、`.github/dependabot.yml`（我的 `@types/vscode` ignore 规则与 #75 的 target-branch 正确并存）。

## 验证
- check-types / lint / 生产打包 / **349 单测** / vsce package 全绿（feature 最新基线：TS6 / vitest4 / vite 8.1.3）。
- Playwright 动态验证 tooltip 互斥；harness 核实胶囊完整不截断。

> 验证边界：hover tooltip 实机手感（CI↔commit 互斥切换、胶囊完整）需真实 VS Code F5 端到端确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
