### PR TITLE
feat(Views): 视图容器迁移至底部 Panel（Terminal 之后） v0.0.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@
 
 ## [Unreleased]
 
+## [0.0.13] - 2026-07-05 — 视图容器由活动栏迁移至底部面板（Terminal 之后）
+
+将 Hyper Git 视图容器从活动栏（Activity Bar / Primary Side Bar）迁移至底部面板（Panel），默认排在 Terminal 页签之后，提供与官方 Terminal / Output / Problems 一致的底部停靠体验。完整用户视角叙述见 [Release Note v0.0.13](./docs/releases/v0.0.13.md)。
+
+### Changed
+- **视图容器 dock 迁移**：`package.json` 的 `viewsContainers` 由 `activitybar` 改为 `panel`，容器 id `hyper-git` 与全部 7 个视图（Commit / Graph / Branches / Stash / Shelf / Worktrees / changesBadge）不变；`.ts` 源码与图标无需改动（dock 类型与 views 归属、API 调用、图标规范完全解耦）。`initialSize` 语义随之由侧边栏高度权重变为 Panel 主轴权重，值本身不改。
+
+### Known Limitations
+- **活动栏「始终可见」未提交角标消失**：迁移后活动栏不再有 Hyper Git 入口图标，[issue #10](./docs/.agents/issue.md) 修复的「面板未打开也持续显示」活动栏计数角标随之失效；未提交计数仅在 Panel 展开时可见（VS Code 平台行为）。详见 [issue #13](./docs/.agents/issue.md)。
+- **老用户需重置视图布局**：VS Code 会记忆旧的 activitybar 位置，升级后需命令面板执行「View: Reset View Locations」或右键容器页签「Reset Location」才采用新默认（[issue #12](./docs/.agents/issue.md) 同款平台行为）。
+
+### Docs
+- 新增 [Release Note v0.0.13](./docs/releases/v0.0.13.md)；[issue #13](./docs/.agents/issue.md) 记录 dock 迁移决策与 badge 权衡。
+
 ## [0.0.12] - 2026-07-04 — 提交详情光标跟随悬浮卡 · Tooltip 交互修复 · 布局优化 · 依赖升级基线
 
 在 v0.0.11 基础上，将 Graph 提交详情悬浮卡重做为**随光标浮现、逐项对齐 VS Code 官方 Source Control GRAPH** 的形态（其间曾尝试迁移至右侧编辑器区面板，最终撤回、改回光标跟随浮层），并配套修复 CI / 提交两类 Tooltip 的定位、互斥、键盘触发与引用胶囊截断等一系列交互回归；同时优化侧边栏视图默认布局，并合入 TypeScript 6 / vitest 4 / vite 8 等依赖升级基线。完整用户视角叙述见 [Release Note v0.0.12](./docs/releases/v0.0.12.md)。

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -102,4 +102,16 @@
 - **后续防范**：① VS Code 侧边栏视图存在约 **142px 硬性最小展开高度**，无法经扩展降低——遇「任意高度 / 无最小高度」类诉求应直接引 #123715（not planned）说明平台边界，**勿承诺实现**；判断「webview 内容 CSS `min-height`」与「外层面板最小高度」是两回事。② `visibility` / `initialSize` **只影响初始状态**（「用户手动折叠/移动/隐藏过后即不再生效」）——老用户需命令面板「View: Reset View Locations」或右键容器图标「Reset Location」才采用新默认；实机验证须用**干净 profile 或先重置**以规避持久化布局。③ 想让展开视图更紧凑，只能靠「减少常驻视图数（默认折叠）+ 权重」，而非解除下限。
 - **同类问题影响**：所有向活动栏/侧边栏容器贡献 TreeView/WebviewView 且希望自定义或取消视图高度的扩展；凡把「webview 内容 `min-height` CSS」误认为能改变外层面板最小高度的实现。
 
+## #13 视图容器由活动栏迁移至底部 Panel（dock 决定 badge 可见性上限 + 页签顺序不可控）
+
+- **表因**：用户要求将 Hyper Git 视图容器从默认的活动栏（Activity Bar / Primary Side Bar）迁移到底部面板（Panel），并希望排在 Terminal 页签之后。
+- **根因**：`contributes.viewsContainers` 的 `activitybar` 与 `panel` 是 dock 选择键，VS Code 通过容器 id 关联 `viewsContainers` 与 `views`，**容器挂在哪个 dock 与 views 归属、API 调用、图标规范完全解耦**——故迁移仅需将 `package.json` 中 `"activitybar"` 改为 `"panel"`，容器 id `hyper-git` 与全部 7 个视图、`.ts` 源码、`media/hyper-git-icon.svg`（24×24 单色 `currentColor`）均无需改动（`engines.vscode: ^1.85.0` ≫ panel 容器所需 1.56+）。
+- **处理方式**：单行改动 `viewsContainers.activitybar` → `viewsContainers.panel`，并 bump `0.0.12` → `0.0.13`。用户经评估后**明确接受 trade-off**（见下），不引入双容器或状态栏计数器。
+- **后续防范**：
+  1. **Panel 容器相对内置页签顺序不可控**：VS Code **不提供**任何 contribution point 控制 panel 容器相对内置页签（Terminal/Output/Problems/Debug）的顺序；默认行为是新装扩展的容器**追加在内置页签之后**，用户可拖拽并持久化。遇「精确紧邻某内置页签」类诉求应直接说明平台边界，**勿承诺实现**。
+  2. **dock 迁移改变 `initialSize` 语义**：`initialSize` 是容器主轴方向的权重（类 flex-grow）；侧边栏主轴=垂直（高度权重），Panel 默认主轴=水平（宽度权重）。值本身无需改，但语义随用户布局方向变化；遇视图过挤应调权重而非解除下限（与 #12 同一硬编码边界）。
+  3. **dock 决定 badge 可见性上限**（关键）：activitybar 容器图标支持「未聚焦也聚合显示」的一等 badge（#10 据此实现「面板未打开也持续显示」）；**panel 容器页签 badge 的可见性受 Panel 展开/收起态约束**。`when:false` TreeView 在 panel dock 下的聚合可见性需 EDH 实测（跨 VS Code 版本）。本案用户**明确接受**此 trade-off——未提交计数仅在 Panel 展开时可见，不触发双容器回退；若后续需恢复「始终可见」计数，应走双容器（panel 主 + activitybar badge 专用）或状态栏计数器方案。
+  4. **dock 迁移属用户可见布局变更**：VS Code 会记忆旧 dock 位置，老用户升级后需「View: Reset View Locations」或右键容器页签「Reset Location」才采用新默认（与 #12 同款平台行为，实机验证须用干净 profile）。
+- **同类问题影响**：所有在 activitybar/panel 间迁移自定义视图容器的扩展；凡依赖容器图标 badge「始终可见」语义的扩展；以及把「dock 迁移」误当作纯内部重构而忽视 badge 可见性回退的实现。
+
 

--- a/docs/.agents/knowledge-map.md
+++ b/docs/.agents/knowledge-map.md
@@ -25,7 +25,7 @@
 - [工程实施方案](../docs/architecture/engineering-plan.md) — 路径 B 架构 + M0-M5 里程碑（**开发蓝图**）。
 - [Git 功能矩阵](../docs/requirements/idea-feature-matrix.md) — 56 功能点 / 8 组（**验收基线**，参考 IDEA 等成熟实现）。
 - [调研报告](../docs/research/README.md) — SCM 集成 / 工程蓝图 / 发布 CI / AI 接缝四路循证报告。
-- [发布说明](../releases/README.md) — 各正式版 Release Notes（GitHub Release 正文单一事实源；最新 [v0.0.12](../releases/v0.0.12.md)）。
+- [发布说明](../releases/README.md) — 各正式版 Release Notes（GitHub Release 正文单一事实源；最新 [v0.0.13](../releases/v0.0.13.md)）。
 
 ## 架构分层（src/）
 > 依赖方向单向：`UI → Adapter → Engine`；`Agent` 以接口注入 `Engine`/`CommitPipeline`，不反向依赖 UI。

--- a/docs/releases/v0.0.13.md
+++ b/docs/releases/v0.0.13.md
@@ -1,0 +1,54 @@
+# Hyper Git - Agentic Git v0.0.13 — 视图容器迁移至底部 Panel（Terminal 之后）
+
+> 将 Hyper Git 视图容器从默认的活动栏（Activity Bar / Primary Side Bar）迁移至**底部面板（Panel）**，默认排在 Terminal 页签之后，与官方 Terminal / Output / Problems 提供一致的底部停靠体验。
+
+> 本版仅变更视图容器的 dock 位置，未改动任何 `viewType`、消息协议、`webview.setState` 形状与配置项，旧状态无需迁移。
+
+---
+
+## ✨ 亮点速览
+
+- **底部 Panel 停靠**：Hyper Git 视图容器从左侧活动栏迁移至底部面板，与 Terminal / Output / Problems / Debug Console 并列；默认页签位置在 Terminal 之后，可拖拽微调。
+- **零回归**：仅 `package.json` 单行 dock 变更（`activitybar` → `panel`），全部 7 个视图（Commit / Graph / Branches / Stash / Shelf / Worktrees / changesBadge）的 id、源码、图标均不变；webview 渲染、tree provider、命令、菜单、配置项全部沿用。
+
+---
+
+## 🧩 完整能力
+
+### 视图容器：活动栏 → 底部 Panel
+
+- **迁移目标**：将 `contributes.viewsContainers` 的容器 `hyper-git` 由 `activitybar`（左侧活动栏）迁至 `panel`（底部面板）。容器 id 与 `views` 归属解耦——VS Code 通过容器 id 关联两者，故视图槽位、API 注册、图标规范均无需改动。
+- **默认页签顺序**：VS Code 平台不提供精确控制 Panel 内页签顺序的能力；新安装扩展的容器默认**追加在内置页签（Terminal / Output / Problems / Debug Console）之后**。如需调整（例如紧邻 Terminal），可在 Panel 页签栏拖拽 Hyper Git 到期望位置，VS Code 会持久化该布局。
+
+### 已知边界：未提交计数角标的可见性变化
+
+迁移到底部 Panel 后，**活动栏不再保留 Hyper Git 入口图标**，因此 [issue #10](../.agents/issue.md) 修复的「面板未打开也持续显示」未提交计数角标随之失效——**未提交计数仅在 Panel 展开（且 Hyper Git 页签可见）时呈现**。这是 VS Code 平台行为：activitybar 容器图标支持「未聚焦也聚合」的一等 badge，而 panel 容器页签的 badge 受 Panel 展开/收起态约束。
+
+> 若你希望恢复「始终可见」的未提交计数，欢迎在 [GitHub Issues](https://github.com/ThreeFish-AI/hyper-git/issues) 反馈，可考虑后续提供「双容器（Panel 主面板 + 活动栏轻量角标）」或「状态栏计数器」补救方案。
+
+---
+
+## ⚙️ 升级与兼容
+
+- **无破坏性变更**：仅 `package.json` 的 dock 字段变更，未改动 `viewType`、消息协议、`setState` 形状或配置项，旧状态无需迁移。
+- **老用户需重置视图布局**：VS Code 会记忆旧的 activitybar 位置，从 v0.0.12 升级后，Hyper Git 可能仍出现在活动栏。执行以下任一操作即可采用新的 Panel 默认：
+  - 命令面板（`Cmd/Ctrl + Shift + P`）→ 输入 **「View: Reset View Locations」**；
+  - 或在 Panel / 活动栏中右键 Hyper Git 图标 → **「Reset Location」**。
+- **页签顺序微调**：如希望 Hyper Git 页签紧邻 Terminal，在 Panel 页签栏拖拽即可，VS Code 会持久化。
+
+---
+
+## 📦 安装
+
+- **VS Code Marketplace**：搜索 `Hyper Git - Agentic Git` 直接安装。
+- **手动**：从 [Releases](https://github.com/ThreeFish-AI/hyper-git/releases/tag/v0.0.13) 下载 `hyper-git-agentic-git-0.0.13.vsix` → 命令面板 `Extensions: Install from VSIX`（Cursor / Windsurf / VSCodium 等用户可经此方式安装）。
+
+**系统要求**：VS Code ≥ 1.85.0，且启用内置 Git 扩展（`vscode.git`，默认随附）。仅支持本地 git 仓库，不支持虚拟 / Web 工作区。
+
+---
+
+## 💬 反馈
+
+欢迎在 [GitHub Issues](https://github.com/ThreeFish-AI/hyper-git/issues) 反馈问题与建议。完整工程视角变更记录见 [CHANGELOG](../../CHANGELOG.md)。
+
+许可证：[MIT](https://github.com/ThreeFish-AI/hyper-git/blob/master/LICENSE)。

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"theme": "dark"
 	},
 	"description": "Hyper Git brings IntelliJ IDEA's powerful Git & Commit modules to VS Code, enhanced with AI-powered autonomous agents for intelligent repository management. Experience Git in a higher dimension.",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"publisher": "ThreeFish-AI",
 	"license": "MIT",
 	"preview": true,
@@ -48,7 +48,7 @@
 	"main": "./dist/extension.js",
 	"contributes": {
 		"viewsContainers": {
-			"activitybar": [
+			"panel": [
 				{
 					"id": "hyper-git",
 					"title": "Hyper Git",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,9 +99,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	const blame = new BlameAnnotationController(service);
 	const shelfService = new ShelfService(service, context.globalStorageUri.fsPath);
 	const shelfTree = new ShelfTreeProvider(shelfService);
-	// 活动栏未提交数角标承载：隐藏 TreeView（package.json 中 when:false，永不渲染）。createTreeView 于
-	// activate 即实例化视图对象，其 badge 无论面板是否打开都可靠聚合到容器图标——规避 WebviewView.badge
-	// 在 resolveWebviewView（用户至少打开过一次视图）前无法显示的已知限制（microsoft/vscode#164974、#146330）。
+	// 未提交数角标承载：隐藏 TreeView（package.json 中 when:false，永不渲染）。createTreeView 于 activate
+	// 即实例化视图对象，其 badge 聚合到容器图标/页签——规避 WebviewView.badge 在 resolveWebviewView（用户
+	// 至少打开过一次视图）前无法显示的已知限制（microsoft/vscode#164974、#146330）。v0.0.13 起容器由活动栏
+	// 迁至底部 Panel（issue #13）：角标仅在 Panel 展开时可见，活动栏「始终可见」特性失效（用户已接受 trade-off）。
 	// 复用占位 EmptyTreeProvider（空树）。
 	const badgeView = vscode.window.createTreeView('hyperGit.changesBadge', {
 		treeDataProvider: new EmptyTreeProvider(),
@@ -150,15 +151,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		registerInlineCommitCommand(service, inlineLens),
 	);
 
-	// 活动栏未提交数角标：承载于隐藏的 changesBadge TreeView（见其创建处说明）。
+	// 未提交数角标：承载于隐藏的 changesBadge TreeView（见其创建处说明）。
 	// 计数复用 service.getChangeCount()（index+工作区+未跟踪去重），为 0 时清空，对齐原生 SCM 行为。
+	// v0.0.13：容器迁至 Panel 后，角标仅在 Panel 展开时聚合显示（issue #13）。
 	const updateBadge = (): void => {
 		const n = service.getChangeCount();
 		badgeView.badge = n > 0 ? { value: n, tooltip: `${n} uncommitted change(s)` } : undefined;
 	};
 
-	// 角标走独立快路径（~40ms 微防抖）：面板即便未打开也近实时更新，并合并 add -A/checkout 等事件风暴，
-	// 与下方重刷新（150ms）解耦，避免被 log/branches 等高频重拉阻塞。
+	// 角标走独立快路径（~40ms 微防抖）：即便视图未 resolve / Panel 未激活也近实时更新计数（Panel 展开即呈现），
+	// 并合并 add -A/checkout 等事件风暴，与下方重刷新（150ms）解耦，避免被 log/branches 等高频重拉阻塞。
 	let badgeTimer: ReturnType<typeof setTimeout> | undefined;
 	const scheduleBadge = (): void => {
 		clearTimeout(badgeTimer);


### PR DESCRIPTION
## 改动摘要

将 Hyper Git 视图容器从活动栏（Activity Bar / Primary Side Bar）迁移至**底部面板（Panel）**，默认排在 Terminal 页签之后。

- **核心改动**：`package.json:51` 单行 `"activitybar"` → `"panel"`；版本号 `0.0.12` → `0.0.13`。
- **零回归**：容器 id `hyper-git` 与全部 7 个视图（Commit / Graph / Branches / Stash / Shelf / Worktrees / changesBadge）不变；`.ts` 源码、`media/hyper-git-icon.svg`（24×24 单色）均无需改动——dock 类型与 views 归属、API 调用、图标规范完全解耦。
- **配套文档**：CHANGELOG v0.0.13、[Release Note v0.0.13](docs/releases/v0.0.13.md)、[issue #13](docs/.agents/issue.md)（dock 迁移决策 + badge 权衡）、knowledge-map 最新 release 链接、`extension.ts` 三处注释措辞同步。

## 为什么

用户诉求：将 Hyper Git 从默认的左侧活动栏迁移到底部面板，与官方 Terminal / Output / Problems 提供一致的底部停靠体验。

## Trade-off（已与用户确认接受）

迁移后**活动栏不再保留 Hyper Git 入口图标**，[issue #10](docs/.agents/issue.md) 修复的「面板未打开也持续显示」未提交计数角标随之失效——**未提交计数仅在 Panel 展开时可见**。这是 VS Code 平台行为：activitybar 容器图标支持「未聚焦也聚合」的一等 badge，panel 容器页签 badge 受 Panel 展开/收起态约束。用户经评估后明确接受此 trade-off，不引入双容器或状态栏计数器补救。详见 [issue #13](docs/.agents/issue.md)。

## 页签顺序

VS Code 平台不提供精确控制 Panel 内页签顺序的 contribution point；新安装扩展的容器默认**追加在内置页签（Terminal / Output / Problems / Debug Console）之后**。如需紧邻 Terminal，可在 Panel 页签栏拖拽微调，VS Code 会持久化。

## 老用户兼容

VS Code 会记忆旧的 activitybar 位置，从 v0.0.12 升级后 Hyper Git 可能仍出现在活动栏。执行以下任一操作即可采用新的 Panel 默认：
- 命令面板（`Cmd/Ctrl + Shift + P`）→ 「View: Reset View Locations」；
- 或右键 Hyper Git 图标 → 「Reset Location」。

无破坏性变更：`viewType`、消息协议、`webview.setState` 形状、配置项全部不变，旧状态无需迁移。

## 验证

- ✅ `pnpm run compile`（check-types + lint + esbuild）零错误
- ⏳ **建议 reviewer 实机回归**（须用干净 profile，规避 VS Code 记忆的旧 activitybar 布局，见 issue #12 防范 ②）：容器位置、页签顺序、7 视图加载、changesBadge 计数、老用户 Reset 路径

## 不在本次范围

- `initialSize` 值调整（语义从高度权重变主轴权重，值不改；若实测水平 Panel 下视图过挤，作为独立后续 PR）
- 双容器 / 状态栏角标回退方案（用户已决策接受 trade-off）
- 精确「紧邻 Terminal」顺序控制（平台不支持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
