### PR TITLE
ci(dependabot): 忽略 typescript major 版本升级（TS7 工具链未适配）

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
       # @types/vscode 的 major.minor ≤ engines.vscode）。Dependabot 单方面 bump 会破坏该约束
       # 并令 CI 的 vsce package 失败，故忽略其升级——抬高最低 VS Code 版本属产品决策，需人工执行。
       - dependency-name: '@types/vscode'
+      # typescript 7.0（Go 原生移植 tsgo）刻意未提供编译器编程 API（延至 7.1），typescript-eslint
+      # 无法运行于 TS7，加载期访问 ts.Extension.Cjs 触发崩溃，使 CI 的 lint 失败（详见
+      # typescript-eslint#12518，closed as not planned）。故忽略 typescript 的 major 升级——
+      # 待 TS 7.1 稳定编程 API 与工具链适配后再由人工重启升级。次要/补丁版仍照常跟进。
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions
     directory: /
     target-branch: feature/1.x.x


### PR DESCRIPTION
## 背景

Dependabot 生成的 #99（`typescript` 6.0.3 → 7.0.2）在 CI 的 `Lint & Build` 阶段崩溃，阻塞了 `feature/1.x.x` 上的依赖集成流。经排查，该失败并非本仓库代码问题（`tsc --noEmit` 在 7.0.2 下通过），而是工具链与 TypeScript 7.0 的上游不兼容。

## 根因

- **TypeScript 7.0**（Go 原生移植 tsgo/Corsa，2026-07-08 GA）为「移植」而非重写，**刻意未保留编译器编程 API**，该稳定 API 延至 **7.1**。
- 本仓库以 **typescript-eslint** 做类型感知 lint（`eslint.config.mjs` 引入 `tseslint.configs.recommended`）。`@typescript-eslint/typescript-estree` 在模块加载期访问 `ts.Extension.Cjs`，TS7 下该符号为 `undefined`，直接抛出 `TypeError: Cannot read properties of undefined (reading 'Cjs')`。
- 该问题官方追踪于 [typescript-eslint#12518](https://github.com/typescript-eslint/typescript-eslint/issues/12518)（2026-07-08 提出，**closed as not planned**）——修复须来自 TS 7.1，非 typescript-eslint。所有已发布版本（含本轮 #97 的 8.64.0）peer 均锁 `typescript >=4.8.4 <6.1.0`。

因此靠升级依赖无法在 7.0.2 下修复 lint；强合并将破坏集成分支 CI。

## 变更内容

在 `.github/dependabot.yml` 的 npm 生态 `ignore` 列表新增：忽略 `typescript` 的 **semver-major** 升级（附中文注释说明根因并引用 #12518）。次要/补丁版本仍照常跟进。此举与文件中既有 `@types/vscode` 忽略先例同类——均为「会破坏工具链/产品约束、需人工决策」的升级。

## 影响与后续

- Dependabot 不再每周重复开启 TS major 升级 PR；#99 将随规则生效被关闭。
- 待 **TypeScript 7.1** 提供稳定编程 API 且 typescript-eslint 适配后，由人工移除本忽略规则、重启 TS 大版本升级。

## 参考

- [Announcing TypeScript 7.0](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/)
- [typescript-eslint · Dependency Versions](https://typescript-eslint.io/users/dependency-versions/)
- [typescript-eslint#12518 — TypeScript 7.0.2 Support](https://github.com/typescript-eslint/typescript-eslint/issues/12518)