### PR TITLE
fix(Graph): CI 与提交详情 Tooltip 定位更贴近光标（gap 14→8）

### DIFF
--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -920,14 +920,14 @@ document.addEventListener('mousemove', function (e) { cursorX = e.clientX; curso
 function positionAtCursor(el) {
   el.style.display = 'flex';
   const w = el.offsetWidth, h = el.offsetHeight;
-  const vw = window.innerWidth, vh = window.innerHeight, pad = 6, gap = 14;
-  // 横向：默认在光标右侧；越右沿翻到左侧；仍越界则收进视口。
+  const vw = window.innerWidth, vh = window.innerHeight, pad = 6, gap = 8;
+  // 横向：默认贴光标右侧；越右沿则翻到光标左侧（右沿紧邻光标）；仍越界收进视口。
   let left = cursorX + gap;
   if (left + w > vw - pad) left = cursorX - gap - w;
   if (left < pad) left = Math.max(pad, vw - pad - w);
-  // 纵向：默认在光标下方；越下沿翻到上方；钳制视口。
+  // 纵向：默认贴光标下方；越下沿则翻到光标上方（底边紧邻光标）；钳制视口。
   let top = cursorY + gap;
-  if (top + h > vh - pad) top = cursorY - gap - h;
+  if (top + h > vh - pad) top = Math.max(pad, cursorY - gap - h);
   if (top < pad) top = pad;
   el.style.left = left + 'px';
   el.style.top = top + 'px';


### PR DESCRIPTION
## 背景

PR #76 合并后，用户反馈 CI 状态详情 Tooltip 离鼠标偏远、不够贴近光标。本 PR 承接该反馈做定位微调。（此提交原误推到 #76 已合并的旧分支上、无承载 PR，现基于最新 `feature/1.x.x` 用新分支干净提出。）

## 变更

`fix(Graph)` — CI 与提交详情 Tooltip 定位更贴近光标（`efd9097`）

**根因**：CI hover 已走 `positionAtCursor`（跟随光标），但 CI 图标恒在行最右、光标 X 贴侧边栏右沿，横向翻转叠加 `gap=14` 使浮层与光标间距偏大，窄侧栏下观感不够「贴」。

**修复**（CI 与提交详情浮层共用 `positionAtCursor`，一并受益）：
- `gap` 14→8：浮层右沿/底边距光标仅 8px，紧贴。
- 纵向翻转补 `Math.max(pad, …)` 钳制，避免上翻越出视口顶部。
- 横向沿用「右侧优先、越界翻左且右沿贴光标」，窄侧栏下浮层右上角紧邻光标（CI 图标）。

## 验证
- check-types / lint / 生产打包 / **349 单测** 全绿（feature 最新基线）。
- Chrome headless 截图确认 CI 浮层右上角紧贴 CI 图标（光标）左下方，较 gap=14 明显更近。

> 实机确认点（F5）：鼠标停在 CI 状态图标 → CI 详情浮层紧贴光标出现；移到行体 → 切换为提交详情浮层，同样贴光标。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
