### PR TITLE
feat(UI): 全面对齐 VS Code 1.136 最佳实践——修复 9 项缺陷并系统性升级控件/交互/API 适配

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,39 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Merge 编辑器「保存→拒绝强制保存→取消」路径失效**：webview 回调内重复调用 `acquireVsCodeApi()`（每个 webview 仅允许调用一次，第二次抛异常），改为脚本顶部获取后全程复用；交互式 Rebase 确认执行同理（[issue #17](./docs/.agents/issue.md)）。
+- **Commit 草稿丢失**：视图隐藏销毁后 message/amend/signoff/skipHooks 全部丢失且模板重灌覆盖。webview state 升 v3 按仓库持久化草稿，输入即时落盘（消除 200ms 防抖尾丢），提交成功清空（[issue #18](./docs/.agents/issue.md)）。
+- **切换深浅主题后 Graph 泳道色/引用胶囊停留旧主题**：泳道色原为启动期一次性快照，补 `MutationObserver` 监听 body 属性热重算并重渲（webview 不随主题切换重载）。
+- **分支树文件夹节点出现分支级菜单**：11 处 `viewItem =~` 正则未锚定误匹配 `hyperGit.branchFolder`（含 `hyperGit.branch` 子串），全部补 `^…$` 锚定。
+- **CLI 通道失败不可诊断**：`execFile` 丢弃 stderr，现透传挂到错误对象并记入 Console（与 vscode.git API 通道的 GitError.stderr 提取对齐）。
+- **交互 Rebase 的 reword 可能拉起新 VS Code 窗口**：`GIT_EDITOR` 经 `process.execPath`（扩展宿主内为 Electron 二进制）运行 helper，补 `ELECTRON_RUN_AS_NODE=1`。
+- **窗口 reload 后 Rebase / Merge 面板空白**：两个 `retainContextWhenHidden` 面板补 `registerWebviewPanelSerializer`（Rebase 按 webview state 恢复用户编辑后的 todo，Merge 按 filePath 重拉冲突三阶段）。
+- **git 扩展不可用时 Branches/Stash/Shelf 视图报 "no tree view registered"**：补空 provider（viewsWelcome 正常触发），Commit/Graph 渲染静态占位说明页。
+- **Blame 注解**：悬浮信息换行折叠（改 MarkdownString）；split 编辑器无注解、已关闭文档条目泄漏（订阅可见编辑器变化统一挂载/清理）。
+
+### Added
+
+- **长时 git 操作进度反馈**：pull/push/fetch/merge/rebase/cherry-pick/reset/updateProject 等以 `withProgress` 呈现（默认标题栏非阻塞，Update Project 与交互 Rebase 用通知位）；git 操作失败通知附 "Show Output" 按钮直达 Console。
+- **入门导览与默认键位**：新增 `walkthroughs` 贡献点（Get Started with Hyper Git，5 步导览）；默认键位 Alt+B 切换 Blame 注解、Alt+G 打开 Graph 过滤（Commit 输入框 Ctrl/Cmd+Enter 提交原有内建保留）。
+- **Stash / Worktrees 批量操作**：两视图启用多选（批量 Drop 按 index 降序防位移、批量 Remove 跳过 main/当前打开项）；新建 stash/worktree/shelf 后聚焦对应视图；provider 加载失败经 `TreeView.message` 内联呈现。
+- **分支/标签名即时校验**：新增 `engine/ref/ref-name.validateRefName` 纯函数（git check-ref-format 的 UI 子集，9 组单测矩阵），挂接全部 8 处分支/标签名输入框。
+- **QuickPick 体验**：提交选择器补 `matchOnDescription/matchOnDetail`（hash 前缀可搜）；Rebase base 与标签目标选择插 `QuickPickItemKind.Separator` 分段；Commit 文件菜单补 `$(codicon)` 图标。
+- **Commit 文件列表键盘导航**：容器级焦点 + ArrowUp/Down/Home/End/Enter/Escape（复刻 Graph 模式）；Rebase 拖拽补 Alt+↑/↓ 键盘替代，确认层补 Escape/焦点圈禁/焦点还原。
+
 ### Changed
+
+- **Webview 控件全面主题化**：滚动条走 `--vscode-scrollbarSlider-*`、checkbox `accent-color`、下拉统一 `--vscode-dropdown-*`（`.hg-select` 基类）、阴影 `--vscode-widget-shadow`；字号全线以 `--vscode-font-size` 为基准 calc 派生（随用户字号设置缩放）；高对比度主题下 Graph 彩色胶囊改描边呈现；Graph 行高/泳道列宽常量单源化。
+- **文件状态点改字母标记**：Commit 视图 `●` 色点改为 M/A/U/R/D/C 着色字母（色盲可辨，对齐官方 SCM 与 Graph 面板）；8 处 Unicode 字符图标全部 SVG 化（折叠箭头/省略号/关闭/导航/空态/merge 标记）。
+- **日志通道现代化**：两 OutputChannel 迁 `LogOutputChannel`（自动时间戳与级别、统一日志视图），懒创建并随扩展释放。
+- **确认对话框多行正文迁 `MessageOptions.detail`**（本地/远程分支删除、Worktree 删除/prune）；用户可见文案统一英文（分支删除确认、Conventional Commits 校验提示）。
+- **能力声明与设置治理**：补 `extensionKind: workspace` 与 `untrustedWorkspaces: unsupported`；11 项设置补 `scope`；5 个预留设置（`ai.enabled` + `agent.*`）描述标注 Reserved 且默认值清除个人化内容（**默认值变更**：agent 偏好默认由内置模板改为空，即内置默认——此前内嵌个人签名等内容不再分发）；palette 补 when 限定（Graph scope/List-Tree 切换、Accept Ours/Theirs 按冲突态显隐）。
+- **同步 IO 清理**：Shelf 服务全量迁 `fs.promises`（原 `listShelves` 同步读阻塞 UI 线程）；Worktree 路径归一 realpath 记忆化。
+
+### Docs
+
+
 
 - **Graph 视图工具栏整体上移 VS Code 标题栏（省一整行竖直空间）**：scope（All / Current / Checkpoints）改为 `$(layers)` 图标下拉子菜单（`toggled` 勾选、默认 All，置于 Refresh Graph 图标左侧）；仓库路径常驻 `WebviewView.description` 副标题（标题「Graph」同行右侧）；多仓库态「切换仓库」`$(repo)` 图标按钮与 CI「登录 GitHub」`$(sign-in)` 图标按钮（授权后自动隐藏）条件显隐；Changed Files 的 List ⇄ Tree 切换改为 `$(list-tree)`/`$(list-flat)` 互斥图标（交互同 Branches 分组切换，文案适配为 "Group Changed Files by Directory" / "Show Changed Files as Flat List"）。scope 与 List/Tree 偏好随之移交 host `workspaceState` 按仓库持久化（`hyperGit.log.scope:<repo>` / `hyperGit.log.dmode:<repo>`）——**原 webview state 中的旧偏好一次性重置为默认**（All / flat；选中与目录折叠不受影响）。
 - **提交详情三区分割线可拖拽**：图 ⇄ 面板（横向面板 ≥200px 且图区 ≥280px、纵向 18%–75%）与面板内 Changed Files ⇄ Commit 信息（15%–85%）两根 gutter，实时调比例、按仓库记忆、键盘可达（方向键 ±2%、Home/End 归边界）。

--- a/docs/.agents/issue.md
+++ b/docs/.agents/issue.md
@@ -148,3 +148,19 @@
 - **处理方式**：落地全局活跃仓库切换（Git Graph 模式）——① 选取逻辑下沉纯函数 `engine/git-state/repo-selection.ts`（三级优先：持久化恢复 → folder0 匹配 → 首个仓库，路径归一化跨平台稳定），`GitRepositoryService` 新增 `selectRepository`/`listRepositories`/`onDidChangeRepository`，活跃仓库持久化 `hyperGit.activeRepoRoot`；② **三重顺序不变量**保证 rebind 先于刷新：`applyRepository` 内先 fire 切换事件（同步 rebind：registry/favorites/branchesTree.setRepoRoot + context key 同步 + blame 清理 + filter 清空）后 fire onDidChange（防抖刷新），且 rebind 订阅先于 `refreshAll` 注册；③ Shelf 目录随 `service.repoRoot` 动态求值（`shelves/<basename>.<sha1[:8]>/`）+ 旧平铺数据一次性安全迁移（仅 rename、目标存在即跳过、失败可重试）；④ Graph 工具栏仓库名升级可点击按钮（单仓库退化纯文本）+ `hyperGit.selectRepository` palette 命令（带参=程序化切换接缝，`activate()` 导出 `{ service }` 供集成测试）；⑤ webview 视图状态（scope/选中/勾选集等）v2 `byRepo` 分区 + 最近提交消息 per-repo key（旧 key 回落一次平滑迁移）。集成测试新增 multi-root 双仓库 fixture 套件（`tests/suite/multi-root.test.js`）。
 - **后续防范**：① **新增组件若构造期快照 repoRoot（拼 memento key / 存储目录），必须订阅 `service.onDidChangeRepository` 重绑**——可用 `grep -rn 'repoRoot' src/adapter/ | grep -v 'service.repoRoot'` 扫描快照点；② 集成测试需 UI 交互时，优先给命令 handler 加可选参数（无参=QuickPick，带参=程序化）+ `activate()` 导出接缝，勿依赖无法自动化的原生弹窗；③ 顺带修复了既有激活竞态（repo 发现晚于 activate 时 memento key 落 workspaceRoot 占位），rebind 事件会纠正——但根治应在「窗口内无写入路径」前提下依赖该纠正，勿在激活早期引入持久化写入。
 - **同类问题影响**：所有围绕「单一活跃仓库」装配的 VS Code Git 扩展；凡按 repoRoot 构造 workspaceState/globalStorage 键或存储目录、却不在仓库集合变化时重绑的实现；以及 macOS 上 VS Code ≥ 1.110 主二进制 `Electron`→`Code` 更名导致 `@vscode/test-electron` 旧版 ENOENT 的集成测试环境（升 3.1.0 解决，见 PR #102）。
+
+## #17 Webview 内联脚本回调中重复调用 acquireVsCodeApi()
+
+- **表因**：Merge 编辑器点击 Save → 拒绝「强制保存」确认 → 点击 Cancel 时按钮无响应；交互 Rebase 冲突失败后重试同理。控制台报 `An instance of the VS Code API has already been acquired`。
+- **根因**：`acquireVsCodeApi()` 每个 webview 全局仅允许成功调用一次（VS Code API 设计约束），第二次调用抛异常。merge-editor 与 rebase-webview 在事件回调内现场调用（`document.getElementById('save').onclick = function(){ acquireVsCodeApi().postMessage(...) }`），首次执行某回调成功后，任何其他回调再调用即崩溃。
+- **处理方式**：脚本顶部 `const vscode = acquireVsCodeApi();` 获取一次，全部回调复用（commit/log webview 本就是此写法）。落地见 `fix(Webview)` 批次。
+- **后续防范**：webview 内联脚本一律顶部单次获取；review 时 `grep -n "acquireVsCodeApi" src/adapter/webview/` 应只命中每文件脚本顶部一处调用。
+- **同类问题影响**：所有自绘 webview 的扩展；回调/异步分支中按需获取 API 的惰性写法均存在此雷。
+
+## #18 Commit 视图草稿随视图销毁丢失（state 未覆盖 + 模板重灌覆盖）
+
+- **表因**：Commit 视图切走再切回（或折叠 Panel 展开），已输入的提交信息与 amend/signoff/skipHooks 勾选全部丢失，模板重新灌入。
+- **根因**：复合缺陷——① WebviewView 未设 `retainContextWhenHidden`，隐藏即销毁；② `vscode.getState()` 只持久化 checked/mode/collapsed，不含草稿；③ message 输入经 200ms debounce 才 postMessage 到 host，销毁前最后一段输入连 host 侧 `currentMessage` 都未到达；④ 重建时模板注入逻辑因 textarea 为空而重新灌模板。内置 SCM 输入框草稿跨销毁可恢复，对比形成 UX 回归。
+- **处理方式**：webview state v3 在 `byRepo` 分区新增 `draft`（message + 三勾选）；输入/勾选变更即时 `saveState()` 落盘（消除 debounce 尾丢）；回灌仅限「重建首帧/切换仓库」两时机且先于 `reconcileChecked`（避免 state 推送往返覆盖当前编辑）；提交成功清空草稿。未采用 `retainContextWhenHidden`（钉死整个 webview 内存，且不跨窗口 reload）。
+- **后续防范**：webview 内用户编辑态一律显式入 `setState`（含 debounce 之外的即时落盘点）；回灌逻辑必须有时机守卫（一次性/切换触发），并注意「先回灌 DOM、后执行任何从 DOM 取数回写 state」的顺序。
+- **同类问题影响**：所有自绘 WebviewView 承载编辑器的扩展；凡输入经防抖上报宿主的模式都存在尾丢窗口。

--- a/media/hyper-git-icon.svg
+++ b/media/hyper-git-icon.svg
@@ -1,4 +1,4 @@
-<!-- Hyper Git activity-bar icon. Single-color (currentColor); VS Code recolors via alpha mask. Glyph adapted from Tabler Icons (MIT). -->
+<!-- Hyper Git container icon (bottom Panel since v0.0.13; also applies if the container is dragged back to a sidebar). Single-color (currentColor); VS Code recolors via alpha mask. Glyph adapted from Tabler Icons (MIT). -->
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg">
   <circle cx="6" cy="6" r="2" />
   <circle cx="6" cy="18" r="2" />

--- a/media/walkthrough/branches.md
+++ b/media/walkthrough/branches.md
@@ -1,0 +1,7 @@
+The **Branches** view covers ref management:
+
+- Group branches **by `/` prefix** or keep them flat
+- Multi-select to delete, favorite, or copy refs in bulk
+- Right-click for checkout, merge, rebase, compare, and cleanup of merged branches
+
+[Open the Branches view](command:hyperGit.branches.focus)

--- a/media/walkthrough/commit.md
+++ b/media/walkthrough/commit.md
@@ -1,0 +1,10 @@
+The **Commit** view consolidates the whole commit flow:
+
+- Group work into multiple **changelists** and commit them independently
+- Pick files with checkboxes, browse **flat or directory-tree** layouts
+- Write the message with live **Conventional Commits** validation
+- Reuse recent messages, amend, sign off, or skip hooks under *Advanced Options*
+
+Press `Ctrl/Cmd+Enter` in the message box to commit.
+
+[Open the Commit view](command:hyperGit.commit.focus)

--- a/media/walkthrough/graph.md
+++ b/media/walkthrough/graph.md
@@ -1,0 +1,7 @@
+The **Graph** view renders the commit graph with lanes, ref chips and CI status:
+
+- Switch scope between **All commits**, the **current branch**, and **checkpoints**
+- Filter by author, path, message (text or regex), date, and merge mode
+- Click a commit to open the resident details panel — changed files, message, and stats
+
+[Open the Graph view](command:hyperGit.log.focus)

--- a/media/walkthrough/panel.md
+++ b/media/walkthrough/panel.md
@@ -1,0 +1,8 @@
+All Hyper Git views live in the **Hyper Git** container in the bottom panel:
+
+- **Commit** — the IntelliJ-style commit window
+- **Graph** — commit graph with filters and CI status
+- **Branches** — local / remote branches and tags
+- **Worktrees**, **Stash**, **Shelf** — parallel work and shelving
+
+[Open the Hyper Git panel](command:hyperGit.commit.focus)

--- a/media/walkthrough/stash.md
+++ b/media/walkthrough/stash.md
@@ -1,0 +1,6 @@
+Beyond stash, Hyper Git brings two IntelliJ favorites:
+
+- **Shelf** — store patches per changelist independently of git stash
+- **Worktrees** — check out multiple branches in parallel working directories
+
+[Open the Worktrees view](command:hyperGit.worktrees.focus)

--- a/package.json
+++ b/package.json
@@ -54,6 +54,56 @@
 		"workspace"
 	],
 	"contributes": {
+		"walkthroughs": [
+			{
+				"id": "hyperGit.getStarted",
+				"title": "Get Started with Hyper Git",
+				"description": "Bring IntelliJ IDEA's Git & Commit workflow into VS Code — changelists, an interactive commit window, a rich graph, shelf, stash, and worktrees.",
+				"steps": [
+					{
+						"id": "panel",
+						"title": "Open the Hyper Git panel",
+						"description": "Find every Hyper Git view in the bottom panel.",
+						"media": {
+							"markdown": "media/walkthrough/panel.md"
+						}
+					},
+					{
+						"id": "commit",
+						"title": "Commit with changelists",
+						"description": "Group changes into changelists and commit them independently, with live Conventional Commits validation.",
+						"media": {
+							"markdown": "media/walkthrough/commit.md"
+						},
+						"primary": true
+					},
+					{
+						"id": "graph",
+						"title": "Explore the commit graph",
+						"description": "Filter the graph, check CI status, and inspect any commit in the details panel.",
+						"media": {
+							"markdown": "media/walkthrough/graph.md"
+						}
+					},
+					{
+						"id": "branches",
+						"title": "Manage branches and tags",
+						"description": "Group, multi-select, and act on refs from one tree.",
+						"media": {
+							"markdown": "media/walkthrough/branches.md"
+						}
+					},
+					{
+						"id": "stash",
+						"title": "Shelf, stash, and worktrees",
+						"description": "Shelve patches per changelist, stash changes, and work on branches in parallel worktrees.",
+						"media": {
+							"markdown": "media/walkthrough/stash.md"
+						}
+					}
+				]
+			}
+		],
 		"viewsContainers": {
 			"panel": [
 				{
@@ -1418,7 +1468,19 @@
 					"scope": "resource"
 				}
 			}
-		}
+		},
+		"keybindings": [
+			{
+				"command": "hyperGit.toggleBlameAnnotation",
+				"key": "alt+b",
+				"when": "editorTextFocus"
+			},
+			{
+				"command": "hyperGit.logFilter",
+				"key": "alt+g",
+				"when": "focusedView == hyperGit.log"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "pnpm run package",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
 		"virtualWorkspaces": {
 			"supported": false,
 			"description": "Hyper Git 依赖本地 git，不支持虚拟/web 工作区。"
+		},
+		"untrustedWorkspaces": {
+			"supported": false,
+			"description": "Hyper Git runs git commands that can commit, push and discard changes. Enable it only in workspaces you trust."
 		}
 	},
 	"extensionDependencies": [
@@ -46,6 +50,9 @@
 	],
 	"activationEvents": [],
 	"main": "./dist/extension.js",
+	"extensionKind": [
+		"workspace"
+	],
 	"contributes": {
 		"viewsContainers": {
 			"panel": [
@@ -63,38 +70,44 @@
 					"name": "Commit",
 					"type": "webview",
 					"visibility": "collapsed",
-					"initialSize": 3
+					"initialSize": 3,
+					"contextualTitle": "Hyper Git"
 				},
 				{
 					"id": "hyperGit.branches",
 					"name": "Branches",
 					"visibility": "visible",
-					"initialSize": 2
+					"initialSize": 2,
+					"contextualTitle": "Hyper Git"
 				},
 				{
 					"id": "hyperGit.log",
 					"name": "Graph",
 					"type": "webview",
 					"visibility": "visible",
-					"initialSize": 3
+					"initialSize": 3,
+					"contextualTitle": "Hyper Git"
 				},
 				{
 					"id": "hyperGit.worktrees",
 					"name": "Worktrees",
 					"visibility": "collapsed",
-					"initialSize": 1
+					"initialSize": 1,
+					"contextualTitle": "Hyper Git"
 				},
 				{
 					"id": "hyperGit.stash",
 					"name": "Stash",
 					"visibility": "hidden",
-					"initialSize": 1
+					"initialSize": 1,
+					"contextualTitle": "Hyper Git"
 				},
 				{
 					"id": "hyperGit.shelf",
 					"name": "Shelf",
 					"visibility": "hidden",
-					"initialSize": 1
+					"initialSize": 1,
+					"contextualTitle": "Hyper Git"
 				},
 				{
 					"id": "hyperGit.changesBadge",
@@ -305,7 +318,7 @@
 				"command": "hyperGit.rebaseBranch",
 				"title": "Rebase Current Branch onto…",
 				"category": "Hyper Git",
-				"icon": "$(call-out)"
+				"icon": "$(arrow-right)"
 			},
 			{
 				"command": "hyperGit.showBlame",
@@ -399,7 +412,7 @@
 				"command": "hyperGit.ignorePath",
 				"title": "Add to .gitignore",
 				"category": "Hyper Git",
-				"icon": "$(eye-closed)"
+				"icon": "$(diff-ignored)"
 			},
 			{
 				"command": "hyperGit.compareBranches",
@@ -625,7 +638,7 @@
 				"command": "hyperGit.startRebase",
 				"title": "Interactive Rebase…",
 				"category": "Hyper Git",
-				"icon": "$(call-out)"
+				"icon": "$(arrow-right)"
 			},
 			{
 				"command": "hyperGit.moveHunkToChangelist",
@@ -942,7 +955,7 @@
 			"view/item/context": [
 				{
 					"command": "hyperGit.branchCheckout",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/ && !listMultiSelection",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/ && !listMultiSelection",
 					"group": "1_branch@1"
 				},
 				{
@@ -957,12 +970,12 @@
 				},
 				{
 					"command": "hyperGit.mergeBranch",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/ && !listMultiSelection",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/ && !listMultiSelection",
 					"group": "1_branch@3"
 				},
 				{
 					"command": "hyperGit.rebaseBranch",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/ && !listMultiSelection",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/ && !listMultiSelection",
 					"group": "1_branch@4"
 				},
 				{
@@ -972,32 +985,32 @@
 				},
 				{
 					"command": "hyperGit.compareBranches",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/ && !listMultiSelection",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/ && !listMultiSelection",
 					"group": "1_branch@6"
 				},
 				{
 					"command": "hyperGit.copyBranchRef",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/",
 					"group": "1_branch@7"
 				},
 				{
 					"command": "hyperGit.toggleFavorite",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/",
 					"group": "inline"
 				},
 				{
 					"command": "hyperGit.toggleFavorite",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/",
 					"group": "1_branch@0"
 				},
 				{
 					"command": "hyperGit.checkoutAsNew",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch/ && !listMultiSelection",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch)$/ && !listMultiSelection",
 					"group": "1_branch@1.5"
 				},
 				{
 					"command": "hyperGit.compareWithCurrent",
-					"when": "view == hyperGit.branches && viewItem =~ /hyperGit.branch|hyperGit.remoteBranch|hyperGit.tag/ && !listMultiSelection",
+					"when": "view == hyperGit.branches && viewItem =~ /^(hyperGit.branch|hyperGit.remoteBranch|hyperGit.tag)$/ && !listMultiSelection",
 					"group": "1_branch@8"
 				},
 				{
@@ -1047,7 +1060,7 @@
 				},
 				{
 					"command": "hyperGit.worktreeOpen",
-					"when": "view == hyperGit.worktrees && viewItem =~ /hyperGit.worktree|hyperGit.worktreeMain/",
+					"when": "view == hyperGit.worktrees && viewItem =~ /^(hyperGit.worktree|hyperGit.worktreeMain)$/",
 					"group": "1_wt@1"
 				},
 				{
@@ -1067,7 +1080,7 @@
 				},
 				{
 					"command": "hyperGit.worktreeCopyPath",
-					"when": "view == hyperGit.worktrees && viewItem =~ /hyperGit.worktree|hyperGit.worktreeMain/",
+					"when": "view == hyperGit.worktrees && viewItem =~ /^(hyperGit.worktree|hyperGit.worktreeMain)$/",
 					"group": "1_wt@5"
 				},
 				{
@@ -1291,6 +1304,34 @@
 				{
 					"command": "hyperGit.logFilterDate",
 					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.log.scopeAll",
+					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.log.scopeCurrent",
+					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.log.scopeCheckpointer",
+					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.log.detailTree",
+					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.log.detailFlat",
+					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.acceptOurs",
+					"when": "hyperGit.hasConflicts"
+				},
+				{
+					"command": "hyperGit.acceptTheirs",
+					"when": "hyperGit.hasConflicts"
 				}
 			]
 		},
@@ -1300,55 +1341,65 @@
 				"hyperGit.commit.template": {
 					"type": "string",
 					"default": "",
-					"markdownDescription": "Commit message template (injected into the Commit view editor)."
+					"markdownDescription": "Commit message template (injected into the Commit view editor).",
+					"scope": "resource"
 				},
 				"hyperGit.commit.conventional": {
 					"type": "boolean",
 					"default": true,
-					"markdownDescription": "Run real-time Conventional Commits validation on commit messages."
+					"markdownDescription": "Run real-time Conventional Commits validation on commit messages.",
+					"scope": "resource"
 				},
 				"hyperGit.ai.enabled": {
 					"type": "boolean",
 					"default": false,
-					"markdownDescription": "Enable AI agent capabilities (currently reserved as an architectural seam; not yet active)."
+					"markdownDescription": "**Reserved** for the upcoming Agentic Git release. This switch has no effect in the current version.",
+					"scope": "resource"
 				},
 				"hyperGit.claudeCode.executablePath": {
 					"type": "string",
 					"default": "",
-					"markdownDescription": "Path to the Claude Code CLI executable used by Hyper Git's Agentic Git features. Leave empty to auto-detect the `claude` binary from your `PATH` (recommended).\n\n[Browse for executable…](command:hyperGit.setClaudeCodePath) · [Open Claude settings (`~/.claude/settings.json`)](command:hyperGit.openClaudeSettings)"
+					"markdownDescription": "Path to the Claude Code CLI executable used by Hyper Git's Agentic Git features. Leave empty to auto-detect the `claude` binary from your `PATH` (recommended).\n\n[Browse for executable…](command:hyperGit.setClaudeCodePath) · [Open Claude settings (`~/.claude/settings.json`)](command:hyperGit.openClaudeSettings)",
+					"scope": "machine-overridable"
 				},
 				"hyperGit.agent.baseBranch": {
 					"type": "string",
 					"default": "",
-					"markdownDescription": "Base branch used as the baseline when creating a pull request. Leave empty to use the repository's default branch."
+					"markdownDescription": "**Reserved** for the upcoming Agentic Git release (no effect yet). Base branch used as the baseline when creating a pull request. Leave empty to use the repository's default branch.",
+					"scope": "window"
 				},
 				"hyperGit.agent.commitPreferences": {
 					"type": "string",
 					"editPresentation": "multilineText",
-					"default": "---\ndescription: \"Commit changes to Git\"\n---\n\nCommit the project's file changes to Git, keeping the commit message clear and concise.\n\n## Workflow\n\n1. Before committing, pull the latest version of the current branch from the remote:\n\n  ```bash\n  git pull\n  ```\n\n2. Commit the changes in well-planned batches with prepared commit messages.\n3. Run `git push` to push the current branch to the GitHub remote.\n\n## Notes\n\n- Do not modify the repository contents again at this point; deleting repository content (or files) is never allowed at any time.\n- When appropriate, split the commit into multiple batches by content category; for a file move, do not split it into separate delete and add operations — commit it as a single file-move operation.\n- Write commit messages in Chinese, using the following signature format:\n  ```\n  🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)\n  Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>\n  ```\n\n## Commit Message Convention\n\n```\n{Header}({Topic}): Commit Message;\n```\n\n- Header (Required): identifier for the type of change\n  - feat: new feature\n  - fix: bug fix\n  - docs: documentation update\n  - style: code-style change that does not affect behavior\n  - refactor: change to existing logic\n  - pref: performance optimization\n  - test: test-case update\n  - build: dependency update\n  - ci: CI-related configuration change\n  - chore: changes outside source and test code\n  - revert: revert previous commits\n- Topic (Required): the subject, module, or feature name of the change; **use a short English label**.\n- Commit Message: a summary of the change; **describe it in Chinese**.\n\nExample:\n\n```\nci(Jenkins): 修改配置文件以支持 staging 环境;\n```",
-					"markdownDescription": "Custom instructions sent to the agent when you click the Commit button."
+					"default": "",
+					"markdownDescription": "**Reserved** for the upcoming Agentic Git release (no effect yet). Custom instructions to send to the agent for this action. Leave empty to use the built-in defaults.",
+					"scope": "window"
 				},
 				"hyperGit.agent.createPrPreferences": {
 					"type": "string",
 					"editPresentation": "multilineText",
-					"default": "The user likes the current state of the code.\n\nThere are 3 uncommitted changes.\nThe current branch is ${YOUR_BRANCH}.\nThe target branch is origin/${TARGET_BRANCH}.\nAn upstream branch exists.\n\nThe user requested a PR.\n\nFollow these steps to create a PR:\n\nIf you have any skills related to creating PRs, invoke them now. Instructions there should take precedence over these instructions.\nRun git diff to review uncommitted changes\nCommit them. Follow any instructions the user gave you about writing commit messages.\nPush with git push -u origin HEAD:${YOUR_BRANCH}.\nUse the mcp__conductor__GetWorkspaceDiff tool to review the PR diff\nUse gh pr create --base ${TARGET_BRANCH} --title <title> --body <description> to create a PR onto the target branch.\nIf any of these steps fail, ask the user for help.\n\nPR Title\n\nThe user has provided this PR title. Use it exactly as-is:\n${PR_TITLE}\n\nPR Description\n\nThe user has provided this PR description. Use it exactly as-is:\n${PR_DESCRIPTION}\n\nIMPORTANT: The following are the user's custom preferences. These preferences take precedence over any default guidelines or instructions provided above. When there is a conflict, always follow the user's preferences.\n\nUser Preferences\n\nUpdate the PR that was just created with a better title and description. The PR number is #{pr_number} and the URL is {pr_url}.\nAnalyze the changes in this branch and write:\n\nA concise, descriptive title that summarizes the changes, follow the commit message format specified in ~/.claude/commands/commit.md\nA detailed description that explains:\nWhat changes were made\nWhy they were made (based on the task context)\nAny important implementation details\nUse the appropriate CLI tool to update the PR (gh pr edit for GitHub, az repos pr update for Azure DevOps).",
-					"markdownDescription": "Custom instructions sent to the agent when you click the Create PR button."
+					"default": "",
+					"markdownDescription": "**Reserved** for the upcoming Agentic Git release (no effect yet). Custom instructions to send to the agent for this action. Leave empty to use the built-in defaults.",
+					"scope": "window"
 				},
 				"hyperGit.agent.reviewPreferences": {
 					"type": "string",
 					"editPresentation": "multilineText",
-					"default": "Review guidelines:\n\nYou are acting as a reviewer for a proposed code change made by another engineer.\n\nBelow are some default guidelines for determining whether the original author would appreciate the issue being flagged.\n\nThese are not the final word in determining whether an issue is a bug. In many cases, you will encounter other, more specific guidelines. These may be present elsewhere in a developer message, a user message, a file, or even elsewhere in this system message.\nThose guidelines should be considered to override these general instructions.\n\nHere are the general guidelines for determining whether something is a bug and should be flagged.\n\nIt meaningfully impacts the accuracy, performance, security, or maintainability of the code.\nThe bug is discrete and actionable (i.e. not a general issue with the codebase or a combination of multiple issues).\nFixing the bug does not demand a level of rigor that is not present in the rest of the codebase (e.g. one doesn’t need very detailed comments and input validation in a repository of one-off scripts in personal projects)\nThe bug was introduced in the commit (pre-existing bugs should not be flagged).\nThe author of the original PR would likely fix the issue if they were made aware of it.\nThe bug does not rely on unstated assumptions about the codebase or author’s intent.\nIt is not enough to speculate that a change may disrupt another part of the codebase, to be considered a bug, one must identify the other parts of the code that are provably affected.\nThe bug is clearly not just an intentional change by the original author.\nWhen flagging a bug, you will also provide an accompanying comment. Once again, these guidelines are not the final word on how to construct a comment — defer to any subsequent guidelines that you encounter.\n\nThe comment should be clear about why the issue is a bug.\nThe comment should appropriately communicate the severity of the issue. It should not claim that an issue is more severe than it actually is.\nThe comment should be brief. The body should be at most 1 paragraph. It should not introduce line breaks within the natural language flow unless it is necessary for the code fragment.\nThe comment should not include any chunks of code longer than 3 lines. Any code chunks should be wrapped in markdown inline code tags or a code block.\nThe comment should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue’s severity depends on these factors.\nThe comment’s tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.\nThe comment should be written such that the original author can immediately grasp the idea without close reading.\nThe comment should avoid excessive flattery and comments that are not helpful to the original author. The comment should avoid phrasing like “Great job …”, “Thanks for …”.\nBelow are some more detailed guidelines that you should apply to this specific review.\n\nHOW MANY FINDINGS TO RETURN:\n\nOutput all findings that the original author would fix if they knew about it. If there is no finding that a person would definitely love to see and fix, prefer outputting no findings. Do not stop at the first qualifying finding. Continue until you’ve listed every qualifying finding.\n\nGUIDELINES:\n\nIgnore trivial style unless it obscures meaning or violates documented standards.\nUse one comment per distinct issue (or a multi-line range if necessary).\nUse ```suggestion blocks ONLY for concrete replacement code (minimal lines; no commentary inside the block).\nIn every ```suggestion block, preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces).\nDo NOT introduce or remove outer indentation levels unless that is the actual fix.\nThe comments will be presented in the code review as inline comments. You should avoid providing unnecessary location details in the comment body. Always keep the line range as short as possible for interpreting the issue. Avoid ranges longer than 5–10 lines; instead, choose the most suitable subrange that pinpoints the problem.\n\nGetting the diff\n\nUse the mcp__conductor__GetWorkspaceDiff tool to review the workspace diff. Start with stat: true to understand the files that changed, then request specific files as needed.\n\nFallback: if you don’t have access to the workspace diff tool\n\nIf you don’t have access to the mcp__conductor__GetWorkspaceDiff tool, use the following git commands to get the diff:\n\n# Get the merge base between this branch and the target\nMERGE_BASE=$(git merge-base origin/${TARGET_BRANCH} HEAD)\n\n# Get the committed diff against the merge base\ngit diff $MERGE_BASE HEAD\n\n# Get any uncommitted changes (staged and unstaged)\ngit diff HEAD\nReview the combination of both outputs: the first shows all committed changes on this branch relative to the target, and the second shows any uncommitted work in progress.\n\nNo need to mention in your report whether or not you used one of the fallback strategies; it’s usually irrelevant.\n\nOutput format\n\nPost inline comments for each issue using mcp__conductor__DiffComment:\n\nIMPORTANT: Only post ONE comment per unique issue.\n\nWrite out a list of issues found, along with the location of the comment. For example:\n\n### **#1 Empty input causes crash**\nIf the input field is empty when page loads, the app will crash.\n\nFile: src/client/frontends/desktop/ui/Input.tsx\n\n#2 Dead code\nThe getUserData function is now unused. It should be deleted.\n\nFile: src/client/frontends/desktop/core/UserData.ts",
-					"markdownDescription": "Custom instructions sent to the agent when you click the Review button."
+					"default": "",
+					"markdownDescription": "**Reserved** for the upcoming Agentic Git release (no effect yet). Custom instructions to send to the agent for this action. Leave empty to use the built-in defaults.",
+					"scope": "window"
 				},
 				"hyperGit.log.ci.enabled": {
 					"type": "boolean",
 					"default": true,
-					"markdownDescription": "Show the final CI status on each commit in the Graph view (GitHub Actions + Commit Statuses). Green check = passed, red cross = failed; hover to see each check and any failure reasons. Requires a GitHub remote."
+					"markdownDescription": "Show the final CI status on each commit in the Graph view (GitHub Actions + Commit Statuses). Green check = passed, red cross = failed; hover to see each check and any failure reasons. Requires a GitHub remote.",
+					"scope": "resource"
 				},
 				"hyperGit.log.ci.remote": {
 					"type": "string",
 					"default": "",
-					"markdownDescription": "Remote name used to query CI status (empty = auto, prefers `origin`). For multi-remote repos, specify e.g. `upstream`."
+					"markdownDescription": "Remote name used to query CI status (empty = auto, prefers `origin`). For multi-remote repos, specify e.g. `upstream`.",
+					"scope": "resource"
 				},
 				"hyperGit.log.ci.provider": {
 					"type": "string",
@@ -1363,7 +1414,8 @@
 						"GitHub Enterprise (self-hosted)"
 					],
 					"default": "auto",
-					"markdownDescription": "CI data source. `auto` is resolved by the origin host (github.com → github.com, otherwise GitHub Enterprise)."
+					"markdownDescription": "CI data source. `auto` is resolved by the origin host (github.com → github.com, otherwise GitHub Enterprise).",
+					"scope": "resource"
 				}
 			}
 		}

--- a/src/adapter/advanced-commands.ts
+++ b/src/adapter/advanced-commands.ts
@@ -193,6 +193,6 @@ async function pickCommitHash(service: GitRepositoryService): Promise<string | u
 		description: `${c.authorName ?? ''} · ${c.hash.slice(0, 7)}`,
 		hash: c.hash,
 	}));
-	const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select a commit' });
+	const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select a commit', matchOnDescription: true, matchOnDetail: true });
 	return pick?.hash;
 }

--- a/src/adapter/advanced-commands.ts
+++ b/src/adapter/advanced-commands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import type { BranchNode, BranchesTreeProvider } from './tree/branches-tree';
 import type { GitRepositoryService } from './git-repository-service';
 import type { LogNode } from './webview/log-webview';
@@ -30,7 +31,7 @@ export function registerAdvancedCommands(service: GitRepositoryService, branches
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage('Undo last commit complete (soft)');
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to undo: ${errMsg(e)}`);
+				void showGitError(`Failed to undo: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -58,7 +59,7 @@ export function registerAdvancedCommands(service: GitRepositoryService, branches
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage(`Dropped commit ${hash.slice(0, 7)}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to drop (may need manual conflict resolution): ${errMsg(e)}`);
+				void showGitError(`Failed to drop (may need manual conflict resolution): ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -89,7 +90,7 @@ export function registerAdvancedCommands(service: GitRepositoryService, branches
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage(`Fixup into ${hash.slice(0, 7)} complete`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Fixup failed: ${errMsg(e)}`);
+				void showGitError(`Fixup failed: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -107,7 +108,7 @@ export function registerAdvancedCommands(service: GitRepositoryService, branches
 				const out = await service.execGit(['branch', '--merged', base]);
 				merged = filterMergeable(out, base, headName ? [headName] : []);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to query merged branches: ${errMsg(e)}`);
+				void showGitError(`Failed to query merged branches: ${errMsg(e)}`);
 				return;
 			}
 			if (merged.length === 0) {
@@ -173,7 +174,7 @@ export function registerAdvancedCommands(service: GitRepositoryService, branches
 				const doc = await vscode.workspace.openTextDocument({ content, language: 'markdown' });
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`3-way diff failed: ${errMsg(e)}`);
+				void showGitError(`3-way diff failed: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/conflict-ui.ts
+++ b/src/adapter/conflict-ui.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import { parseConflictState, type OngoingOperation } from '../engine/git-state/conflict-detector';
 import type { GitRepositoryService } from './git-repository-service';
 
@@ -48,7 +49,7 @@ export async function handleGitConflict(service: GitRepositoryService, opName: s
 				await service.execGit(ABORT_ARGS[op]);
 				void vscode.window.showInformationMessage(`${op} aborted, working tree restored`);
 			} catch {
-				void vscode.window.showErrorMessage('Failed to abort, please handle manually');
+				void showGitError('Failed to abort, please handle manually');
 			}
 		} else if (choice === 'Resolve conflicts') {
 			// 打开自绘 3-way merge editor（resolveConflicts 列出冲突文件供选择）

--- a/src/adapter/editor/blame-annotation.ts
+++ b/src/adapter/editor/blame-annotation.ts
@@ -9,11 +9,13 @@ const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(
  * 编辑器内 Blame 注解（逐行作者 / 日期 / 提交注解）。
  *
  * Toggle：对当前文件执行 `git blame --line-porcelain`，解析每行作者/日期，用行内
- * before 装饰渲染在每行行首（gutter 风格）。再次 toggle 关闭。切换编辑器/文档变更时清理。
+ * before 装饰渲染在每行行首（gutter 风格）。再次 toggle 关闭。
+ * 生命周期：同一文档 split 出的每个可见编辑器都同步挂载/卸载装饰；文档在所有编辑器
+ * 关闭后自动移出注解表；文档编辑（行号失配）与仓库切换时清除对应注解。
  */
 export class BlameAnnotationController implements vscode.Disposable {
 	private readonly decoration: vscode.TextEditorDecorationType;
-	private readonly annotated = new Set<string>(); // 已注解的 document uri
+	private readonly annotations = new Map<string, vscode.DecorationOptions[]>(); // uri → 装饰选项
 	private readonly disposables: vscode.Disposable[] = [];
 
 	constructor(private readonly service: GitRepositoryService) {
@@ -26,8 +28,25 @@ export class BlameAnnotationController implements vscode.Disposable {
 		// 文档变更后清除注解（行号失配）
 		this.disposables.push(
 			vscode.workspace.onDidChangeTextDocument((e) => {
-				if (this.annotated.has(e.document.uri.toString())) {
+				if (this.annotations.has(e.document.uri.toString())) {
 					this.clear(e.document.uri);
+				}
+			}),
+		);
+		// 可见编辑器变化：新 split 出的编辑器补挂装饰；文档全部关闭则移出注解表（防泄漏）。
+		this.disposables.push(
+			vscode.window.onDidChangeVisibleTextEditors((editors) => {
+				const openKeys = new Set(editors.map((e) => e.document.uri.toString()));
+				for (const [key, options] of this.annotations) {
+					if (!openKeys.has(key)) {
+						this.annotations.delete(key);
+						continue;
+					}
+					for (const e of editors) {
+						if (e.document.uri.toString() === key) {
+							e.setDecorations(this.decoration, options);
+						}
+					}
 				}
 			}),
 		);
@@ -43,7 +62,7 @@ export class BlameAnnotationController implements vscode.Disposable {
 			return;
 		}
 		const key = editor.document.uri.toString();
-		if (this.annotated.has(key)) {
+		if (this.annotations.has(key)) {
 			this.clear(editor.document.uri);
 			return;
 		}
@@ -66,6 +85,8 @@ export class BlameAnnotationController implements vscode.Disposable {
 			if (!b) {
 				continue;
 			}
+			// hover 用 MarkdownString.appendText：换行真实生效（纯字符串会把 \n 折叠成空格）且转义作者名/摘要中的 markdown 字符。
+			const hover = new vscode.MarkdownString().appendText(`${b.sha.slice(0, 7)} · ${b.author}`).appendText('\n\n').appendText(b.summary);
 			options.push({
 				range: new vscode.Range(line, 0, line, 0),
 				renderOptions: {
@@ -74,26 +95,40 @@ export class BlameAnnotationController implements vscode.Disposable {
 						fontStyle: 'italic',
 					},
 				},
-				hoverMessage: `${b.sha.slice(0, 7)} · ${b.author}\n${b.summary}`,
+				hoverMessage: hover,
 			});
 		}
-		editor.setDecorations(this.decoration, options);
-		this.annotated.add(key);
+		this.annotations.set(key, options);
+		this.applyToVisibleEditors(editor.document.uri);
+	}
+
+	/** 对展示同一文档的全部可见编辑器（含 split）统一挂载当前注解。 */
+	private applyToVisibleEditors(uri: vscode.Uri): void {
+		const key = uri.toString();
+		const options = this.annotations.get(key) ?? [];
+		for (const e of vscode.window.visibleTextEditors) {
+			if (e.document.uri.toString() === key) {
+				e.setDecorations(this.decoration, options);
+			}
+		}
 	}
 
 	private clear(uri: vscode.Uri): void {
-		const editor = vscode.window.visibleTextEditors.find((e) => e.document.uri.toString() === uri.toString());
-		editor?.setDecorations(this.decoration, []);
-		this.annotated.delete(uri.toString());
+		const key = uri.toString();
+		const empty: vscode.DecorationOptions[] = [];
+		for (const e of vscode.window.visibleTextEditors) {
+			if (e.document.uri.toString() === key) {
+				e.setDecorations(this.decoration, empty);
+			}
+		}
+		this.annotations.delete(key);
 	}
 
-	/** 清除全部注解（仓库切换时，annotated 中的 uri 逐个对可见编辑器复位装饰）。 */
+	/** 清除全部注解（仓库切换时，对可见编辑器复位装饰）。 */
 	private clearAll(): void {
-		for (const key of [...this.annotated]) {
-			const editor = vscode.window.visibleTextEditors.find((e) => e.document.uri.toString() === key);
-			editor?.setDecorations(this.decoration, []);
+		for (const key of [...this.annotations.keys()]) {
+			this.clear(vscode.Uri.parse(key));
 		}
-		this.annotated.clear();
 	}
 
 	dispose(): void {

--- a/src/adapter/editor/inline-commit-codelens.ts
+++ b/src/adapter/editor/inline-commit-codelens.ts
@@ -16,11 +16,12 @@ function repoRelative(root: string, fsPath: string): string | null {
 /**
  * 行内提交 CodeLensProvider（编辑器内逐 Hunk 提交）。
  *
- * 对当前文件每个未暂存 hunk，在其起始行上方渲染可点击 CodeLens「✓ 提交此 Hunk (+N -M)」。
+ * 对当前文件每个未暂存 hunk，在其起始行上方渲染可点击 CodeLens「$(check) Commit this Hunk (+N -M)」
+ * （codicon 主题图标，随 product icon theme 渲染）。
  * 点击 → 仅暂存该 hunk（patch 重建 + `git apply --cached`）→ 输入 message → `git commit`。
  * gutter 视觉标记（绿/红/蓝）由原生 git quickDiff 提供，不重复造。
  */
-export class InlineCommitCodeLensProvider implements vscode.CodeLensProvider {
+export class InlineCommitCodeLensProvider implements vscode.CodeLensProvider, vscode.Disposable {
 	private readonly _onDidChangeCodeLenses = new vscode.EventEmitter<void>();
 	readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event;
 
@@ -30,7 +31,11 @@ export class InlineCommitCodeLensProvider implements vscode.CodeLensProvider {
 		this._onDidChangeCodeLenses.fire();
 	}
 
-	async provideCodeLenses(doc: vscode.TextDocument): Promise<vscode.CodeLens[]> {
+	dispose(): void {
+		this._onDidChangeCodeLenses.dispose();
+	}
+
+	async provideCodeLenses(doc: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
 		const repo = this.service.repo;
 		if (!repo) {
 			return [];
@@ -41,7 +46,7 @@ export class InlineCommitCodeLensProvider implements vscode.CodeLensProvider {
 		}
 		try {
 			const diff = await this.service.execGit(['diff', '-U3', '--', rel]);
-			if (!diff.trim()) {
+			if (token.isCancellationRequested || !diff.trim()) {
 				return [];
 			}
 			const files = parseUnifiedDiff(diff);
@@ -53,7 +58,7 @@ export class InlineCommitCodeLensProvider implements vscode.CodeLensProvider {
 				const line = Math.max(0, r.startLine - 1);
 				return new vscode.CodeLens(new vscode.Range(line, 0, line, 0), {
 					command: 'hyperGit.inlineCommitHunk',
-					title: `✓ Commit this Hunk (+${r.addedCount} -${r.removedCount})`,
+					title: `$(check) Commit this Hunk (+${r.addedCount} -${r.removedCount})`,
 					arguments: [rel, r.hunkIndex],
 				});
 			});
@@ -97,15 +102,13 @@ export function registerInlineCommitCommand(service: GitRepositoryService, provi
 			}
 			const patch = buildPatch(files[0], [hunkIndex]);
 			const tmp = path.join(os.tmpdir(), `hg-inline-${Date.now()}.diff`);
-			fs.writeFileSync(tmp, patch);
+			await fs.promises.writeFile(tmp, patch, 'utf8');
 			try {
 				await service.execGit(['apply', '--cached', '--whitespace=nowarn', tmp]);
 			} finally {
-				try {
-					fs.unlinkSync(tmp);
-				} catch {
+				void fs.promises.unlink(tmp).catch(() => {
 					/* ignore */
-				}
+				});
 			}
 			await service.execGit(['commit', '-m', message.trim()]);
 			provider.refresh();

--- a/src/adapter/git-cli-commands.ts
+++ b/src/adapter/git-cli-commands.ts
@@ -1,6 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
+import { runWithProgress } from './task-progress';
 import type { BranchNode, BranchesTreeProvider } from './tree/branches-tree';
 import type { ChangeItem, GitRepositoryService } from './git-repository-service';
 import type { LogFilterControl, LogNode } from './webview/log-webview';
@@ -26,13 +28,13 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				return;
 			}
 			try {
-				await service.execGit(['cherry-pick', hash]);
+				await runWithProgress(`Cherry-picking ${hash.slice(0, 7)}…`, () => service.execGit(['cherry-pick', hash]));
 				branchesTree.refresh();
 				logTree.refresh();
 				void vscode.window.showInformationMessage(`Cherry-pick ${hash.slice(0, 7)} complete`);
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Cherry-pick'))) {
-					void vscode.window.showErrorMessage(`Cherry-pick failed: ${errMsg(e)}`);
+					void showGitError(`Cherry-pick failed: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -49,13 +51,13 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				return;
 			}
 			try {
-				await service.execGit(['revert', '--no-edit', hash]);
+				await runWithProgress(`Reverting ${hash.slice(0, 7)}…`, () => service.execGit(['revert', '--no-edit', hash]));
 				branchesTree.refresh();
 				logTree.refresh();
 				void vscode.window.showInformationMessage(`Revert ${hash.slice(0, 7)} complete`);
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Revert'))) {
-					void vscode.window.showErrorMessage(`Revert failed: ${errMsg(e)}`);
+					void showGitError(`Revert failed: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -91,12 +93,12 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				}
 			}
 			try {
-				await service.execGit(['reset', `--${pick.label}`, target]);
+				await runWithProgress(`Resetting to ${target.slice(0, 7)}…`, () => service.execGit(['reset', `--${pick.label}`, target]));
 				branchesTree.refresh();
 				logTree.refresh();
 				void vscode.window.showInformationMessage(`Reset (--${pick.label} ${target.slice(0, 7)}) complete`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Reset failed: ${errMsg(e)}`);
+				void showGitError(`Reset failed: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -116,7 +118,7 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				await service.execGit(['branch', '-m', oldName, newName.trim()]);
 				branchesTree.refresh();
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Rename failed: ${errMsg(e)}`);
+				void showGitError(`Rename failed: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -138,7 +140,7 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				});
 				void vscode.window.showInformationMessage(`Added to .gitignore: ${rel}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Ignore failed: ${errMsg(e)}`);
+				void showGitError(`Ignore failed: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -166,7 +168,7 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				const doc = await vscode.workspace.openTextDocument({ content: `$ git diff --stat ${base}...${target}\n\n${out}`, language: 'plaintext' });
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Compare failed: ${errMsg(e)}`);
+				void showGitError(`Compare failed: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -185,7 +187,7 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				await repo.commit(message.trim(), { amend: true });
 				void vscode.window.showInformationMessage('Rewrote latest commit');
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Rewrite failed: ${errMsg(e)}`);
+				void showGitError(`Rewrite failed: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/git-cli-commands.ts
+++ b/src/adapter/git-cli-commands.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { showGitError } from './notify';
 import { runWithProgress } from './task-progress';
+import { validateRefName } from '../engine/ref/ref-name';
 import type { BranchNode, BranchesTreeProvider } from './tree/branches-tree';
 import type { ChangeItem, GitRepositoryService } from './git-repository-service';
 import type { LogFilterControl, LogNode } from './webview/log-webview';
@@ -110,7 +111,11 @@ export function registerGitCliCommands(service: GitRepositoryService, branchesTr
 				return;
 			}
 			const oldName = node.ref.shortName;
-			const newName = await vscode.window.showInputBox({ prompt: `Rename branch "${oldName}"`, value: oldName });
+			const newName = await vscode.window.showInputBox({
+				prompt: `Rename branch "${oldName}"`,
+				value: oldName,
+				validateInput: (v) => validateRefName(v, 'branch'),
+			});
 			if (!newName || !newName.trim() || newName === oldName) {
 				return;
 			}
@@ -206,7 +211,8 @@ async function pickCommitHash(service: GitRepositoryService): Promise<string | u
 		description: `${c.authorName ?? ''} · ${c.hash.slice(0, 7)}`,
 		hash: c.hash,
 	}));
-	const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select a commit' });
+	// matchOnDescription：description 含短 hash，输入 hash 前缀可直接命中。
+	const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select a commit', matchOnDescription: true, matchOnDetail: true });
 	return pick?.hash;
 }
 
@@ -231,6 +237,6 @@ async function pickResetTarget(service: GitRepositoryService): Promise<string | 
 		description: `${c.hash.slice(0, 7)}${i === 0 ? ' · HEAD' : ''}`,
 		hash: c.hash,
 	}));
-	const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select reset target commit' });
+	const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select reset target commit', matchOnDescription: true, matchOnDetail: true });
 	return pick?.hash;
 }

--- a/src/adapter/git-repository-service.ts
+++ b/src/adapter/git-repository-service.ts
@@ -183,13 +183,17 @@ export class GitRepositoryService implements vscode.Disposable {
 	async execGit(args: string[], options?: { env?: NodeJS.ProcessEnv }): Promise<string> {
 		const repo = this._repo;
 		if (!repo) {
-			throw new Error('未找到 Git 仓库');
+			throw new Error('No Git repository found');
 		}
 		return new Promise((resolve, reject) => {
-			execFile(this.api.git.path, args, { cwd: repo.rootUri.fsPath, maxBuffer: 20 * 1024 * 1024, encoding: 'utf8', env: options?.env }, (err, stdout) => {
+			execFile(this.api.git.path, args, { cwd: repo.rootUri.fsPath, maxBuffer: 20 * 1024 * 1024, encoding: 'utf8', env: options?.env }, (err, stdout, stderr) => {
 				if (err) {
-					logGit(args, undefined, err.message);
-					reject(err);
+					// execFile 的 err.message 是通用串；真实失败原因在 stderr——透传挂到错误对象并记入 Console，
+					// 否则 CLI 通道失败在通知与日志中均不可诊断（与 API 通道 GitError.stderr 提取对齐）。
+					const gitErr = err as NodeJS.ErrnoException & { stderr?: string };
+					gitErr.stderr = stderr?.trim() || undefined;
+					logGit(args, undefined, gitErr.stderr ? `${err.message}\n${gitErr.stderr}` : err.message);
+					reject(gitErr);
 				} else {
 					logGit(args, stdout);
 					resolve(stdout);

--- a/src/adapter/history-commands.ts
+++ b/src/adapter/history-commands.ts
@@ -1,5 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
+import { runWithProgress } from './task-progress';
 import type { BranchNode } from './tree/branches-tree';
 import type { BranchesTreeProvider } from './tree/branches-tree';
 import type { BranchFavorites } from './branch-favorites';
@@ -109,7 +111,7 @@ export function registerHistoryCommands(
 					await repo.createBranch(name.trim(), true);
 					branchesTree.refresh();
 				} catch (e) {
-					void vscode.window.showErrorMessage(`Failed to create branch: ${errMsg(e)}`);
+					void showGitError(`Failed to create branch: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -125,7 +127,7 @@ export function registerHistoryCommands(
 				await repo.checkout(node.ref.shortName);
 				branchesTree.refresh();
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to checkout: ${errMsg(e)}`);
+				void showGitError(`Failed to checkout: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -156,7 +158,8 @@ export function registerHistoryCommands(
 			const { merged, unmerged } = partitionByMerged(mergedOut, names);
 			const mergedSet = new Set(merged);
 			const { detail, confirmLabel } = formatBranchDeleteConfirm(merged, unmerged);
-			const choice = await vscode.window.showWarningMessage(detail, { modal: true }, confirmLabel);
+			// 多行明细走 MessageOptions.detail（VS Code 模态框的次要文字载体），标题保持单行。
+			const choice = await vscode.window.showWarningMessage('Delete local branch(es)?', { modal: true, detail }, confirmLabel);
 			if (choice !== confirmLabel) {
 				return;
 			}
@@ -195,7 +198,7 @@ export function registerHistoryCommands(
 				branchesTree.refresh();
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Merge'))) {
-					void vscode.window.showErrorMessage(`Failed to merge: ${errMsg(e)}`);
+					void showGitError(`Failed to merge: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -217,7 +220,7 @@ export function registerHistoryCommands(
 				branchesTree.refresh();
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Rebase'))) {
-					void vscode.window.showErrorMessage(`Failed to rebase: ${errMsg(e)}`);
+					void showGitError(`Failed to rebase: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -244,7 +247,7 @@ export function registerHistoryCommands(
 				const doc = await vscode.workspace.openTextDocument({ content: blame, language: 'plaintext' });
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to Blame: ${errMsg(e)}`);
+				void showGitError(`Failed to Blame: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -256,11 +259,11 @@ export function registerHistoryCommands(
 				return;
 			}
 			try {
-				await repo.pull();
+				await runWithProgress('Pulling…', () => repo.pull());
 				branchesTree.refresh();
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Pull'))) {
-					void vscode.window.showErrorMessage(`Failed to Pull: ${errMsg(e)}`);
+					void showGitError(`Failed to Pull: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -280,7 +283,7 @@ export function registerHistoryCommands(
 			try {
 				if (head.upstream) {
 					// 已配置上游：按 push.default 推送到追踪分支（正确处理本地名/上游名不一致）。
-					await repo.push();
+					await runWithProgress('Pushing…', () => repo.push());
 				} else {
 					// 无上游：选定 remote 并以 -u 建立追踪（修复「Failed to execute git」根因）。
 					const remotes = repo.state.remotes.map((r) => r.name);
@@ -297,12 +300,12 @@ export function registerHistoryCommands(
 					if (!remote) {
 						return;
 					}
-					await repo.push(remote, head.name, true);
+					await runWithProgress('Pushing…', () => repo.push(remote, head.name, true));
 				}
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage(`Pushed ${head.name}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to Push: ${errMsg(e)}`);
+				void showGitError(`Failed to Push: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -321,11 +324,11 @@ export function registerHistoryCommands(
 				return;
 			}
 			try {
-				await repo.fetch(pick.includes('Prune') ? { prune: true } : undefined);
+				await runWithProgress('Fetching…', () => repo.fetch(pick.includes('Prune') ? { prune: true } : undefined));
 				branchesTree.refresh();
 				logTree.refresh();
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to Fetch: ${errMsg(e)}`);
+				void showGitError(`Failed to Fetch: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -348,7 +351,7 @@ export function registerHistoryCommands(
 			// 逐 remote 执行 fetch --prune：API 的 FetchOptions 仅接受单 remote，遍历以覆盖多远程场景。
 			for (const remote of remotes) {
 				try {
-					await repo.fetch({ remote, prune: true });
+					await runWithProgress('Pruning remotes…', () => repo.fetch({ remote, prune: true }));
 				} catch {
 					failed.push(remote);
 				}
@@ -397,7 +400,7 @@ export function registerHistoryCommands(
 				await repo.createBranch(name.trim(), true, source);
 				branchesTree.refresh();
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create branch: ${errMsg(e)}`);
+				void showGitError(`Failed to create branch: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -414,7 +417,7 @@ export function registerHistoryCommands(
 				const doc = await vscode.workspace.openTextDocument({ content: `$ git diff --stat HEAD...${selected}\n\n${out}`, language: 'plaintext' });
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to compare: ${errMsg(e)}`);
+				void showGitError(`Failed to compare: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -447,7 +450,7 @@ export function registerHistoryCommands(
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage(`Created tag ${name.trim()} @ ${pick.target === 'HEAD' ? 'HEAD' : pick.target.slice(0, 7)}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create tag: ${errMsg(e)}`);
+				void showGitError(`Failed to create tag: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -498,7 +501,7 @@ export function registerHistoryCommands(
 				await repo.checkout(name);
 				branchesTree.refresh();
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to checkout tag: ${errMsg(e)}`);
+				void showGitError(`Failed to checkout tag: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -527,7 +530,7 @@ export function registerHistoryCommands(
 			try {
 				await vscode.commands.executeCommand('vscode.diff', left, right, `${filePath} · ${hash.slice(0, 7)} (commit diff)`, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to open diff: ${errMsg(e)}`);
+				void showGitError(`Failed to open diff: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -561,7 +564,7 @@ export function registerHistoryCommands(
 				void vscode.window.showInformationMessage(`Reset (--${pick.label} ${hash.slice(0, 7)}) complete`);
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Reset'))) {
-					void vscode.window.showErrorMessage(`Failed to Reset: ${errMsg(e)}`);
+					void showGitError(`Failed to Reset: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -582,7 +585,7 @@ export function registerHistoryCommands(
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage(`Created and checked out ${name.trim()} @ ${node.commit.hash.slice(0, 7)}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create branch: ${errMsg(e)}`);
+				void showGitError(`Failed to create branch: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -601,7 +604,7 @@ export function registerHistoryCommands(
 				branchesTree.refresh();
 				void vscode.window.showInformationMessage(`Created tag ${name.trim()} @ ${node.commit.hash.slice(0, 7)}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create tag: ${errMsg(e)}`);
+				void showGitError(`Failed to create tag: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -619,7 +622,7 @@ export function registerHistoryCommands(
 				});
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to query: ${errMsg(e)}`);
+				void showGitError(`Failed to query: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/history-commands.ts
+++ b/src/adapter/history-commands.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { showGitError } from './notify';
 import { runWithProgress } from './task-progress';
+import { validateRefName } from '../engine/ref/ref-name';
 import type { BranchNode } from './tree/branches-tree';
 import type { BranchesTreeProvider } from './tree/branches-tree';
 import type { BranchFavorites } from './branch-favorites';
@@ -105,7 +106,10 @@ export function registerHistoryCommands(
 			if (!repo) {
 				return;
 			}
-			const name = await vscode.window.showInputBox({ prompt: 'New branch name' });
+			const name = await vscode.window.showInputBox({
+				prompt: 'New branch name',
+				validateInput: (v) => validateRefName(v, 'branch'),
+			});
 			if (name && name.trim()) {
 				try {
 					await repo.createBranch(name.trim(), true);
@@ -392,7 +396,11 @@ export function registerHistoryCommands(
 				return;
 			}
 			const source = node.ref.shortName;
-			const name = await vscode.window.showInputBox({ prompt: `Create and checkout a new local branch from "${source}"`, placeHolder: 'New branch name' });
+			const name = await vscode.window.showInputBox({
+				prompt: `Create and checkout a new local branch from "${source}"`,
+				placeHolder: 'New branch name',
+				validateInput: (v) => validateRefName(v, 'branch'),
+			});
 			if (!name || !name.trim()) {
 				return;
 			}
@@ -428,23 +436,29 @@ export function registerHistoryCommands(
 			if (!repo) {
 				return;
 			}
-			const name = await vscode.window.showInputBox({ prompt: 'Tag name (e.g. v1.0.0)' });
+			const name = await vscode.window.showInputBox({
+				prompt: 'Tag name (e.g. v1.0.0)',
+				validateInput: (v) => validateRefName(v, 'tag'),
+			});
 			if (!name || !name.trim()) {
 				return;
 			}
 			const commits = await repo.log({ maxEntries: 20 });
-			const items = [
+			// Separator 分段 HEAD 与历史提交（QuickPickItemKind.Separator，1.53+）；description 带 hash 供模糊搜索。
+			const items: Array<{ label: string; description?: string; target: string } | { label: string; kind: vscode.QuickPickItemKind.Separator }> = [
 				{ label: 'HEAD', description: 'Current commit', target: 'HEAD' },
+				{ label: 'Recent Commits', kind: vscode.QuickPickItemKind.Separator },
 				...commits.map((c) => ({
 					label: (c.message.split('\n', 1)[0] ?? c.hash).slice(0, 50),
 					description: c.hash.slice(0, 7),
 					target: c.hash,
 				})),
 			];
-			const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Choose a commit to tag' });
-			if (!pick) {
+			const picked = await vscode.window.showQuickPick(items, { placeHolder: 'Choose a commit to tag', matchOnDescription: true, matchOnDetail: true });
+			if (!picked || !('target' in picked)) {
 				return;
 			}
+			const pick = picked;
 			try {
 				await service.execGit(['tag', name.trim(), pick.target]);
 				branchesTree.refresh();
@@ -576,7 +590,11 @@ export function registerHistoryCommands(
 			if (!repo || node?.kind !== 'commit') {
 				return;
 			}
-			const name = await vscode.window.showInputBox({ prompt: `Create and checkout a new branch from ${node.commit.hash.slice(0, 7)}`, placeHolder: 'New branch name' });
+			const name = await vscode.window.showInputBox({
+				prompt: `Create and checkout a new branch from ${node.commit.hash.slice(0, 7)}`,
+				placeHolder: 'New branch name',
+				validateInput: (v) => validateRefName(v, 'branch'),
+			});
 			if (!name || !name.trim()) {
 				return;
 			}
@@ -595,7 +613,11 @@ export function registerHistoryCommands(
 			if (node?.kind !== 'commit') {
 				return;
 			}
-			const name = await vscode.window.showInputBox({ prompt: `Create a new tag at ${node.commit.hash.slice(0, 7)}`, placeHolder: 'e.g. v1.0.0' });
+			const name = await vscode.window.showInputBox({
+				prompt: `Create a new tag at ${node.commit.hash.slice(0, 7)}`,
+				placeHolder: 'e.g. v1.0.0',
+				validateInput: (v) => validateRefName(v, 'tag'),
+			});
 			if (!name || !name.trim()) {
 				return;
 			}

--- a/src/adapter/misc-commands.ts
+++ b/src/adapter/misc-commands.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import type { GitRepositoryService } from './git-repository-service';
 import type { LogFilterControl } from './webview/log-webview';
 import type { BranchesTreeProvider } from './tree/branches-tree';
@@ -42,7 +43,7 @@ export function registerMiscCommands(
 			try {
 				patch = await service.execGit(scope.args);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to generate patch: ${errMsg(e)}`);
+				void showGitError(`Failed to generate patch: ${errMsg(e)}`);
 				return;
 			}
 			if (!patch.trim()) {
@@ -60,7 +61,7 @@ export function registerMiscCommands(
 				await fs.promises.writeFile(target.fsPath, patch, 'utf8');
 				void vscode.window.showInformationMessage(`Patch exported: ${target.fsPath}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to write patch: ${errMsg(e)}`);
+				void showGitError(`Failed to write patch: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -97,7 +98,7 @@ export function registerMiscCommands(
 				void vscode.window.showInformationMessage('Patch applied');
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Apply Patch'))) {
-					void vscode.window.showErrorMessage(`Failed to apply patch: ${errMsg(e)}`);
+					void showGitError(`Failed to apply patch: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -114,7 +115,7 @@ export function registerMiscCommands(
 				const doc = await vscode.workspace.openTextDocument({ content: `# git reflog (latest 200 entries)\n\n${out}`, language: 'plaintext' });
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to read reflog: ${errMsg(e)}`);
+				void showGitError(`Failed to read reflog: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/notify.ts
+++ b/src/adapter/notify.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+import { showGitConsole } from '../infra/git-console';
+
+/**
+ * git 操作失败通知 + "Show Output" 动作按钮（联动 Hyper Git Console 命令誊录通道）。
+ * 与裸 showErrorMessage 的差别：给用户一条直达诊断信息的路径（含 execGit 透传的 stderr）。
+ */
+export async function showGitError(message: string): Promise<void> {
+	const choice = await vscode.window.showErrorMessage(message, 'Show Output');
+	if (choice === 'Show Output') {
+		showGitConsole();
+	}
+}

--- a/src/adapter/partial-commands.ts
+++ b/src/adapter/partial-commands.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import { buildPatch, parseUnifiedDiff } from '../engine/diff/hunk-parser';
 import type { ChangelistRegistry } from './changelist-registry';
 import type { ChangeItem, GitRepositoryService } from './git-repository-service';
@@ -81,7 +82,7 @@ export function registerPartialCommands(service: GitRepositoryService, registry:
 				await applyToIndex(buildPatch(file, sel.indices), false);
 				void vscode.window.showInformationMessage(`Staged ${sel.indices.length} hunk(s)`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to stage: ${errMsg(e)}`);
+				void showGitError(`Failed to stage: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -110,7 +111,7 @@ export function registerPartialCommands(service: GitRepositoryService, registry:
 				await applyToIndex(buildPatch(file, sel.indices), true);
 				void vscode.window.showInformationMessage(`Unstaged ${sel.indices.length} hunk(s)`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to unstage: ${errMsg(e)}`);
+				void showGitError(`Failed to unstage: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -146,7 +147,7 @@ export function registerPartialCommands(service: GitRepositoryService, registry:
 				await applyToIndex(buildPatch(file, overlapping.map((o) => o.i)), false);
 				void vscode.window.showInformationMessage('Staged hunk at cursor');
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to stage: ${errMsg(e)}`);
+				void showGitError(`Failed to stage: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -188,7 +189,7 @@ export function registerPartialCommands(service: GitRepositoryService, registry:
 					void vscode.window.showInformationMessage(`Assigned Hunk ${hunkIdx + 1} (${rel}) to "${pick.label}"`);
 				}
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to assign: ${errMsg(e)}`);
+				void showGitError(`Failed to assign: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/remote-commands.ts
+++ b/src/adapter/remote-commands.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
+import { runWithProgress } from './task-progress';
 import { selectedBranchRefs } from './branch-selection';
 import { handleGitConflict } from './conflict-ui';
 import type { BranchNode, BranchesTreeProvider } from './tree/branches-tree';
@@ -70,16 +72,18 @@ export function registerRemoteCommands(
 				return;
 			}
 			try {
-				await repo.push(remote, undefined, false, mode.force);
-				if (tags === 'Yes') {
-					await service.execGit(['push', remote, '--tags']);
-				}
+				await runWithProgress('Pushing…', async () => {
+					await repo.push(remote, undefined, false, mode.force);
+					if (tags === 'Yes') {
+						await service.execGit(['push', remote, '--tags']);
+					}
+				});
 				branchesTree.refresh();
 				logTree.refresh();
 				void vscode.window.showInformationMessage(`Pushed to ${remote} ${previewCount}`.trim());
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Push'))) {
-					void vscode.window.showErrorMessage(`Push failed: ${errMsg(e)}`);
+					void showGitError(`Push failed: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -102,13 +106,15 @@ export function registerRemoteCommands(
 				return;
 			}
 			try {
-				await service.execGit(pick.args);
+				await runWithProgress(`Updating project (${pick.args.join(' ')})…`, () => service.execGit(pick.args), {
+					location: vscode.ProgressLocation.Notification,
+				});
 				branchesTree.refresh();
 				logTree.refresh();
 				void vscode.window.showInformationMessage('Update Project complete');
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Update'))) {
-					void vscode.window.showErrorMessage(`Update failed: ${errMsg(e)}`);
+					void showGitError(`Update failed: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -144,13 +150,13 @@ export function registerRemoteCommands(
 				}
 			}
 			try {
-				await service.execGit(['merge', ...mode.args, ...msgArgs, target]);
+				await runWithProgress(`Merging ${target}…`, () => service.execGit(['merge', ...mode.args, ...msgArgs, target]));
 				branchesTree.refresh();
 				logTree.refresh();
 				void vscode.window.showInformationMessage(`Merged ${target}`);
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Merge'))) {
-					void vscode.window.showErrorMessage(`Merge failed: ${errMsg(e)}`);
+					void showGitError(`Merge failed: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -195,7 +201,8 @@ export function registerRemoteCommands(
 				protectedTargets.length > 0
 					? `${detail}\n\nAutomatically skipped protected branches: ${truncateNames(protectedTargets.map((t) => t.shortName))}`
 					: detail;
-			const choice = await vscode.window.showWarningMessage(fullDetail, { modal: true }, confirmLabel);
+			// 多行明细走 MessageOptions.detail（模态框次要文字载体），标题保持单行。
+			const choice = await vscode.window.showWarningMessage('Delete remote branch(es)?', { modal: true, detail: fullDetail }, confirmLabel);
 			if (choice !== confirmLabel) {
 				return;
 			}

--- a/src/adapter/remote-commands.ts
+++ b/src/adapter/remote-commands.ts
@@ -60,7 +60,7 @@ export function registerRemoteCommands(
 				[
 					{ label: 'Normal', description: 'Normal push', force: undefined as 0 | 1 | undefined },
 					{ label: 'Force-with-lease', description: 'Safe force push (recommended)', force: 1 as const },
-					{ label: 'Force', description: '⚠ Force overwrite remote (dangerous)', force: 0 as const },
+					{ label: 'Force', description: '$(alert) Force overwrite remote (dangerous)', force: 0 as const },
 				],
 				{ placeHolder: 'Push mode' },
 			);

--- a/src/adapter/shelf.ts
+++ b/src/adapter/shelf.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import type { GitRepositoryService } from './git-repository-service';
 import { handleGitConflict } from './conflict-ui';
 import { mdTooltip, relativeDate } from './tree/tree-tooltip';
@@ -67,25 +68,28 @@ export class ShelfService {
 	 * 仅 rename（零删除）、目标已存在即跳过（零覆盖）、失败静默可重试（已移入保留，未移入下次续迁）。
 	 * 多仓库历史混仓数据无法事后归因，归属当前活跃仓库（Known Limitation）。
 	 */
-	private migrateLegacyShelves(targetDir: string): void {
+	private async migrateLegacyShelves(targetDir: string): Promise<void> {
 		try {
-			if (fs.existsSync(targetDir)) {
-				return; // 本仓库已迁移/已使用（幂等出口）
-			}
-			if (!fs.existsSync(this.shelvesBase)) {
-				return;
-			}
-			const legacyFiles = fs.readdirSync(this.shelvesBase).filter((f) => f.endsWith('.json'));
+			await fs.promises.access(targetDir);
+			return; // 本仓库已迁移/已使用（幂等出口）
+		} catch {
+			/* 目标目录不存在 → 检查旧版平铺数据 */
+		}
+		try {
+			const legacyFiles = (await fs.promises.readdir(this.shelvesBase)).filter((f) => f.endsWith('.json'));
 			if (legacyFiles.length === 0) {
 				return;
 			}
-			fs.mkdirSync(targetDir, { recursive: true });
+			await fs.promises.mkdir(targetDir, { recursive: true });
 			for (const f of legacyFiles) {
 				const dest = path.join(targetDir, f);
-				if (fs.existsSync(dest)) {
+				try {
+					await fs.promises.access(dest);
 					continue; // 绝不覆盖
+				} catch {
+					/* 目标不存在 → 迁移 */
 				}
-				fs.renameSync(path.join(this.shelvesBase, f), dest);
+				await fs.promises.rename(path.join(this.shelvesBase, f), dest);
 			}
 			logGit(['shelf:migrateLegacy'], targetDir);
 		} catch (e) {
@@ -107,21 +111,21 @@ export class ShelfService {
 		if (!patch.trim()) {
 			throw new Error('Selected files have no changes (or are untracked)');
 		}
-		this.migrateLegacyShelves(dir);
-		fs.mkdirSync(dir, { recursive: true });
+		await this.migrateLegacyShelves(dir);
+		await fs.promises.mkdir(dir, { recursive: true });
 		const entry: ShelfEntry = { name, paths, timestamp, patch };
-		fs.writeFileSync(path.join(dir, `${sanitize(name)}.json`), JSON.stringify(entry, null, 2));
+		await fs.promises.writeFile(path.join(dir, `${sanitize(name)}.json`), JSON.stringify(entry, null, 2), 'utf8');
 		// 移除工作区改动（变更已保存在 patch）
 		await this.service.execGit(['checkout', '--', ...paths]);
 	}
 
 	async unshelve(name: string, threeWay: boolean): Promise<void> {
-		const entry = this.readEntry(name);
+		const entry = await this.readEntry(name);
 		if (!entry) {
 			throw new Error(`Shelf "${name}" does not exist`);
 		}
 		const tmp = path.join(os.tmpdir(), `hg-unshelve-${Date.now()}.patch`);
-		fs.writeFileSync(tmp, entry.patch);
+		await fs.promises.writeFile(tmp, entry.patch, 'utf8');
 		try {
 			const args = ['apply'];
 			if (threeWay) {
@@ -130,64 +134,64 @@ export class ShelfService {
 			args.push(tmp);
 			await this.service.execGit(args);
 		} finally {
-			try {
-				fs.unlinkSync(tmp);
-			} catch {
+			void fs.promises.unlink(tmp).catch(() => {
 				/* ignore */
-			}
+			});
 		}
 	}
 
 	async unshelveAndDrop(name: string, threeWay: boolean): Promise<void> {
 		await this.unshelve(name, threeWay);
-		this.drop(name);
+		await this.drop(name);
 	}
 
-	drop(name: string): void {
+	async drop(name: string): Promise<void> {
 		const dir = this.currentDir();
 		if (!dir) {
 			return;
 		}
 		const file = path.join(dir, `${sanitize(name)}.json`);
-		if (fs.existsSync(file)) {
-			fs.unlinkSync(file);
+		try {
+			await fs.promises.unlink(file);
+		} catch {
+			/* 不存在/占用：静默（幂等） */
 		}
 	}
 
-	listShelves(): ShelfNode[] {
+	/** 异步枚举（fs.promises）：此前同步 readdir/readFile 阻塞扩展宿主，getChildren 处 UI 请求路径。 */
+	async listShelves(): Promise<ShelfNode[]> {
 		const dir = this.currentDir();
 		if (!dir) {
 			return [];
 		}
-		this.migrateLegacyShelves(dir);
-		if (!fs.existsSync(dir)) {
+		await this.migrateLegacyShelves(dir);
+		let files: string[];
+		try {
+			files = (await fs.promises.readdir(dir)).filter((f) => f.endsWith('.json'));
+		} catch {
 			return [];
 		}
-		return fs
-			.readdirSync(dir)
-			.filter((f) => f.endsWith('.json'))
-			.map((f) => {
+		const nodes = await Promise.all(
+			files.map(async (f) => {
 				try {
-					const entry = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')) as ShelfEntry;
+					const entry = JSON.parse(await fs.promises.readFile(path.join(dir, f), 'utf8')) as ShelfEntry;
 					return { kind: 'shelf' as const, name: entry.name, paths: entry.paths, timestamp: entry.timestamp };
 				} catch {
 					return null;
 				}
-			})
-			.filter((n): n is ShelfNode => n !== null);
+			}),
+		);
+		return nodes.filter((n): n is ShelfNode => n !== null);
 	}
 
-	private readEntry(name: string): ShelfEntry | null {
+	private async readEntry(name: string): Promise<ShelfEntry | null> {
 		const dir = this.currentDir();
 		if (!dir) {
 			return null;
 		}
 		const file = path.join(dir, `${sanitize(name)}.json`);
-		if (!fs.existsSync(file)) {
-			return null;
-		}
 		try {
-			return JSON.parse(fs.readFileSync(file, 'utf8')) as ShelfEntry;
+			return JSON.parse(await fs.promises.readFile(file, 'utf8')) as ShelfEntry;
 		} catch {
 			return null;
 		}
@@ -205,7 +209,7 @@ export class ShelfTreeProvider implements vscode.TreeDataProvider<ShelfTreeNode>
 		this._onDidChange.fire(undefined);
 	}
 
-	getChildren(element?: ShelfTreeNode): ShelfTreeNode[] {
+	async getChildren(element?: ShelfTreeNode): Promise<ShelfTreeNode[]> {
 		if (!element) {
 			return this.shelfService.listShelves();
 		}
@@ -274,9 +278,11 @@ export function registerShelfCommands(service: GitRepositoryService, shelfServic
 			try {
 				await shelfService.shelve(name.trim(), picks.map((p) => p.label), new Date().toISOString());
 				shelfTree.refresh();
+				// Shelf 视图默认隐藏：创建后聚焦引导定位（reveal 需要 provider 重建的元素实例，focus 更稳）。
+				void vscode.commands.executeCommand('hyperGit.shelf.focus');
 				void vscode.window.showInformationMessage(`Shelved "${name.trim()}" (${picks.length} files)`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to shelve: ${errMsg(e)}`);
+				void showGitError(`Failed to shelve: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -291,7 +297,7 @@ export function registerShelfCommands(service: GitRepositoryService, shelfServic
 				shelfTree.refresh();
 				void vscode.window.showInformationMessage(`Unshelved "${node.name}"`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to unshelve: ${errMsg(e)}`);
+				void showGitError(`Failed to unshelve: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -307,7 +313,7 @@ export function registerShelfCommands(service: GitRepositoryService, shelfServic
 				void vscode.window.showInformationMessage(`Unshelved "${node.name}" (3-way)`);
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Unshelve'))) {
-					void vscode.window.showErrorMessage(`Failed to unshelve: ${errMsg(e)}`);
+					void showGitError(`Failed to unshelve: ${errMsg(e)}`);
 				}
 			}
 		}),
@@ -320,7 +326,7 @@ export function registerShelfCommands(service: GitRepositoryService, shelfServic
 			}
 			const ok = await vscode.window.showWarningMessage(`Delete shelf "${node.name}"?`, { modal: true }, 'Delete');
 			if (ok === 'Delete') {
-				shelfService.drop(node.name);
+				await shelfService.drop(node.name);
 				shelfTree.refresh();
 			}
 		}),

--- a/src/adapter/shelf.ts
+++ b/src/adapter/shelf.ts
@@ -76,6 +76,11 @@ export class ShelfService {
 			/* 目标目录不存在 → 检查旧版平铺数据 */
 		}
 		try {
+			await fs.promises.access(this.shelvesBase);
+		} catch {
+			return; // 基目录不存在（从未创建过 shelf）：无旧数据可迁，静默退出（ENOENT 非失败，勿污染 Console）
+		}
+		try {
 			const legacyFiles = (await fs.promises.readdir(this.shelvesBase)).filter((f) => f.endsWith('.json'));
 			if (legacyFiles.length === 0) {
 				return;

--- a/src/adapter/stash-commands.ts
+++ b/src/adapter/stash-commands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { showGitError } from './notify';
+import { validateRefName } from '../engine/ref/ref-name';
 import type { GitRepositoryService } from './git-repository-service';
 import type { StashEntryNode, StashNode, StashTreeProvider } from './tree/stash-tree';
 import { handleGitConflict } from './conflict-ui';
@@ -200,7 +201,11 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 					return;
 				}
 			}
-			const name = await vscode.window.showInputBox({ prompt: `Create and checkout a new branch from stash@{${index}}`, placeHolder: 'New branch name' });
+			const name = await vscode.window.showInputBox({
+				prompt: `Create and checkout a new branch from stash@{${index}}`,
+				placeHolder: 'New branch name',
+				validateInput: (v) => validateRefName(v, 'branch'),
+			});
 			if (!name || !name.trim()) {
 				return;
 			}

--- a/src/adapter/stash-commands.ts
+++ b/src/adapter/stash-commands.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import type { GitRepositoryService } from './git-repository-service';
-import type { StashNode, StashTreeProvider } from './tree/stash-tree';
+import type { StashEntryNode, StashNode, StashTreeProvider } from './tree/stash-tree';
 import { handleGitConflict } from './conflict-ui';
 
 /**
@@ -30,7 +31,7 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 				const doc = await vscode.workspace.openTextDocument({ content: patch, language: 'diff' });
 				await vscode.window.showTextDocument(doc, { preview: true });
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to show stash: ${errMsg(e)}`);
+				void showGitError(`Failed to show stash: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -45,8 +46,10 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 			try {
 				await repo.createStash({ message: message && message.trim() ? message.trim() : undefined, includeUntracked: true });
 				stashTree.refresh();
+				// Stash 视图默认隐藏：创建后聚焦引导定位。
+				void vscode.commands.executeCommand('hyperGit.stash.focus');
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create stash: ${errMsg(e)}`);
+				void showGitError(`Failed to create stash: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -62,7 +65,7 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 				await repo.applyStash(index);
 				stashTree.refresh();
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to apply stash: ${errMsg(e)}`);
+				void showGitError(`Failed to apply stash: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -79,27 +82,44 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 				stashTree.refresh();
 			} catch (e) {
 				if (!(await handleGitConflict(service, 'Stash pop'))) {
-					void vscode.window.showErrorMessage(`Failed to pop stash: ${errMsg(e)}`);
+					void showGitError(`Failed to pop stash: ${errMsg(e)}`);
 				}
 			}
 		}),
 	);
 
 	subs.push(
-		vscode.commands.registerCommand('hyperGit.stashDrop', async (node?: StashNode) => {
+		vscode.commands.registerCommand('hyperGit.stashDrop', async (node?: StashNode, nodes?: StashNode[]) => {
 			const repo = service.repo;
 			if (!repo) {
 				return;
 			}
-			const index = node?.kind === 'stash' ? node.index : 0;
-			const choice = await vscode.window.showWarningMessage(`Drop stash@{${index}}?`, { modal: true }, 'Drop');
-			if (choice === 'Drop') {
+			// 多选批量（canSelectMany）：drop stash@{n} 会使更高序号前移，按 index 降序删除防位移错删。
+			const targets = (nodes?.length ? nodes : node ? [node] : [])
+				.filter((n): n is StashEntryNode => n?.kind === 'stash')
+				.sort((a, b) => b.index - a.index);
+			if (targets.length === 0) {
+				return;
+			}
+			const label =
+				targets.length === 1
+					? `Drop stash@{${targets[0].index}}?`
+					: `Drop ${targets.length} stashes?`;
+			const choice = await vscode.window.showWarningMessage(label, { modal: true }, 'Drop');
+			if (choice !== 'Drop') {
+				return;
+			}
+			const failures: string[] = [];
+			for (const t of targets) {
 				try {
-					await repo.dropStash(index);
-					stashTree.refresh();
-				} catch (e) {
-					void vscode.window.showErrorMessage(`Failed to drop stash: ${errMsg(e)}`);
+					await repo.dropStash(t.index);
+				} catch {
+					failures.push(`stash@{${t.index}}`);
 				}
+			}
+			stashTree.refresh();
+			if (failures.length > 0) {
+				void vscode.window.showWarningMessage(`Dropped ${targets.length - failures.length} stash(es), ${failures.length} failed: ${failures.join(', ')}`);
 			}
 		}),
 	);
@@ -122,7 +142,7 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 				stashTree.refresh();
 				void vscode.window.showInformationMessage('Stashed (index kept)');
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to stash: ${errMsg(e)}`);
+				void showGitError(`Failed to stash: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -142,7 +162,7 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 				stashTree.refresh();
 				void vscode.window.showInformationMessage('Cleared all stashes');
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to clear stashes: ${errMsg(e)}`);
+				void showGitError(`Failed to clear stashes: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -176,7 +196,7 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 					}
 					index = pick.index;
 				} catch (e) {
-					void vscode.window.showErrorMessage(`Failed to read stash list: ${errMsg(e)}`);
+					void showGitError(`Failed to read stash list: ${errMsg(e)}`);
 					return;
 				}
 			}
@@ -189,7 +209,7 @@ export function registerStashCommands(service: GitRepositoryService, stashTree: 
 				stashTree.refresh();
 				void vscode.window.showInformationMessage(`Created branch ${name.trim()} from stash@{${index}}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create branch: ${errMsg(e)}`);
+				void showGitError(`Failed to create branch: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/task-progress.ts
+++ b/src/adapter/task-progress.ts
@@ -1,0 +1,17 @@
+import * as vscode from 'vscode';
+
+/**
+ * 长时 git 操作的进度反馈封装（对齐全内置 Git 视图行为）。
+ *
+ * 默认 ProgressLocation.Window（标题栏非阻塞、不遮挡交互）；重量级或可能长时间
+ * 无响应的操作（updateProject、交互 rebase）以 Notification 位置显式告知。
+ * cancellable 恒 false：execGit 无 kill 通道，真取消需先打通进程终止，延后实现。
+ * 只应包裹用户交互（QuickPick/确认框）完成后的 git 执行段，避免进度条覆盖对话框。
+ */
+export async function runWithProgress<T>(
+	title: string,
+	task: (progress: vscode.Progress<{ message?: string; increment?: number }>) => Promise<T>,
+	opts?: { location?: vscode.ProgressLocation },
+): Promise<T> {
+	return vscode.window.withProgress({ location: opts?.location ?? vscode.ProgressLocation.Window, title, cancellable: false }, task);
+}

--- a/src/adapter/tree/stash-tree.ts
+++ b/src/adapter/tree/stash-tree.ts
@@ -22,8 +22,14 @@ export type StashNode = StashEntryNode;
 export class StashTreeProvider implements vscode.TreeDataProvider<StashNode>, vscode.Disposable {
 	private readonly _onDidChange = new vscode.EventEmitter<StashNode | undefined>();
 	readonly onDidChangeTreeData = this._onDidChange.event;
+	private viewMessageSink?: (message: string | undefined) => void;
 
 	constructor(private readonly service: GitRepositoryService) {}
+
+	/** 视图内联消息通道（extension.ts 接线到 TreeView.message；加载失败不再静默成空树）。 */
+	setViewMessageSink(sink: (message: string | undefined) => void): void {
+		this.viewMessageSink = sink;
+	}
 
 	refresh(): void {
 		this._onDidChange.fire(undefined);
@@ -35,6 +41,7 @@ export class StashTreeProvider implements vscode.TreeDataProvider<StashNode>, vs
 			return [];
 		}
 		try {
+			this.viewMessageSink?.(undefined);
 			const out = await this.service.execGit(['stash', 'list', '--date=relative']);
 			return out
 				.split('\n')
@@ -52,15 +59,16 @@ export class StashTreeProvider implements vscode.TreeDataProvider<StashNode>, vs
 					}
 					return { kind: 'stash', index, message: rest, date };
 				});
-		} catch {
+		} catch (e) {
+			this.viewMessageSink?.(`Failed to list stashes: ${(e as Error).message}`);
 			return [];
 		}
 	}
 
 	getTreeItem(node: StashNode): vscode.TreeItem {
+		// label 不预截断：VS Code 树渲染自带省略，完整 subject 保留给 tooltip。
 		const subject = node.message.split(':').slice(1).join(':').trim() || node.message;
-		const trimmed = subject.length > 60 ? `${subject.slice(0, 60)}…` : subject;
-		const item = new vscode.TreeItem(trimmed, vscode.TreeItemCollapsibleState.None);
+		const item = new vscode.TreeItem(subject, vscode.TreeItemCollapsibleState.None);
 		item.id = `stash:${node.index}`;
 		item.description = node.date || `stash@{${node.index}}`;
 		item.contextValue = 'hyperGit.stash';

--- a/src/adapter/tree/tree-tooltip.ts
+++ b/src/adapter/tree/tree-tooltip.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { formatRelative } from '../../engine/log/format-time';
 
 /**
  * 树 Tooltip 共享构造器（MarkdownString，单一下沉入口）。
@@ -7,9 +8,8 @@ import * as vscode from 'vscode';
  * 取代各树 `\n` 拼接的纯文本 tooltip，统一粗体标签 + code 样式，深/浅主题自适应。
  */
 export function mdTooltip(rows: ReadonlyArray<readonly [string, string]>, opts?: { title?: string }): vscode.MarkdownString {
+	// 构造器第二参即 supportThemeIcons（无冗余属性赋值）；isTrusted 缺省 false（安全默认）。
 	const md = new vscode.MarkdownString('', true);
-	md.isTrusted = false;
-	md.supportThemeIcons = true;
 	if (opts?.title) {
 		md.appendMarkdown(`**${escapeMd(opts.title)}**\n\n`);
 	}
@@ -29,31 +29,10 @@ function escapeMd(s: string): string {
 }
 
 /**
- * ISO 时间 → 相对人可读描述（"just now" / "N min ago" / "N hr ago" / "N days ago" / "Mon D"）。
- * 用于 stash/shelf 行内描述；技术标识（stash@{n} / 原始 ISO）保留在 Tooltip。
- * 解析失败时原样返回，不阻断渲染。
+ * ISO 时间 → 相对人可读描述，委托 engine/log/format-time.formatRelative（单一事实源，
+ * 措辞对齐官方 GRAPH）。用于 stash/shelf 行内描述；技术标识保留在 Tooltip。
+ * 解析失败时原样返回（formatRelative 回空串），不阻断渲染。
  */
 export function relativeDate(iso: string): string {
-	const t = new Date(iso).getTime();
-	if (Number.isNaN(t)) {
-		return iso;
-	}
-	const diff = Date.now() - t;
-	const min = 60_000;
-	const hr = 3_600_000;
-	const day = 86_400_000;
-	if (diff < min) {
-		return 'just now';
-	}
-	if (diff < hr) {
-		return `${Math.floor(diff / min)} min ago`;
-	}
-	if (diff < day) {
-		return `${Math.floor(diff / hr)} hr ago`;
-	}
-	const days = Math.floor(diff / day);
-	if (days < 30) {
-		return `${days} day${days === 1 ? '' : 's'} ago`;
-	}
-	return new Date(t).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+	return formatRelative(iso) || iso;
 }

--- a/src/adapter/tree/worktree-tree.ts
+++ b/src/adapter/tree/worktree-tree.ts
@@ -34,6 +34,12 @@ export class WorktreeTreeProvider implements vscode.TreeDataProvider<WorktreeNod
 	private readonly disposables: vscode.Disposable[] = [];
 	private cache: WorktreeNode[] | undefined;
 	private inFlight: Promise<WorktreeNode[]> | undefined;
+	private viewMessageSink?: (message: string | undefined) => void;
+
+	/** 视图内联消息通道（extension.ts 接线到 TreeView.message；加载失败不再静默成空树）。 */
+	setViewMessageSink(sink: (message: string | undefined) => void): void {
+		this.viewMessageSink = sink;
+	}
 
 	constructor(private readonly service: GitRepositoryService) {
 		this.disposables.push(service.onDidChange(() => this.refresh()));
@@ -60,8 +66,10 @@ export class WorktreeTreeProvider implements vscode.TreeDataProvider<WorktreeNod
 				const out = await this.service.execGit(['worktree', 'list', '--porcelain', '-z']);
 				const nodes = parseWorktreeList(out).map((p) => this.toNode(p));
 				this.cache = nodes;
+				this.viewMessageSink?.(undefined);
 				return nodes;
-			} catch {
+			} catch (e) {
+				this.viewMessageSink?.(`Failed to list worktrees: ${(e as Error).message}`);
 				return [];
 			} finally {
 				this.inFlight = undefined;
@@ -154,7 +162,10 @@ export class WorktreeTreeProvider implements vscode.TreeDataProvider<WorktreeNod
 /**
  * 工作树路径归一比较：`realpathSync` 规避 macOS `/tmp` ↔ `/private/tmp` 软链漏判；
  * 路径不存在（如 prunable，目录已删除）时退回原值。`path.normalize` 后去尾部分隔符。
+ * 结果按路径记忆化：避免 getTreeItem 每行渲染重复同步 IO（工作树个数少，缓存无界风险可忽略）。
  */
+const normalizedPathCache = new Map<string, string>();
+
 function isSameWorktreePath(a: string, b: string | undefined): boolean {
 	if (!b) {
 		return false;
@@ -163,11 +174,17 @@ function isSameWorktreePath(a: string, b: string | undefined): boolean {
 }
 
 function normalizeWorktreePath(p: string): string {
+	const cached = normalizedPathCache.get(p);
+	if (cached !== undefined) {
+		return cached;
+	}
 	let resolved = p;
 	try {
 		resolved = fs.realpathSync(p);
 	} catch {
 		// 路径不存在（prunable）或不可读 → 用原值（不阻断比较）。
 	}
-	return path.normalize(resolved).replace(/[\\/]+$/, '');
+	const normalized = path.normalize(resolved).replace(/[\\/]+$/, '');
+	normalizedPathCache.set(p, normalized);
+	return normalized;
 }

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -202,45 +202,48 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 <meta http-equiv="Content-Security-Policy" content="${csp}">
 <style>
 ${getBaseStyles()}
-body { margin: 0; padding: var(--hg-space-2); font-family: var(--vscode-font-family); color: var(--vscode-foreground); font-size: var(--vscode-font-size); }
+body { margin: 0; padding: var(--hg-space-2); font-family: var(--vscode-font-family); color: var(--vscode-foreground); font-size: var(--vscode-font-size); background: var(--vscode-sideBar-background); }
 .cl-bar { display: flex; align-items: center; gap: 6px; margin-bottom: var(--hg-space-1); }
 .cl-bar .cl-label { flex: 0 0 auto; font-weight: 600; }
-#cl-switch { flex: 1 1 auto; min-width: 0; background: var(--vscode-dropdown-background); color: var(--vscode-dropdown-foreground); border: 1px solid var(--vscode-dropdown-border, var(--vscode-input-border, transparent)); border-radius: var(--hg-radius-control); padding: 2px 4px; font-size: 12px; }
+#cl-switch { flex: 1 1 auto; min-width: 0; } /* 视觉走共享 .hg-select（dropdown token 单一事实源） */
 .cl-menu-btn { flex: 0 0 auto; padding: 1px 7px; }
 .seg { display: inline-flex; border: 1px solid var(--vscode-input-border, transparent); border-radius: 3px; overflow: hidden; }
-.seg button { background: transparent; color: var(--vscode-foreground); border: none; padding: 2px 8px; font-size: 11px; cursor: pointer; opacity: 0.7; }
+.seg button { background: transparent; color: var(--vscode-foreground); border: none; padding: 2px 8px; font-size: calc(var(--vscode-font-size) - 2px); cursor: pointer; opacity: 0.7; }
 .seg button.active { background: var(--vscode-button-background); color: var(--vscode-button-foreground); opacity: 1; }
 .files { max-height: 260px; overflow-y: auto; border: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.3)); border-radius: var(--hg-radius-control); margin-bottom: var(--hg-space-2); }
 .file { display: flex; align-items: center; gap: 6px; padding: 2px 6px; cursor: pointer; }
 .file:hover { background: var(--vscode-list-hoverBackground); }
-.file .dot { font-size: 14px; line-height: 1; flex: 0 0 auto; }
+.file .dot { font-size: calc(var(--vscode-font-size) + 1px); line-height: 1; flex: 0 0 auto; }
 .file .name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.file .dir { margin-left: auto; color: var(--vscode-descriptionForeground); font-size: 11px; white-space: nowrap; padding-left: 8px; }
+.file .dir { margin-left: auto; color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 2px); white-space: nowrap; padding-left: 8px; }
 .tree-dir { display: flex; align-items: center; gap: 6px; padding: 2px 6px; cursor: pointer; user-select: none; }
 .tree-dir:hover { background: var(--vscode-list-hoverBackground); }
-.tree-twist { flex: 0 0 12px; text-align: center; font-size: 10px; opacity: 0.8; }
+.tree-twist { flex: 0 0 12px; text-align: center; font-size: calc(var(--vscode-font-size) - 3px); opacity: 0.8; }
 .tree-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--vscode-descriptionForeground); }
 textarea { width: 100%; box-sizing: border-box; resize: vertical; }
-.validation { font-size: 11px; min-height: 16px; margin: 4px 2px; }
+.validation { font-size: calc(var(--vscode-font-size) - 2px); min-height: 16px; margin: 4px 2px; }
 .validation.ok { color: var(--vscode-testing-iconPassed, #3fb950); }
 .validation.warning { color: var(--vscode-editorWarning-foreground, #d29922); }
 .validation.error { color: var(--vscode-errorForeground, #f85149); }
 .recent { margin: 4px 0 var(--hg-space-2); display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }
-.recent-label { color: var(--vscode-descriptionForeground); font-size: 11px; }
-.chip { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: none; border-radius: 9px; padding: 1px 8px; font-size: 11px; cursor: pointer; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.chip:hover { opacity: 0.85; }
-.opt { display: block; font-size: 12px; margin: 3px 2px; }
+.recent-label { color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 2px); }
+.hg-chip { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: none; border-radius: 9px; padding: 1px 8px; font-size: calc(var(--vscode-font-size) - 2px); cursor: pointer; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.hg-chip:hover { opacity: 0.85; }
+.opt { display: block; font-size: calc(var(--vscode-font-size) - 1px); margin: 3px 2px; }
 .buttons { display: flex; gap: 6px; margin-top: var(--hg-space-2); }
 .buttons .hg-btn { flex: 1; }
 .files-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; min-height: 18px; padding: 0 6px; color: var(--vscode-descriptionForeground); }
-.files-empty { padding: 14px 8px; text-align: center; color: var(--vscode-descriptionForeground); font-size: 12px; }
+.files-empty { padding: 14px 8px; text-align: center; color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 1px); }
 .spinner { display: inline-block; width: 12px; height: 12px; border: 1.5px solid currentColor; border-top-color: transparent; border-radius: 50%; animation: hg-spin 0.8s linear infinite; vertical-align: -2px; margin-right: 5px; }
 @keyframes hg-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+	.spinner { animation-duration: 1.6s; } /* 前庭安全：降频保留进行中指示（与 Graph .ci-spin 同策略） */
+}
 details.advanced { margin: 6px 0 var(--hg-space-2); }
-details.advanced summary { cursor: pointer; font-size: 12px; color: var(--vscode-descriptionForeground); }
+details.advanced summary { cursor: pointer; font-size: calc(var(--vscode-font-size) - 1px); color: var(--vscode-descriptionForeground); }
 details.advanced summary:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 1px; border-radius: 2px; }
 details.advanced[open] summary { margin-bottom: 4px; }
-.toast { font-size: 12px; margin-top: var(--hg-space-2); min-height: 16px; }
+.toast { font-size: calc(var(--vscode-font-size) - 1px); margin-top: var(--hg-space-2); min-height: 16px; }
 .toast.ok { color: var(--vscode-testing-iconPassed, #3fb950); }
 .toast.err { color: var(--vscode-errorForeground, #f85149); }
 </style>
@@ -248,7 +251,7 @@ details.advanced[open] summary { margin-bottom: 4px; }
 <body>
 <div class="cl-bar">
   <span class="cl-label">Active Changelist:</span>
-  <select id="cl-switch" title="Switch active changelist"></select>
+  <select id="cl-switch" class="hg-select" title="Switch active changelist"></select>
   <button id="cl-menu" class="hg-btn hg-btn--secondary hg-btn--sm cl-menu-btn" title="Changelist actions" aria-label="Changelist actions">⋯</button>
 </div>
 <div class="files-header" id="files-header" style="display:none">
@@ -563,7 +566,7 @@ function renderRecent(messages) {
   recentEl.appendChild(label);
   messages.slice(0, 5).forEach(function (m) {
     const chip = document.createElement('button');
-    chip.className = 'chip';
+    chip.className = 'hg-chip';
     chip.textContent = m.split('\\n')[0].slice(0, 40);
     chip.title = m;
     chip.addEventListener('click', function () {

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'crypto';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { getDecoration } from '../../engine/scm-mapping/status-decoration';
@@ -15,6 +14,7 @@ import type {
 } from '../../shared/protocol';
 import type { CommitService } from '../commit/commit-service';
 import { getBaseStyles } from './shared-styles';
+import { getNonce } from './nonce';
 
 /**
  * Commit 提交窗口（WebviewView，自绘提交面板）。
@@ -275,12 +275,14 @@ details.advanced[open] summary { margin-bottom: 4px; }
 
 <script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
-// ── 勾选集/视图模式按仓库分区（v2，issue #107）：勾选是相对路径集合，跨仓库本就错位；
-// 切换仓库换装载互不串扰；无 v2 时从旧平铺结构一次性升级（旧值归首个见到的仓库）。──
+// ── 勾选集/视图模式/提交草稿按仓库分区（v3，issue #107）：勾选是相对路径集合，跨仓库本就错位；
+// 切换仓库换装载互不串扰；v3 起 draft（message + amend/signoff/skipHooks）一并入 state——
+// 视图隐藏销毁 / 窗口 reload 后草稿可恢复（对齐内置 SCM 输入框草稿语义），提交成功即清空。
+// 旧版 state（v2 byRepo / v1 平铺）无感升级，draft 缺省为空。──
 const persistedRaw = vscode.getState() || {};
 let persistedRepo = '';
 let persistedByRepo = {};
-if (persistedRaw.v === 2 && persistedRaw.byRepo) {
+if ((persistedRaw.v === 2 || persistedRaw.v === 3) && persistedRaw.byRepo) {
   persistedByRepo = persistedRaw.byRepo;
 } else if (persistedRaw.checked || persistedRaw.mode || persistedRaw.collapsed) {
   persistedByRepo = { '': { checked: persistedRaw.checked, mode: persistedRaw.mode, collapsed: persistedRaw.collapsed } };
@@ -288,17 +290,26 @@ if (persistedRaw.v === 2 && persistedRaw.byRepo) {
 let checked = new Set();
 let mode = 'flat';
 let collapsed = new Set();
+let draft = null; // 当前仓库的草稿快照（loadPersistedFor 装载；仅 webview 重建/切仓库时回灌 DOM）
 function loadPersistedFor(repoRoot) {
   persistedRepo = repoRoot;
   const s = persistedByRepo[repoRoot] || persistedByRepo[''] || {};
   checked = new Set(s.checked || []);
   mode = s.mode === 'tree' ? 'tree' : 'flat';
   collapsed = new Set(s.collapsed || []);
+  draft = s.draft || null;
 }
+// saveState 从 DOM 现值取 draft（草稿写点统一收敛于此）：输入即时保存，彻底消除 200ms debounce 尾丢。
 function saveState() {
-  persistedByRepo[persistedRepo] = { checked: Array.from(checked), mode: mode, collapsed: Array.from(collapsed) };
-  vscode.setState({ v: 2, byRepo: persistedByRepo });
+  persistedByRepo[persistedRepo] = {
+    checked: Array.from(checked),
+    mode: mode,
+    collapsed: Array.from(collapsed),
+    draft: { message: msgEl.value, amend: amendEl.checked, signoff: signoffEl.checked, skipHooks: skipHooksEl.checked }
+  };
+  vscode.setState({ v: 3, byRepo: persistedByRepo });
 }
+let draftRestored = false;
 let conventionalEnabled = true;
 let templateApplied = false;
 let curFiles = [];
@@ -324,11 +335,15 @@ const modeTreeEl = document.getElementById('mode-tree');
 
 let msgTimer = null;
 msgEl.addEventListener('input', function () {
+  saveState(); // 草稿即时持久化（防抖前落盘，视图销毁不丢尾部输入）
   clearTimeout(msgTimer);
   msgTimer = setTimeout(function () {
     vscode.postMessage({ type: 'messageChanged', payload: { message: msgEl.value } });
   }, 200);
 });
+amendEl.addEventListener('change', saveState);
+signoffEl.addEventListener('change', saveState);
+skipHooksEl.addEventListener('change', saveState);
 
 // Ctrl/Cmd+Enter 提交（业界通用快捷键：VS Code/GitHub/JetBrains 一致）。
 msgEl.addEventListener('keydown', function (e) {
@@ -552,6 +567,7 @@ function renderRecent(messages) {
     chip.title = m;
     chip.addEventListener('click', function () {
       msgEl.value = m;
+      saveState();
       vscode.postMessage({ type: 'messageChanged', payload: { message: msgEl.value } });
     });
     recentEl.appendChild(chip);
@@ -577,7 +593,21 @@ window.addEventListener('message', function (e) {
   const m = e.data;
   if (m.type === 'state') {
     const p = m.payload;
-    loadPersistedFor(p.repoRoot || '');
+    const repoRoot = p.repoRoot || '';
+    // 草稿回灌仅两种时机：webview 重建后首帧、活跃仓库切换（loadPersistedFor 会改写 persistedRepo，先判定）。
+    // 必须先于 reconcileChecked/saveState——saveState 从 DOM 取草稿，先回灌才能在后续保存中保住草稿。
+    const restoreDraft = !draftRestored || repoRoot !== persistedRepo;
+    loadPersistedFor(repoRoot);
+    if (restoreDraft && draft) {
+      msgEl.value = draft.message || '';
+      amendEl.checked = Boolean(draft.amend);
+      signoffEl.checked = Boolean(draft.signoff);
+      skipHooksEl.checked = Boolean(draft.skipHooks);
+      if (draft.message) {
+        vscode.postMessage({ type: 'messageChanged', payload: { message: draft.message } });
+      }
+    }
+    draftRestored = true;
     curFiles = p.files || [];
     curTree = p.tree || [];
     reconcileChecked(curFiles);
@@ -589,6 +619,7 @@ window.addEventListener('message', function (e) {
     conventionalEnabled = p.conventionalEnabled;
     if (!templateApplied && p.template && !msgEl.value) {
       msgEl.value = p.template;
+      saveState();
       vscode.postMessage({ type: 'messageChanged', payload: { message: msgEl.value } });
     }
     templateApplied = true;
@@ -600,6 +631,7 @@ window.addEventListener('message', function (e) {
       toast(m.payload.warning || 'Commit succeeded', Boolean(m.payload.warning));
       msgEl.value = '';
       amendEl.checked = false; signoffEl.checked = false; skipHooksEl.checked = false;
+      saveState(); // 提交成功清空草稿（失败保留，供修改重试）
       vscode.postMessage({ type: 'messageChanged', payload: { message: '' } });
     } else {
       toast(m.payload.error || 'Commit failed', true);
@@ -612,8 +644,4 @@ vscode.postMessage({ type: 'requestState' });
 </body>
 </html>`;
 	}
-}
-
-function getNonce(): string {
-	return crypto.randomBytes(16).toString('base64');
 }

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -93,14 +93,15 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 		if (!change) {
 			return;
 		}
+		// QuickPick label 支持 $(codicon) 内联图标（与 changelist 菜单对齐）。
 		const actions: ReadonlyArray<{ readonly label: string; readonly command: string }> = [
-			{ label: 'Open Diff', command: 'hyperGit.openDiff' },
-			{ label: 'Move to Changelist…', command: 'hyperGit.moveChangelist' },
-			{ label: 'Show History', command: 'hyperGit.showHistory' },
-			{ label: 'Stage Hunks…', command: 'hyperGit.partialStage' },
-			{ label: 'Unstage Hunks…', command: 'hyperGit.partialUnstage' },
-			{ label: 'Add to .gitignore', command: 'hyperGit.ignorePath' },
-			{ label: 'Discard Changes', command: 'hyperGit.discardChanges' },
+			{ label: '$(diff) Open Diff', command: 'hyperGit.openDiff' },
+			{ label: '$(symbol-enum) Move to Changelist…', command: 'hyperGit.moveChangelist' },
+			{ label: '$(history) Show History', command: 'hyperGit.showHistory' },
+			{ label: '$(diff-added) Stage Hunks…', command: 'hyperGit.partialStage' },
+			{ label: '$(diff-removed) Unstage Hunks…', command: 'hyperGit.partialUnstage' },
+			{ label: '$(diff-ignored) Add to .gitignore', command: 'hyperGit.ignorePath' },
+			{ label: '$(discard) Discard Changes', command: 'hyperGit.discardChanges' },
 		];
 		const pick = await vscode.window.showQuickPick(actions.slice(), { placeHolder: relativePath });
 		if (!pick) {

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -304,7 +304,10 @@ let collapsed = new Set();
 let draft = null; // 当前仓库的草稿快照（loadPersistedFor 装载；仅 webview 重建/切仓库时回灌 DOM）
 function loadPersistedFor(repoRoot) {
   persistedRepo = repoRoot;
-  const s = persistedByRepo[repoRoot] || persistedByRepo[''] || {};
+  // '' 条目兜底仅用于旧版 state（v1 平铺 / v2 迁移语义）；v3 起按仓严格隔离——
+  // 无本仓条目即空对象，避免无仓库会话期（repoRoot=''）写入的草稿回灌到其他仓库。
+  const fallback = persistedRaw.v === 3 ? undefined : persistedByRepo[''];
+  const s = persistedByRepo[repoRoot] || fallback || {};
   checked = new Set(s.checked || []);
   mode = s.mode === 'tree' ? 'tree' : 'flat';
   collapsed = new Set(s.collapsed || []);
@@ -653,16 +656,16 @@ window.addEventListener('message', function (e) {
     const repoRoot = p.repoRoot || '';
     // 草稿回灌仅两种时机：webview 重建后首帧、活跃仓库切换（loadPersistedFor 会改写 persistedRepo，先判定）。
     // 必须先于 reconcileChecked/saveState——saveState 从 DOM 取草稿，先回灌才能在后续保存中保住草稿。
+    // 回灌必须无条件同步 DOM（目标仓库无草稿则清空）：否则旧仓库的 message/amend 残留 DOM，
+    // 随后被 saveState 落盘为新仓库草稿（跨仓串扰；amend=true 泄漏会静默改写新仓库 HEAD）。
     const restoreDraft = !draftRestored || repoRoot !== persistedRepo;
     loadPersistedFor(repoRoot);
-    if (restoreDraft && draft) {
-      msgEl.value = draft.message || '';
-      amendEl.checked = Boolean(draft.amend);
-      signoffEl.checked = Boolean(draft.signoff);
-      skipHooksEl.checked = Boolean(draft.skipHooks);
-      if (draft.message) {
-        vscode.postMessage({ type: 'messageChanged', payload: { message: draft.message } });
-      }
+    if (restoreDraft) {
+      msgEl.value = (draft && draft.message) || '';
+      amendEl.checked = Boolean(draft && draft.amend);
+      signoffEl.checked = Boolean(draft && draft.signoff);
+      skipHooksEl.checked = Boolean(draft && draft.skipHooks);
+      vscode.postMessage({ type: 'messageChanged', payload: { message: msgEl.value } });
     }
     draftRestored = true;
     curFiles = p.files || [];

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -302,11 +302,14 @@ let checked = new Set();
 let mode = 'flat';
 let collapsed = new Set();
 let draft = null; // 当前仓库的草稿快照（loadPersistedFor 装载；仅 webview 重建/切仓库时回灌 DOM）
+let stateV3Written = false; // 本会话是否已落盘 v3 state：true 后 '' 兜底关闭（见 loadPersistedFor）
 function loadPersistedFor(repoRoot) {
   persistedRepo = repoRoot;
   // '' 条目兜底仅用于旧版 state（v1 平铺 / v2 迁移语义）；v3 起按仓严格隔离——
   // 无本仓条目即空对象，避免无仓库会话期（repoRoot=''）写入的草稿回灌到其他仓库。
-  const fallback = persistedRaw.v === 3 ? undefined : persistedByRepo[''];
+  // persistedRaw.v 是启动快照、saveState 后不更新：stateV3Written 补位——本会话首写 v3 后
+  // 即关闭兜底，升级/全新会话内同样保持隔离，无需等下一次 webview 重建。
+  const fallback = persistedRaw.v === 3 || stateV3Written ? undefined : persistedByRepo[''];
   const s = persistedByRepo[repoRoot] || fallback || {};
   checked = new Set(s.checked || []);
   mode = s.mode === 'tree' ? 'tree' : 'flat';
@@ -322,6 +325,7 @@ function saveState() {
     draft: { message: msgEl.value, amend: amendEl.checked, signoff: signoffEl.checked, skipHooks: skipHooksEl.checked }
   };
   vscode.setState({ v: 3, byRepo: persistedByRepo });
+  stateV3Written = true;
 }
 let draftRestored = false;
 let conventionalEnabled = true;

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -13,7 +13,7 @@ import type {
 	WebviewToHostMessage,
 } from '../../shared/protocol';
 import type { CommitService } from '../commit/commit-service';
-import { getBaseStyles } from './shared-styles';
+import { getBaseStyles, ICON_CHEVRON_DOWN, ICON_ELLIPSIS } from './shared-styles';
 import { getNonce } from './nonce';
 
 /**
@@ -158,6 +158,7 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 			label: path.basename(c.relativePath),
 			dir: path.dirname(c.relativePath),
 			themeColor: decoration.themeColor,
+			letter: decoration.letter,
 		};
 	}
 
@@ -210,15 +211,20 @@ body { margin: 0; padding: var(--hg-space-2); font-family: var(--vscode-font-fam
 .seg { display: inline-flex; border: 1px solid var(--vscode-input-border, transparent); border-radius: 3px; overflow: hidden; }
 .seg button { background: transparent; color: var(--vscode-foreground); border: none; padding: 2px 8px; font-size: calc(var(--vscode-font-size) - 2px); cursor: pointer; opacity: 0.7; }
 .seg button.active { background: var(--vscode-button-background); color: var(--vscode-button-foreground); opacity: 1; }
+.seg button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
 .files { max-height: 260px; overflow-y: auto; border: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.3)); border-radius: var(--hg-radius-control); margin-bottom: var(--hg-space-2); }
+.files:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
+.file.kb-focus, .tree-dir.kb-focus { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
 .file { display: flex; align-items: center; gap: 6px; padding: 2px 6px; cursor: pointer; }
 .file:hover { background: var(--vscode-list-hoverBackground); }
-.file .dot { font-size: calc(var(--vscode-font-size) + 1px); line-height: 1; flex: 0 0 auto; }
+.file .dot { flex: 0 0 1.2em; text-align: center; font-weight: 600; font-size: calc(var(--vscode-font-size) - 1px); line-height: 1; }
 .file .name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .file .dir { margin-left: auto; color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 2px); white-space: nowrap; padding-left: 8px; }
 .tree-dir { display: flex; align-items: center; gap: 6px; padding: 2px 6px; cursor: pointer; user-select: none; }
 .tree-dir:hover { background: var(--vscode-list-hoverBackground); }
-.tree-twist { flex: 0 0 12px; text-align: center; font-size: calc(var(--vscode-font-size) - 3px); opacity: 0.8; }
+.tree-twist { flex: 0 0 14px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.8; }
+.tree-twist svg { display: block; }
+.tree-twist.collapsed svg { transform: rotate(-90deg); }
 .tree-name { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--vscode-descriptionForeground); }
 textarea { width: 100%; box-sizing: border-box; resize: vertical; }
 .validation { font-size: calc(var(--vscode-font-size) - 2px); min-height: 16px; margin: 4px 2px; }
@@ -229,6 +235,7 @@ textarea { width: 100%; box-sizing: border-box; resize: vertical; }
 .recent-label { color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 2px); }
 .hg-chip { background: var(--vscode-button-secondaryBackground); color: var(--vscode-button-secondaryForeground); border: none; border-radius: 9px; padding: 1px 8px; font-size: calc(var(--vscode-font-size) - 2px); cursor: pointer; max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .hg-chip:hover { opacity: 0.85; }
+.hg-chip:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 1px; }
 .opt { display: block; font-size: calc(var(--vscode-font-size) - 1px); margin: 3px 2px; }
 .buttons { display: flex; gap: 6px; margin-top: var(--hg-space-2); }
 .buttons .hg-btn { flex: 1; }
@@ -252,7 +259,7 @@ details.advanced[open] summary { margin-bottom: 4px; }
 <div class="cl-bar">
   <span class="cl-label">Active Changelist:</span>
   <select id="cl-switch" class="hg-select" title="Switch active changelist"></select>
-  <button id="cl-menu" class="hg-btn hg-btn--secondary hg-btn--sm cl-menu-btn" title="Changelist actions" aria-label="Changelist actions">⋯</button>
+  <button id="cl-menu" class="hg-btn hg-btn--secondary hg-btn--sm cl-menu-btn" title="Changelist actions" aria-label="Changelist actions">${ICON_ELLIPSIS}</button>
 </div>
 <div class="files-header" id="files-header" style="display:none">
   <label class="opt" style="margin:0"><input type="checkbox" id="select-all"> Select All</label>
@@ -261,7 +268,7 @@ details.advanced[open] summary { margin-bottom: 4px; }
     <button id="mode-tree" aria-pressed="false" title="Group by directory">Tree</button>
   </span>
 </div>
-<div class="files" id="files"></div>
+<div class="files" id="files" tabindex="0" role="tree" aria-label="Changed files"></div>
 <textarea id="message" class="hg-input" rows="4" placeholder="Commit message (Conventional Commits: type(scope): description)" spellcheck="false"></textarea>
 <div id="validation" class="validation" role="status" aria-live="polite"></div>
 <div class="recent" id="recent"></div>
@@ -319,6 +326,7 @@ let templateApplied = false;
 let curFiles = [];
 let curTree = [];
 const INDENT = 14;
+const ICON_CHEVRON = ${JSON.stringify(ICON_CHEVRON_DOWN)};
 const EMPTY_HTML = '<div class="files-empty">No changes in this changelist.<br>Edit files in your workspace and they will appear here.</div>';
 const filesEl = document.getElementById('files');
 const msgEl = document.getElementById('message');
@@ -410,10 +418,11 @@ function makeLeafRow(f, depth) {
     if (cb.checked) checked.add(f.path); else checked.delete(f.path);
     saveState(); syncSelectAll(); updateDirStates();
   });
+  // 状态字母标记（M/A/U/R/D/C…）替代色点：色盲可辨、对齐官方 SCM 角标（兜底空串）。
   const dot = document.createElement('span');
   dot.className = 'dot';
   dot.style.color = 'var(--vscode-' + f.themeColor.replace(/\\./g, '-') + ')';
-  dot.textContent = '\\u25CF';
+  dot.textContent = f.letter || '';
   const name = document.createElement('span');
   name.className = 'name';
   name.textContent = f.label;
@@ -457,8 +466,8 @@ function renderNode(node, depth, parent, files) {
     dirRow.style.paddingLeft = (depth * INDENT + 6) + 'px';
     dirRow.dataset.dir = node.path;
     const tw = document.createElement('span');
-    tw.className = 'tree-twist';
-    tw.textContent = isCol ? '\\u25B8' : '\\u25BE';
+    tw.className = 'tree-twist' + (isCol ? ' collapsed' : '');
+    tw.innerHTML = ICON_CHEVRON;
     const cb = document.createElement('input');
     cb.type = 'checkbox'; cb.className = 'dir-cb'; cb.dataset.dir = node.path;
     cb.addEventListener('click', function (e) { e.stopPropagation(); });
@@ -516,6 +525,7 @@ function toggleCollapse(p) {
 }
 
 function renderList() {
+  kbIdx = -1;
   filesEl.innerHTML = '';
   if (!curFiles || curFiles.length === 0) {
     filesHeaderEl.style.display = 'none';
@@ -526,6 +536,39 @@ function renderList() {
   if (mode === 'tree') { renderTree(curTree, curFiles); } else { renderFlat(curFiles); }
   syncSelectAll();
 }
+
+// ── 键盘可达性（复刻 Graph #viewport 模式）：容器级焦点，ArrowUp/Down/Home/End 移动、Enter 触发行、Escape 归还 ──
+let kbIdx = -1;
+function kbRows() { return Array.from(filesEl.querySelectorAll('.file, .tree-dir')); }
+function kbApply(idx) {
+  const rows = kbRows();
+  kbRows().forEach(function (r) { r.classList.remove('kb-focus'); });
+  kbIdx = idx;
+  if (kbIdx >= 0 && kbIdx < rows.length) {
+    rows[kbIdx].classList.add('kb-focus');
+    rows[kbIdx].scrollIntoView({ block: 'nearest' });
+  }
+}
+filesEl.addEventListener('keydown', function (e) {
+  const rows = kbRows();
+  if (rows.length === 0) { return; }
+  if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+    e.preventDefault();
+    if (kbIdx < 0) { kbApply(e.key === 'ArrowDown' ? 0 : rows.length - 1); return; }
+    kbApply(Math.max(0, Math.min(rows.length - 1, kbIdx + (e.key === 'ArrowDown' ? 1 : -1))));
+  } else if (e.key === 'Home') {
+    e.preventDefault(); kbApply(0);
+  } else if (e.key === 'End') {
+    e.preventDefault(); kbApply(rows.length - 1);
+  } else if (e.key === 'Enter' && kbIdx >= 0) {
+    e.preventDefault();
+    rows[kbIdx].click();
+  } else if (e.key === 'Escape') {
+    kbApply(-1);
+    filesEl.blur();
+  }
+});
+filesEl.addEventListener('focus', function () { if (kbIdx < 0) { kbApply(0); } });
 
 function updateModeButtons() {
   modeFlatEl.classList.toggle('active', mode === 'flat');
@@ -580,10 +623,20 @@ function renderRecent(messages) {
 
 function showValidation(v) {
   valEl.className = 'validation ' + v.severity;
+  valEl.textContent = '';
+  // 图标字符单独 aria-hidden（不进读屏播报）；\\uFE0E 强制文本呈现（防 ⚠/ℹ 在部分平台渲染为彩色 emoji）。
+  function iconSpan(ch) {
+    const el = document.createElement('span');
+    el.setAttribute('aria-hidden', 'true');
+    el.textContent = ch + '\\uFE0E';
+    el.style.marginRight = '4px';
+    return el;
+  }
   if (v.severity === 'ok') {
-    valEl.textContent = conventionalEnabled ? '\\u2713 Valid Conventional Commits' : '';
+    if (conventionalEnabled) { valEl.appendChild(iconSpan('\\u2713')); valEl.appendChild(document.createTextNode('Valid Conventional Commits')); }
   } else {
-    valEl.textContent = (v.severity === 'error' ? '\\u26A0 ' : '\\u2139 ') + (v.reason || '');
+    valEl.appendChild(iconSpan(v.severity === 'error' ? '\\u26A0' : '\\u2139'));
+    valEl.appendChild(document.createTextNode(v.reason || ''));
   }
 }
 

--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -1,11 +1,11 @@
-import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import type { GitRepositoryService } from '../git-repository-service';
 import { parseNameStatus, statusLabel, parseShortStat } from '../../engine/log/commit-files';
 import { applyClientFilters, toClientFilter, type LogFilter } from '../../engine/log/log-filter';
 import { DEFAULT_LANE_PALETTE } from '../../engine/log/graph-color';
 import { computeGraphLayout, maxLanes } from '../../engine/log/graph-layout';
-import { getBaseStyles } from './shared-styles';
+import { getBaseStyles, GRAPH_ROW_H, GRAPH_LANE_W } from './shared-styles';
+import { getNonce } from './nonce';
 import { parseLogLines } from '../../engine/log/log-line';
 import { buildLogArgs, type LogScope } from '../../engine/log/log-query';
 import { buildFileTree } from '../../engine/tree/file-tree';
@@ -531,7 +531,7 @@ export class LogWebviewProvider implements vscode.WebviewViewProvider, LogFilter
 	// ─── HTML 渲染 ──────────────────────────────────────────────────────────────
 
 	private renderHtml(): string {
-		const nonce = crypto.randomBytes(16).toString('base64');
+		const nonce = getNonce();
 		const laneFallback = JSON.stringify(DEFAULT_LANE_PALETTE);
 		const csp = ['default-src \'none\'', 'style-src \'unsafe-inline\'', `script-src 'nonce-${nonce}'`].join('; ');
 		return `<!DOCTYPE html>
@@ -541,7 +541,6 @@ export class LogWebviewProvider implements vscode.WebviewViewProvider, LogFilter
 <meta http-equiv="Content-Security-Policy" content="${csp}">
 <style>
 ${getBaseStyles()}
-:root { --hg-row: 24px; --hg-lane: 14px; }
 * { box-sizing: border-box; }
 body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-sideBar-background); display: flex; flex-direction: column; height: 100vh; overflow: hidden; }
 #viewport { flex: 1; min-width: 0; overflow-y: auto; overflow-x: hidden; position: relative; outline: none; }
@@ -564,8 +563,8 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 .chip .chip-ico { flex: 0 0 auto; width: 11px; height: 11px; display: inline-flex; }
 .chip .chip-ico svg { width: 11px; height: 11px; display: block; }
 .chip .chip-nm { overflow: hidden; text-overflow: ellipsis; }
-.author { flex: 0 0 auto; font-size: 11px; opacity: 0.7; max-width: 110px; overflow: hidden; text-overflow: ellipsis; padding-left: 8px; }
-.date { flex: 0 0 auto; font-size: 11px; opacity: 0.55; padding-left: 8px; }
+.author { flex: 0 0 auto; font-size: calc(var(--vscode-font-size) - 2px); opacity: 0.7; max-width: 110px; overflow: hidden; text-overflow: ellipsis; padding-left: 8px; }
+.date { flex: 0 0 auto; font-size: calc(var(--vscode-font-size) - 2px); opacity: 0.55; padding-left: 8px; }
 #viewport.narrow .author, #viewport.narrow .date { display: none; }
 /* ── 图 + 右侧详情面板水平分栏（panel 容器无法并排子视图 → webview 内自分栏）──
    工具栏整体上移 VS Code 标题栏（scope 子菜单 / List-Tree 图标 / 仓库切换 / CI 登录），
@@ -587,21 +586,21 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #main.stacked #gutter-main { cursor: row-resize; }
 #details { flex: 0 0 55%; min-height: 0; overflow-y: auto; }
 #commit-meta { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
-.panel-loading { padding: 10px 12px; font-size: 12px; color: var(--vscode-descriptionForeground); }
-#details .dh { position: sticky; top: 0; display: flex; align-items: center; gap: 6px; background: var(--vscode-sideBar-background); padding: 4px 8px; font-size: 11px; color: var(--vscode-descriptionForeground); border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.15)); }
+.panel-loading { padding: 10px 12px; font-size: calc(var(--vscode-font-size) - 1px); color: var(--vscode-descriptionForeground); }
+#details .dh { position: sticky; top: 0; display: flex; align-items: center; gap: 6px; background: var(--vscode-sideBar-background); padding: 4px 8px; font-size: calc(var(--vscode-font-size) - 2px); color: var(--vscode-descriptionForeground); border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.15)); }
 #details .dh #details-title { flex: 1 1 auto; }
 .dh-close { flex: 0 0 auto; background: transparent; border: none; color: var(--vscode-descriptionForeground); cursor: pointer; font-size: 16px; line-height: 1; padding: 0 4px; border-radius: var(--hg-radius-control); }
 .dh-close:hover { color: var(--vscode-foreground); background: var(--vscode-list-hoverBackground); }
 .dh-close:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: 1px; }
-#details .file { display: flex; align-items: center; gap: 6px; padding: 2px 10px; font-size: 12px; cursor: pointer; }
+#details .file { display: flex; align-items: center; gap: 6px; padding: 2px 10px; font-size: calc(var(--vscode-font-size) - 1px); cursor: pointer; }
 #details .file:hover { background: var(--vscode-list-hoverBackground); }
 #details .file .dot { font-size: 13px; line-height: 1; }
 #details .file .nm { overflow: hidden; text-overflow: ellipsis; }
-#empty, #error { padding: 28px 16px; text-align: center; color: var(--vscode-descriptionForeground); font-size: 12px; }
+#empty, #error { padding: 28px 16px; text-align: center; color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 1px); }
 #empty .empty-icon { font-size: 30px; opacity: 0.4; margin-bottom: 8px; }
 .empty-title { font-size: 13px; color: var(--vscode-foreground); margin-bottom: 3px; }
-.empty-hint { font-size: 11px; }
-#spinner { position: absolute; bottom: 6px; right: 8px; font-size: 11px; opacity: 0.6; display: none; }
+.empty-hint { font-size: calc(var(--vscode-font-size) - 2px); }
+#spinner { position: absolute; bottom: 6px; right: 8px; font-size: calc(var(--vscode-font-size) - 2px); opacity: 0.6; display: none; }
 /* ── CI 状态图标（提交行最右侧，固定 16px 槽位，保证 author/date 列对齐）── */
 .ci { flex: 0 0 16px; width: 16px; display: inline-flex; align-items: center; justify-content: center; }
 .ci svg { display: block; shape-rendering: geometricPrecision; pointer-events: none; }
@@ -616,7 +615,7 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 .ci-spin { transform-origin: 50% 50%; animation: ci-rot 1s linear infinite; }
 @media (prefers-reduced-motion: reduce) { .ci-spin { animation: none; } }
 /* ── CI Tooltip（自定义浮层，置于 #rows 之外，虚拟滚动重写不销毁）── */
-#ci-tip { position: fixed; z-index: 50; display: none; max-width: 360px; min-width: 220px; max-height: 320px; overflow: hidden; background: var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background)); color: var(--vscode-editorHoverWidget-foreground, var(--vscode-foreground)); border: 1px solid var(--vscode-editorHoverWidget-border, var(--vscode-editorWidget-border, rgba(128,128,128,.3))); border-radius: 4px; box-shadow: 0 2px 8px rgba(0,0,0,.35); font-size: 12px; }
+#ci-tip { position: fixed; z-index: 50; display: none; max-width: 360px; min-width: 220px; max-height: 320px; overflow: hidden; background: var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background)); color: var(--vscode-editorHoverWidget-foreground, var(--vscode-foreground)); border: 1px solid var(--vscode-editorHoverWidget-border, var(--vscode-editorWidget-border, rgba(128,128,128,.3))); border-radius: 4px; box-shadow: 0 2px 8px var(--vscode-widget-shadow, rgba(0,0,0,.35)); font-size: calc(var(--vscode-font-size) - 1px); }
 #ci-tip.show { display: flex; flex-direction: column; }
 #ci-tip .tip-h { padding: 7px 10px; font-weight: 600; border-bottom: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); display: flex; align-items: center; gap: 6px; }
 #ci-tip .tip-h .g { flex: 0 0 14px; display: inline-flex; }
@@ -625,14 +624,14 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #ci-tip .tip-row:hover { background: var(--vscode-list-hoverBackground); }
 #ci-tip .tip-row .g { flex: 0 0 14px; display: inline-flex; margin-top: 1px; }
 #ci-tip .tip-row .nm { flex: 1 1 auto; min-width: 0; overflow: hidden; }
-#ci-tip .tip-row .nm .desc { display: block; font-size: 11px; opacity: 0.7; white-space: normal; word-break: break-word; margin-top: 1px; }
+#ci-tip .tip-row .nm .desc { display: block; font-size: calc(var(--vscode-font-size) - 2px); opacity: 0.7; white-space: normal; word-break: break-word; margin-top: 1px; }
 #ci-tip .tip-foot { padding: 6px 10px; border-top: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); }
 #ci-tip .tip-foot a { color: var(--vscode-textLink-foreground); cursor: pointer; text-decoration: none; }
 #ci-tip .tip-foot a:hover { text-decoration: underline; }
 #ci-tip .g-success { color: var(--vscode-testing-iconPassed, #3fb950); }
 #ci-tip .g-failure { color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground, #f85149)); }
 #ci-tip .g-pending { color: var(--vscode-testing-iconQueued, var(--vscode-editorWarning-foreground, #d29922)); }
-#ci-tip .g-skipped, #ci-tip .g-unknown { color: var(--vscode-descriptionForeground, #8b949e); }
+#ci-tip .g-skipped, #ci-tip .g-unknown { color: var(--vscode-descriptionForeground); }
 /* ── 提交详情面板下半区（#commit-meta，复用 .ct-* 视觉语言；editorHoverWidget 语义令牌与 CI 浮层同源）── */
 #commit-meta .ct-scroll { padding: 12px 14px; }
 #commit-meta .ct-head { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; }
@@ -640,17 +639,23 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #commit-meta .ct-avatar svg { width: 16px; height: 16px; opacity: 0.85; }
 #commit-meta .ct-who { display: flex; flex-direction: column; min-width: 0; }
 #commit-meta .ct-author { font-weight: 600; font-size: 13px; }
-#commit-meta .ct-time { font-size: 11px; color: var(--vscode-descriptionForeground); margin-top: 1px; }
+#commit-meta .ct-time { font-size: calc(var(--vscode-font-size) - 2px); color: var(--vscode-descriptionForeground); margin-top: 1px; }
 #commit-meta .ct-msg { margin-bottom: 10px; }
 #commit-meta .ct-subj { font-size: 13px; font-weight: 600; line-height: 1.4; word-break: break-word; }
-#commit-meta .ct-body { margin-top: 6px; white-space: pre-wrap; word-break: break-word; font-family: var(--vscode-editor-font-family, monospace); font-size: 12px; line-height: 1.5; opacity: 0.9; }
+#commit-meta .ct-body { margin-top: 6px; white-space: pre-wrap; word-break: break-word; font-family: var(--vscode-editor-font-family, var(--vscode-font-family)); font-size: calc(var(--vscode-font-size) - 1px); line-height: 1.5; opacity: 0.9; }
 #commit-meta .ct-refs-wrap { margin-bottom: 10px; display: flex; flex-direction: column; gap: 5px; }
-#commit-meta .ct-sec { display: flex; gap: 8px; align-items: baseline; font-size: 12px; }
+#commit-meta .ct-sec { display: flex; gap: 8px; align-items: baseline; font-size: calc(var(--vscode-font-size) - 1px); }
 #commit-meta .ct-sec .ct-k { flex: 0 0 66px; color: var(--vscode-descriptionForeground); font-size: 10px; text-transform: uppercase; letter-spacing: .3px; }
 #commit-meta .ct-sec .ct-v { flex: 1 1 auto; min-width: 0; word-break: break-word; }
 #commit-meta .ct-refs { display: flex; flex-wrap: wrap; gap: 4px; }
 /* 面板内引用胶囊完整显示（覆盖行内 .chip 的 max-width/省略号截断）：换行不截断，空间由面板承载。 */
 #commit-meta .chip { max-width: none; }
+/* 高对比度主题：避免大面积彩色填充——chip 改 contrastBorder 描边 + 主题前景色（!important 覆盖行内样式）。 */
+body[data-vscode-theme-kind~='high-contrast'] .chip {
+	color: var(--vscode-foreground) !important;
+	background: transparent !important;
+	border: 1px solid var(--vscode-contrastBorder);
+}
 #commit-meta .chip .chip-nm { overflow: visible; text-overflow: clip; white-space: normal; word-break: break-all; }
 #commit-meta .ct-dim { color: var(--vscode-descriptionForeground); }
 #commit-meta .ct-stat { display: flex; gap: 12px; padding: 8px 0; border-top: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); border-bottom: 1px solid var(--vscode-editorHoverWidget-border, rgba(128,128,128,.2)); font-size: 12px; font-variant-numeric: tabular-nums; }
@@ -658,8 +663,8 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 #commit-meta .ct-stat .ins { color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950); }
 #commit-meta .ct-stat .del { color: var(--vscode-gitDecoration-deletedResourceForeground, #f14c4c); }
 #commit-meta .ct-foot { display: flex; align-items: center; gap: 14px; margin-top: 10px; flex-wrap: wrap; }
-#commit-meta .ct-sha { font-family: var(--vscode-editor-font-family, monospace); font-size: 11px; color: var(--vscode-descriptionForeground); word-break: break-all; }
-#commit-meta .ct-gh { color: var(--vscode-textLink-foreground); cursor: pointer; font-size: 12px; display: inline-flex; align-items: center; gap: 4px; }
+#commit-meta .ct-sha { font-family: var(--vscode-editor-font-family, var(--vscode-font-family)); font-size: calc(var(--vscode-font-size) - 2px); color: var(--vscode-descriptionForeground); word-break: break-all; }
+#commit-meta .ct-gh { color: var(--vscode-textLink-foreground); cursor: pointer; font-size: calc(var(--vscode-font-size) - 1px); display: inline-flex; align-items: center; gap: 4px; }
 #commit-meta .ct-gh:hover { text-decoration: underline; }
 #commit-meta .ct-gh:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: 2px; border-radius: 2px; }
 #commit-meta .ct-gh svg { width: 13px; height: 13px; }
@@ -721,7 +726,7 @@ new MutationObserver(function () {
 		}
 	});
 }).observe(document.body, { attributes: true });
-const ROW_H = 24, LANE_W = 14, NODE_R = 4, GUTTER = 10, OVERSCAN = 8, LOAD_THRESHOLD = 40;
+const ROW_H = ${GRAPH_ROW_H}, LANE_W = ${GRAPH_LANE_W}, NODE_R = 4, GUTTER = 10, OVERSCAN = 8, LOAD_THRESHOLD = 40; // ROW_H/LANE_W 与 CSS --hg-row/--hg-lane 同源（shared-styles 常量注入）
 // ── 视图状态按仓库分区（v2，issue #107）：选中/目录折叠/分栏比例记忆跟随仓库，切换仓库换装载互不串扰；
 // scope 与 List/Tree 模式已上移标题栏（host workspaceState 为事实源，随 graphData 下发），不再入 webview state；
 // 无 v2 时从旧平铺结构一次性升级（旧值归首个见到的仓库，不丢偏好）。──

--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -4,7 +4,7 @@ import { parseNameStatus, statusLabel, parseShortStat } from '../../engine/log/c
 import { applyClientFilters, toClientFilter, type LogFilter } from '../../engine/log/log-filter';
 import { DEFAULT_LANE_PALETTE } from '../../engine/log/graph-color';
 import { computeGraphLayout, maxLanes } from '../../engine/log/graph-layout';
-import { getBaseStyles, GRAPH_ROW_H, GRAPH_LANE_W } from './shared-styles';
+import { getBaseStyles, GRAPH_ROW_H, GRAPH_LANE_W, ICON_CHEVRON_DOWN, ICON_CLOSE } from './shared-styles';
 import { getNonce } from './nonce';
 import { parseLogLines } from '../../engine/log/log-line';
 import { buildLogArgs, type LogScope } from '../../engine/log/log-query';
@@ -671,7 +671,9 @@ body[data-vscode-theme-kind~='high-contrast'] .chip {
 /* ── 变更文件目录树（详情面板 Group By Directory 形态）── */
 #details .tree-dir { display: flex; align-items: center; gap: 6px; padding: 2px 10px; font-size: 12px; cursor: pointer; user-select: none; }
 #details .tree-dir:hover { background: var(--vscode-list-hoverBackground); }
-#details .tree-dir .tree-twist { flex: 0 0 12px; text-align: center; font-size: 10px; opacity: 0.8; }
+#details .tree-dir .tree-twist { flex: 0 0 14px; display: inline-flex; align-items: center; justify-content: center; opacity: 0.8; }
+#details .tree-dir .tree-twist svg { display: block; }
+#details .tree-dir .tree-twist.collapsed svg { transform: rotate(-90deg); }
 #details .tree-dir .tree-name { color: var(--vscode-descriptionForeground); overflow: hidden; text-overflow: ellipsis; }
 </style>
 </head>
@@ -679,13 +681,13 @@ body[data-vscode-theme-kind~='high-contrast'] .chip {
 <div id="main">
   <div id="viewport" tabindex="0" role="tree" aria-label="Commit graph">
     <div id="spacer"><div id="rows"></div></div>
-    <div id="empty"><div class="empty-icon" aria-hidden="true">⌥</div><div class="empty-title">No Commits</div><div class="empty-hint">No commits match the current scope or filter.</div></div>
+    <div id="empty"><div class="empty-icon" aria-hidden="true"><svg width="28" height="28" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"><circle cx="8" cy="8" r="2.8"/><path d="M8 1.5v3.7M8 10.8v3.7"/></svg></div><div class="empty-title">No Commits</div><div class="empty-hint">No commits match the current scope or filter.</div></div>
     <div id="error" style="display:none"><div class="empty-title">Failed to Load Commits</div><div class="empty-hint" id="error-msg"></div><button class="hg-btn hg-btn--sm" id="retry-btn" style="margin-top:8px">Retry</button></div>
     <div id="spinner">Loading…</div>
   </div>
   <div class="gutter" id="gutter-main" role="separator" aria-orientation="vertical" tabindex="0" aria-label="Resize commit panel"></div>
   <aside id="commit-panel" role="region" aria-label="Commit details">
-    <section id="details" role="group" aria-label="Changed files"><div class="dh" id="details-head"><span id="details-title"></span><button class="dh-close" id="details-close" title="Deselect commit" aria-label="Deselect commit">×</button></div><div id="details-list"></div></section>
+    <section id="details" role="group" aria-label="Changed files"><div class="dh" id="details-head"><span id="details-title"></span><button class="dh-close" id="details-close" title="Deselect commit" aria-label="Deselect commit">${ICON_CLOSE}</button></div><div id="details-list"></div></section>
     <div class="gutter" id="gutter-meta" role="separator" aria-orientation="horizontal" tabindex="0" aria-label="Resize changed files section"></div>
     <section id="commit-meta" role="group" aria-label="Commit information"></section>
   </aside>
@@ -694,6 +696,7 @@ body[data-vscode-theme-kind~='high-contrast'] .chip {
 <script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
 const LANE_FALLBACK = ${laneFallback};
+const ICON_CHEVRON = ${JSON.stringify(ICON_CHEVRON_DOWN)};
 // 泳道色解析：优先主题 --vscode-charts-* 令牌（深/浅主题自适应），缺失或与其它 lane 撞色时
 // 回落 DEFAULT_LANE_PALETTE 原始 distinct hex，保底相邻 lane 可区分（对齐 graph-color 设计注释）。
 // 主题热切换监听：webview 不随换主题重载，CSS 变量热更但 JS 快照不会——MutationObserver 观察
@@ -893,7 +896,9 @@ function ciSlotHtml(row) {
 
 function rowHtml(row, idx) {
   const sel = row.hash === selectedHash ? ' selected' : '';
-  const merge = row.isMerge ? '<span class="merge" title="Merge commit">⇠</span>' : '';
+  // merge 标记：双父提交的 graph 型 SVG（Unicode ⇠ 随字体渲染不稳定且进读屏）。
+  const MERGE_ICON = '<svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><circle cx="4" cy="4" r="1.8"/><circle cx="4" cy="12" r="1.8"/><circle cx="12" cy="8" r="1.8"/></svg>';
+  const merge = row.isMerge ? '<span class="merge" title="Merge commit">' + MERGE_ICON + '</span>' : '';
   // 列顺序对齐官方 GRAPH：泳道图 → message → 引用胶囊 → author → date → CI。chips 作为 message 右侧后缀。
   return '<div class="row' + sel + '" data-i="' + idx + '" data-hash="' + esc(row.hash) + '" role="treeitem" aria-selected="' + (sel !== '') + '">'
     + rowSvg(row)
@@ -1224,7 +1229,7 @@ function detailLeafHtml(hash, f, depth, label) {
 function renderDetailNode(node, depth, hash, files, out) {
   if (node.dir) {
     const isCol = dcollapsed.has(node.path);
-    out.push('<div class="tree-dir" style="padding-left:' + (depth * DINDENT + 8) + 'px" data-dir="' + esc(node.path) + '"><span class="tree-twist">' + (isCol ? '\\u25B8' : '\\u25BE') + '</span><span class="tree-name">' + esc(node.name) + '</span></div>');
+    out.push('<div class="tree-dir" style="padding-left:' + (depth * DINDENT + 8) + 'px" data-dir="' + esc(node.path) + '"><span class="tree-twist' + (isCol ? ' collapsed' : '') + '">' + ICON_CHEVRON + '</span><span class="tree-name">' + esc(node.name) + '</span></div>');
     if (!isCol) { for (const c of node.children) renderDetailNode(c, depth + 1, hash, files, out); }
   } else {
     out.push(detailLeafHtml(hash, files[node.fileIndex], depth, node.name));

--- a/src/adapter/webview/log-webview.ts
+++ b/src/adapter/webview/log-webview.ts
@@ -689,9 +689,11 @@ body { margin: 0; font-family: var(--vscode-font-family); font-size: var(--vscod
 <script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
 const LANE_FALLBACK = ${laneFallback};
-// 启动期解析泳道色：优先主题 --vscode-charts-* 令牌（深/浅主题自适应），缺失或与其它 lane 撞色时
+// 泳道色解析：优先主题 --vscode-charts-* 令牌（深/浅主题自适应），缺失或与其它 lane 撞色时
 // 回落 DEFAULT_LANE_PALETTE 原始 distinct hex，保底相邻 lane 可区分（对齐 graph-color 设计注释）。
-const PALETTE = (function () {
+// 主题热切换监听：webview 不随换主题重载，CSS 变量热更但 JS 快照不会——MutationObserver 观察
+// body 属性（VS Code 换主题时更新 class/data-vscode-theme-*），rAF 节流重算并全量重渲可见行。
+function computePalette() {
 	const cs = getComputedStyle(document.body);
 	const hues = ['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'cyan', 'orange'];
 	const resolved = hues.map(function (hue, i) {
@@ -704,7 +706,21 @@ const PALETTE = (function () {
 		if (seen[key] === undefined) { seen[key] = true; return c; }
 		return LANE_FALLBACK[i];
 	});
-})();
+}
+let PALETTE = computePalette();
+let themeRaf = 0;
+new MutationObserver(function () {
+	if (themeRaf) { return; }
+	themeRaf = requestAnimationFrame(function () {
+		themeRaf = 0;
+		const next = computePalette();
+		if (next.join(',') !== PALETTE.join(',')) {
+			PALETTE = next;
+			renderedFirst = -1; // 强制重渲可见行（泳道色/chip 已随旧色内联注入）
+			scheduleRender();
+		}
+	});
+}).observe(document.body, { attributes: true });
 const ROW_H = 24, LANE_W = 14, NODE_R = 4, GUTTER = 10, OVERSCAN = 8, LOAD_THRESHOLD = 40;
 // ── 视图状态按仓库分区（v2，issue #107）：选中/目录折叠/分栏比例记忆跟随仓库，切换仓库换装载互不串扰；
 // scope 与 List/Tree 模式已上移标题栏（host workspaceState 为事实源，随 graphData 下发），不再入 webview state；

--- a/src/adapter/webview/merge-editor.ts
+++ b/src/adapter/webview/merge-editor.ts
@@ -1,4 +1,3 @@
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -6,6 +5,7 @@ import type { GitRepositoryService } from '../git-repository-service';
 import { diff3, type MergeHunk } from '../../engine/merge/diff3';
 import { parseConflictState } from '../../engine/git-state/conflict-detector';
 import { getBaseStyles } from './shared-styles';
+import { getNonce } from './nonce';
 
 const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 
@@ -53,8 +53,19 @@ export class MergeEditorWebview {
 			vscode.ViewColumn.Active,
 			{ enableScripts: true, retainContextWhenHidden: true },
 		);
+		MergeEditorWebview.attachPanel(service, panel, filePath, hunks, conflicts);
+	}
+
+	/** 面板装配：渲染 HTML + 消息接线（订阅随 panel dispose 释放）。 */
+	private static attachPanel(
+		service: GitRepositoryService,
+		panel: vscode.WebviewPanel,
+		filePath: string,
+		hunks: readonly MergeHunk[],
+		conflicts: number,
+	): void {
 		panel.webview.html = MergeEditorWebview.renderHtml(filePath, hunks, conflicts);
-		panel.webview.onDidReceiveMessage(async (msg) => {
+		const msgSub = panel.webview.onDidReceiveMessage(async (msg) => {
 			if (msg?.type === 'save' && typeof msg.content === 'string') {
 				await MergeEditorWebview.saveResult(service, filePath, msg.content);
 				panel.dispose();
@@ -62,6 +73,61 @@ export class MergeEditorWebview {
 				panel.dispose();
 			}
 		});
+		panel.onDidDispose(() => msgSub.dispose());
+	}
+
+	/**
+	 * 窗口 reload 后的面板恢复：按 state 中的 filePath 重拉三阶段冲突数据重渲染。
+	 * 已编辑未保存的 Result 不随 state 保留（known limitation）；若冲突已在他处解决则直接关闭恢复的面板。
+	 */
+	static registerSerializer(service: GitRepositoryService): vscode.Disposable {
+		return vscode.window.registerWebviewPanelSerializer('hyperGit.mergeEditor', {
+			async deserializeWebviewPanel(panel, state) {
+				const filePath = (state as { filePath?: unknown } | undefined)?.filePath;
+				if (typeof filePath !== 'string' || !service.repo) {
+					panel.webview.html = MergeEditorWebview.renderStaleHtml();
+					return;
+				}
+				try {
+					const [base, ours, theirs] = await Promise.all([
+						service.execGit(['show', `:1:${filePath}`]),
+						service.execGit(['show', `:2:${filePath}`]),
+						service.execGit(['show', `:3:${filePath}`]),
+					]);
+					const hunks = diff3(splitLines(base), splitLines(ours), splitLines(theirs));
+					const conflicts = hunks.filter((h) => h.kind === 'conflict').length;
+					if (conflicts === 0) {
+						// reload 前冲突已被解决：恢复无意义，直接关闭。
+						void vscode.window.showInformationMessage(`"${filePath}" has no unresolved conflicts; the restored merge editor was closed.`);
+						panel.dispose();
+						return;
+					}
+					MergeEditorWebview.attachPanel(service, panel, filePath, hunks, conflicts);
+				} catch {
+					panel.webview.html = MergeEditorWebview.renderStaleHtml();
+				}
+			},
+		});
+	}
+
+	/** 面板过期（无有效 state / 冲突数据已不可读）时的占位页。 */
+	private static renderStaleHtml(): string {
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+<style>
+${getBaseStyles()}
+body { margin: 0; padding: 16px 20px; font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); }
+p { color: var(--vscode-descriptionForeground); }
+</style>
+</head>
+<body>
+<h3>Merge</h3>
+<p>This merge session is no longer available. Close this tab and re-open it from <strong>Resolve Conflicts…</strong> if needed.</p>
+</body>
+</html>`;
 	}
 
 	private static async saveResult(service: GitRepositoryService, filePath: string, content: string): Promise<void> {
@@ -90,7 +156,7 @@ export class MergeEditorWebview {
 	}
 
 	private static renderHtml(filePath: string, hunks: readonly MergeHunk[], conflicts: number): string {
-		const nonce = crypto.randomBytes(16).toString('base64');
+		const nonce = getNonce();
 		// JSON 注入 <script> 内的 JS 字符串上下文：按 JS-string 转义（反斜杠/引号）+ < → < 防 </script> 破出。
 		// 不可用 escapeHtml——其产出 &quot; 在 <script> raw-text 中不被解码，会令 JSON.parse 失败。
 		const dataJson = JSON.stringify(hunks)
@@ -143,6 +209,10 @@ body { margin: 0; padding: 10px 14px; font-family: var(--vscode-font-family); fo
 </div>
 <div id="hunks"></div>
 <script nonce="${nonce}">
+// acquireVsCodeApi 每个 webview 仅可调用一次：顶部获取后全程复用（回调内重复调用会抛异常）。
+var vscode = acquireVsCodeApi();
+// 窗口 reload 后的面板恢复：state 仅存 filePath（host 侧重拉三阶段，编辑中内容不保留）。
+vscode.setState({ filePath: ${JSON.stringify(filePath).replace(/</g, '\\u003c')} });
 var HUNKS = JSON.parse("${dataJson}");
 function lines(pre){ return (pre||[]); }
 function markerText(h){
@@ -243,9 +313,9 @@ document.getElementById('save').onclick = function(){
     if (h.kind === 'stable') { result.push.apply(result, h.content||[]); }
     else { ci += 1; result.push(document.getElementById('result-' + ci).value); }
   });
-  acquireVsCodeApi().postMessage({ type: 'save', content: result.join('\\n') + '\\n' });
+  vscode.postMessage({ type: 'save', content: result.join('\\n') + '\\n' });
 };
-document.getElementById('cancel').onclick = function(){ acquireVsCodeApi().postMessage({ type: 'cancel' }); };
+document.getElementById('cancel').onclick = function(){ vscode.postMessage({ type: 'cancel' }); };
 </script>
 </body>
 </html>`;

--- a/src/adapter/webview/merge-editor.ts
+++ b/src/adapter/webview/merge-editor.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showGitError } from '../notify';
 import type { GitRepositoryService } from '../git-repository-service';
 import { diff3, type MergeHunk } from '../../engine/merge/diff3';
 import { parseConflictState } from '../../engine/git-state/conflict-detector';
@@ -34,7 +35,7 @@ export class MergeEditorWebview {
 				service.execGit(['show', `:3:${filePath}`]),
 			]);
 		} catch (e) {
-			void vscode.window.showErrorMessage(`Failed to read conflict stages (file may have no conflicts): ${errMsg(e)}`);
+			void showGitError(`Failed to read conflict stages (file may have no conflicts): ${errMsg(e)}`);
 			return;
 		}
 		const hunks = diff3(splitLines(base), splitLines(ours), splitLines(theirs));
@@ -151,7 +152,7 @@ p { color: var(--vscode-descriptionForeground); }
 			await service.execGit(['add', '--', filePath]);
 			void vscode.window.showInformationMessage(`"${filePath}" saved and marked resolved`);
 		} catch (e) {
-			void vscode.window.showErrorMessage(`Failed to save: ${errMsg(e)}`);
+			void showGitError(`Failed to save: ${errMsg(e)}`);
 		}
 	}
 
@@ -381,7 +382,7 @@ export function registerMergeCommands(service: GitRepositoryService): vscode.Dis
 				await service.execGit(['add', '--', file]);
 				void vscode.window.showInformationMessage(`"${file}" resolved with ours`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed: ${errMsg(e)}`);
+				void showGitError(`Failed: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -401,7 +402,7 @@ export function registerMergeCommands(service: GitRepositoryService): vscode.Dis
 				await service.execGit(['add', '--', file]);
 				void vscode.window.showInformationMessage(`"${file}" resolved with theirs`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed: ${errMsg(e)}`);
+				void showGitError(`Failed: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/webview/merge-editor.ts
+++ b/src/adapter/webview/merge-editor.ts
@@ -5,7 +5,7 @@ import { showGitError } from '../notify';
 import type { GitRepositoryService } from '../git-repository-service';
 import { diff3, type MergeHunk } from '../../engine/merge/diff3';
 import { parseConflictState } from '../../engine/git-state/conflict-detector';
-import { getBaseStyles } from './shared-styles';
+import { getBaseStyles, ICON_CHEVRON_DOWN } from './shared-styles';
 import { getNonce } from './nonce';
 
 const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
@@ -178,6 +178,10 @@ body { margin: 0; padding: 10px 14px; font-family: var(--vscode-font-family); fo
 .bar .spacer { flex: 1; }
 .bar .nav { display: inline-flex; align-items: center; gap: 2px; }
 .bar .nav #conflict-pos { font-size: calc(var(--vscode-font-size) - 2px); min-width: 46px; text-align: center; color: var(--vscode-descriptionForeground); }
+.nav-ico { display: inline-flex; align-items: center; }
+.nav-ico svg { display: block; }
+.nav-ico--prev svg { transform: rotate(90deg); }
+.nav-ico--next svg { transform: rotate(-90deg); }
 .remaining { font-size: calc(var(--vscode-font-size) - 2px); opacity: 0.75; margin-left: 6px; }
 .remaining.has-unresolved { color: var(--vscode-editorWarning-foreground, #d29922); opacity: 1; }
 .hunk { margin-bottom: 10px; }
@@ -201,9 +205,9 @@ body { margin: 0; padding: 10px 14px; font-family: var(--vscode-font-family); fo
   <span class="count">${conflicts} conflict${conflicts === 1 ? '' : 's'}</span>
   <span class="spacer"></span>
   <span class="nav" id="conflict-nav" role="group" aria-label="Conflict navigation">
-    <button class="hg-btn hg-btn--sm" id="prev-conflict" title="Previous conflict" aria-label="Previous conflict">‹</button>
+    <button class="hg-btn hg-btn--sm" id="prev-conflict" title="Previous conflict" aria-label="Previous conflict"><span class="nav-ico nav-ico--prev">${ICON_CHEVRON_DOWN}</span></button>
     <span id="conflict-pos" aria-live="polite">—</span>
-    <button class="hg-btn hg-btn--sm" id="next-conflict" title="Next conflict" aria-label="Next conflict">›</button>
+    <button class="hg-btn hg-btn--sm" id="next-conflict" title="Next conflict" aria-label="Next conflict"><span class="nav-ico nav-ico--next">${ICON_CHEVRON_DOWN}</span></button>
   </span>
   <button class="hg-btn hg-btn--secondary" id="cancel">Cancel</button>
   <button class="hg-btn" id="save">Save &amp; Mark Resolved<span class="remaining" id="remaining"></span></button>

--- a/src/adapter/webview/merge-editor.ts
+++ b/src/adapter/webview/merge-editor.ts
@@ -171,27 +171,27 @@ p { color: var(--vscode-descriptionForeground); }
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'">
 <style>
 ${getBaseStyles()}
-body { margin: 0; padding: 10px 14px; font-family: var(--vscode-font-family); font-size: 12px; color: var(--vscode-foreground); background: var(--vscode-editor-background); }
+body { margin: 0; padding: 10px 14px; font-family: var(--vscode-font-family); font-size: calc(var(--vscode-font-size) - 1px); color: var(--vscode-foreground); background: var(--vscode-editor-background); }
 .bar { display: flex; align-items: center; gap: 10px; margin-bottom: 10px; flex-wrap: wrap; }
 .bar .path { font-weight: 600; }
 .bar .count { color: var(--vscode-editorWarning-foreground, #d29922); }
 .bar .spacer { flex: 1; }
 .bar .nav { display: inline-flex; align-items: center; gap: 2px; }
-.bar .nav #conflict-pos { font-size: 11px; min-width: 46px; text-align: center; color: var(--vscode-descriptionForeground); }
-.remaining { font-size: 11px; opacity: 0.75; margin-left: 6px; }
+.bar .nav #conflict-pos { font-size: calc(var(--vscode-font-size) - 2px); min-width: 46px; text-align: center; color: var(--vscode-descriptionForeground); }
+.remaining { font-size: calc(var(--vscode-font-size) - 2px); opacity: 0.75; margin-left: 6px; }
 .remaining.has-unresolved { color: var(--vscode-editorWarning-foreground, #d29922); opacity: 1; }
 .hunk { margin-bottom: 10px; }
 .stable { background: var(--vscode-editor-inactiveSelectionBackground, rgba(128,128,128,.12)); border-left: 3px solid transparent; padding: 2px 8px; white-space: pre-wrap; font-family: var(--vscode-editor-font-family); }
 .conflict { border: 1px solid var(--vscode-inputOption-activeBorder, #d29922); border-radius: 3px; }
 .conflict-head { display: flex; align-items: center; gap: 8px; background: var(--vscode-editorWarning-background, rgba(210,153,34,.15)); padding: 3px 8px; font-weight: 600; }
-.c-badge { margin-left: auto; font-size: 10px; font-weight: 600; padding: 1px 7px; border-radius: 9px; border: 1px solid transparent; }
+.c-badge { margin-left: auto; font-size: calc(var(--vscode-font-size) - 3px); font-weight: 600; padding: 1px 7px; border-radius: 9px; border: 1px solid transparent; }
 .c-badge.unresolved { color: var(--vscode-editorWarning-foreground, #d29922); border-color: var(--vscode-editorWarning-foreground, #d29922); }
 .c-badge.resolved { color: var(--vscode-testing-iconPassed, #3fb950); border-color: var(--vscode-testing-iconPassed, #3fb950); }
 .c3 { display: grid; grid-template-columns: 1fr 1.3fr 1fr; gap: 1px; background: var(--vscode-editorWidget-border, rgba(128,128,128,.3)); }
 .col { background: var(--vscode-editor-background); padding: 4px 8px; }
-.col-label { font-size: 10px; opacity: 0.7; margin-bottom: 3px; text-transform: uppercase; }
+.col-label { font-size: calc(var(--vscode-font-size) - 3px); opacity: 0.7; margin-bottom: 3px; text-transform: uppercase; }
 .col pre { white-space: pre; overflow-x: auto; font-family: var(--vscode-editor-font-family); margin: 0; min-height: 14px; }
-.col textarea { width: 100%; min-height: 60px; resize: vertical; background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, transparent); font-family: var(--vscode-editor-font-family); font-size: 12px; padding: 4px; box-sizing: border-box; }
+.col textarea { width: 100%; min-height: 60px; resize: vertical; background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, transparent); font-family: var(--vscode-editor-font-family); font-size: calc(var(--vscode-font-size) - 1px); padding: 4px; box-sizing: border-box; }
 .col-actions { margin-top: 4px; display: flex; gap: 4px; }
 </style>
 </head>

--- a/src/adapter/webview/nonce.ts
+++ b/src/adapter/webview/nonce.ts
@@ -1,0 +1,9 @@
+import * as crypto from 'crypto';
+
+/**
+ * CSP nonce（单一实现，替代各 webview 内联的 randomBytes 拼接）。
+ * randomUUID 产 hex（无 base64 的 +/= 字符），对 CSP 属性值更稳。
+ */
+export function getNonce(): string {
+	return crypto.randomUUID().replace(/-/g, '');
+}

--- a/src/adapter/webview/rebase-webview.ts
+++ b/src/adapter/webview/rebase-webview.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
+import { showGitError } from '../notify';
+import { runWithProgress } from '../task-progress';
 import type { GitRepositoryService } from '../git-repository-service';
 import { handleGitConflict } from '../conflict-ui';
 import { type RebaseTodoItem, isValidAction, serializeTodo } from '../../engine/rebase/todo';
@@ -89,7 +91,7 @@ export class RebaseWebview {
 					return { hash, subject: subj.join('|') };
 				});
 		} catch (e) {
-			void vscode.window.showErrorMessage(`Failed to load commits: ${errMsg(e)}`);
+			void showGitError(`Failed to load commits: ${errMsg(e)}`);
 			return;
 		}
 		if (rebaseCommits.length === 0) {
@@ -217,7 +219,12 @@ p { color: var(--vscode-descriptionForeground); }
 		}
 
 		try {
-			await service.execGit(['rebase', '-i', base], { env });
+			// 交互 rebase 可能耗时较长且无中间输出：Notification 进度显式告知（避免 UI 疑似冻结）。
+			await runWithProgress(
+				`Rebasing onto ${base}…`,
+				() => service.execGit(['rebase', '-i', base], { env }),
+				{ location: vscode.ProgressLocation.Notification },
+			);
 			// rebase 可能因 edit / squash 暂停（exit 0 但 rebase-merge 仍在）：检测并提示
 			const gitDir = (await service.execGit(['rev-parse', '--absolute-git-dir'])).trim();
 			if (fs.existsSync(path.join(gitDir, 'rebase-merge'))) {
@@ -230,7 +237,7 @@ p { color: var(--vscode-descriptionForeground); }
 			}
 		} catch (e) {
 			if (!(await handleGitConflict(service, 'Rebase'))) {
-				void vscode.window.showErrorMessage(`Rebase failed: ${errMsg(e)}`);
+				void showGitError(`Rebase failed: ${errMsg(e)}`);
 			}
 		} finally {
 			for (const f of [tmpTodo, tmpEditor, tmpState]) {

--- a/src/adapter/webview/rebase-webview.ts
+++ b/src/adapter/webview/rebase-webview.ts
@@ -7,10 +7,18 @@ import type { GitRepositoryService } from '../git-repository-service';
 import { handleGitConflict } from '../conflict-ui';
 import { type RebaseTodoItem, isValidAction, serializeTodo } from '../../engine/rebase/todo';
 import { getBaseStyles } from './shared-styles';
+import { getNonce } from './nonce';
 
 interface RebaseCommit {
 	readonly hash: string;
 	readonly subject: string;
+}
+
+/** 渲染行（初始 = 原始提交默认 pick；恢复 = 序列化保存的 action/subject/DOM 顺序）。 */
+interface RebaseRow {
+	readonly hash: string;
+	readonly subject: string;
+	readonly action?: string;
 }
 
 const errMsg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
@@ -93,9 +101,18 @@ export class RebaseWebview {
 			enableScripts: true,
 			retainContextWhenHidden: true,
 		});
-		panel.webview.html = RebaseWebview.renderHtml(rebaseCommits);
+		RebaseWebview.attachPanel(service, panel, base, rebaseCommits.map((c) => ({ hash: c.hash, subject: c.subject })));
+	}
 
-		panel.webview.onDidReceiveMessage(async (msg) => {
+	/** 面板装配：渲染 HTML + 消息接线（订阅随 panel dispose 释放，避免悬挂监听）。 */
+	private static attachPanel(
+		service: GitRepositoryService,
+		panel: vscode.WebviewPanel,
+		base: string,
+		rows: readonly RebaseRow[],
+	): void {
+		panel.webview.html = RebaseWebview.renderHtml(base, rows);
+		const msgSub = panel.webview.onDidReceiveMessage(async (msg) => {
 			if (msg.type === 'rebase') {
 				await RebaseWebview.executeRebase(
 					service,
@@ -107,6 +124,53 @@ export class RebaseWebview {
 				panel.dispose();
 			}
 		});
+		panel.onDidDispose(() => msgSub.dispose());
+	}
+
+	/**
+	 * 窗口 reload 后的面板恢复：webview state（base + 用户编辑后的 actions，按 DOM 顺序）重渲染 todo 列表。
+	 * 恢复的 panel 是纯 todo 编辑器——若 reload 前 rebase 已执行完毕，重放需用户再次确认 Start Rebase（可 Cancel）。
+	 */
+	static registerSerializer(service: GitRepositoryService): vscode.Disposable {
+		return vscode.window.registerWebviewPanelSerializer('hyperGit.rebase', {
+			async deserializeWebviewPanel(panel, state) {
+				const actions = (state as { base?: unknown; actions?: unknown } | undefined)?.actions;
+				const base = (state as { base?: unknown } | undefined)?.base;
+				if (typeof base !== 'string' || !Array.isArray(actions) || actions.length === 0) {
+					panel.webview.html = RebaseWebview.renderStaleHtml();
+					return;
+				}
+				const rows: RebaseRow[] = [];
+				for (const a of actions) {
+					if (typeof a?.hash !== 'string' || typeof a?.subject !== 'string') {
+						panel.webview.html = RebaseWebview.renderStaleHtml();
+						return;
+					}
+					rows.push({ hash: a.hash, subject: a.subject, action: typeof a.action === 'string' ? a.action : undefined });
+				}
+				RebaseWebview.attachPanel(service, panel, base, rows);
+			},
+		});
+	}
+
+	/** 面板过期（无有效 state / 数据不完整）时的占位页。 */
+	private static renderStaleHtml(): string {
+		return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+<style>
+${getBaseStyles()}
+body { margin: 0; padding: 16px 20px; font-family: var(--vscode-font-family); font-size: var(--vscode-font-size); color: var(--vscode-foreground); background: var(--vscode-editor-background); }
+p { color: var(--vscode-descriptionForeground); }
+</style>
+</head>
+<body>
+<h3>Interactive Rebase</h3>
+<p>This rebase session is no longer available. Close this tab and run <strong>Interactive Rebase…</strong> to start a new one.</p>
+</body>
+</html>`;
 	}
 
 	private static async executeRebase(
@@ -143,6 +207,9 @@ export class RebaseWebview {
 			tmpState = path.join(os.tmpdir(), `hg-reword-state-${tag}.json`);
 			fs.writeFileSync(tmpEditor, REWORD_EDITOR_JS);
 			fs.writeFileSync(tmpState, JSON.stringify({ counter: 0, subjects: rewordSubjects }));
+			// 扩展宿主内 process.execPath 是 Electron 二进制而非独立 node：必须以 node 模式运行 helper
+			// （否则 git 每次调用 GIT_EDITOR 会拉起新的编辑器进程）。
+			env.ELECTRON_RUN_AS_NODE = '1';
 			env.GIT_EDITOR = `"${process.execPath}" "${tmpEditor}"`;
 			env.HYPERGIT_REWORD_STATE = tmpState;
 		} else {
@@ -179,24 +246,23 @@ export class RebaseWebview {
 		}
 	}
 
-	private static renderHtml(commits: RebaseCommit[]): string {
-		const nonce = crypto.randomBytes(16).toString('base64');
-		const rows = commits
-			.map(
-				(c) => `<tr draggable="true" data-hash="${escapeHtml(c.hash)}">
+	private static renderHtml(base: string, rows: readonly RebaseRow[]): string {
+		const nonce = getNonce();
+		// base 注入 <script> 内的 JS 字符串语境：JSON.stringify + < 转义（防 </script> 破出）。
+		const baseJson = JSON.stringify(base).replace(/</g, '\\u003c');
+		const trs = rows
+			.map((r) => {
+				const action = isValidAction(r.action ?? 'pick') ? (r.action ?? 'pick') : 'pick';
+				const options = ['pick', 'reword', 'edit', 'squash', 'fixup', 'drop']
+					.map((a) => `<option value="${a}"${a === action ? ' selected' : ''}>${a}</option>`)
+					.join('');
+				return `<tr draggable="true" data-hash="${escapeHtml(r.hash)}">
 <td class="drag" title="Drag to reorder"><svg class="grip" width="10" height="16" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true"><circle cx="2" cy="3" r="1.3"/><circle cx="2" cy="8" r="1.3"/><circle cx="2" cy="13" r="1.3"/><circle cx="7" cy="3" r="1.3"/><circle cx="7" cy="8" r="1.3"/><circle cx="7" cy="13" r="1.3"/></svg></td>
-<td><select class="action">
-<option value="pick">pick</option>
-<option value="reword">reword</option>
-<option value="edit">edit</option>
-<option value="squash">squash</option>
-<option value="fixup">fixup</option>
-<option value="drop">drop</option>
-</select></td>
-<td class="hash">${escapeHtml(c.hash.slice(0, 7))}</td>
-<td><input class="subject" value="${escapeHtml(c.subject)}" disabled spellcheck="false"></td>
-</tr>`,
-			)
+<td><select class="action">${options}</select></td>
+<td class="hash">${escapeHtml(r.hash.slice(0, 7))}</td>
+<td><input class="subject" value="${escapeHtml(r.subject)}"${action === 'reword' ? '' : ' disabled'} spellcheck="false"></td>
+</tr>`;
+			})
 			.join('\n');
 		return `<!DOCTYPE html>
 <html lang="en">
@@ -240,7 +306,7 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
 <p class="legend"><code>reword</code> — edit the message inline &nbsp;·&nbsp; <code>edit</code>/<code>squash</code> — pauses rebase (continue in terminal) &nbsp;·&nbsp; <code>drop</code> — remove the commit &nbsp;·&nbsp; drag the handle to reorder.</p>
 <div class="summary" id="summary"></div>
 <table><thead><tr><th></th><th>Action</th><th>Hash</th><th>Subject</th></tr></thead>
-<tbody>${rows}</tbody></table>
+<tbody>${trs}</tbody></table>
 <div class="row-actions">
 <button class="hg-btn hg-btn--secondary" id="cancel-btn">Cancel</button>
 <button class="hg-btn" id="rebase-btn">Start Rebase</button>
@@ -257,6 +323,9 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
 </div>
 <script nonce="${nonce}">
 (function () {
+  // acquireVsCodeApi 每个 webview 仅可调用一次：顶部获取后全程复用（回调内重复调用会抛异常）。
+  var vscode = acquireVsCodeApi();
+  var BASE = ${baseJson};
   var tbody = document.querySelector('tbody');
   var rows = function () { return Array.from(tbody.querySelectorAll('tr')); };
   var confirmEl = document.getElementById('confirm');
@@ -285,10 +354,12 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
       if (isReword) { input.focus(); }
       updateRowStates();
       updateSummary();
+      persist();
     }
   });
   updateRowStates();
   updateSummary();
+  persist();
 
   // 拖拽重排序
   var dragged = null;
@@ -313,6 +384,7 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
     var after = (e.clientY - rect.top) > rect.height / 2;
     if (after && target.nextSibling) { tbody.insertBefore(dragged, target.nextSibling); }
     else { tbody.insertBefore(dragged, target); }
+    persist();
   });
 
   function collectActions() {
@@ -320,6 +392,16 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
       return { hash: row.dataset.hash, action: row.querySelector('select.action').value, subject: row.querySelector('input.subject').value };
     });
   }
+
+  // 窗口 reload 后的面板恢复（registerWebviewPanelSerializer）：action/subject/行序存入 webview state。
+  var persistTimer = null;
+  function persist() {
+    clearTimeout(persistTimer);
+    persistTimer = setTimeout(function () {
+      try { vscode.setState({ base: BASE, actions: collectActions() }); } catch (e) { /* state 序列化失败不阻断编辑 */ }
+    }, 150);
+  }
+  tbody.addEventListener('input', persist);
 
   // 执行前确认：rebase 改写历史，前置确认防误操作（非阻塞 HTML 覆盖层）。
   document.getElementById('rebase-btn').addEventListener('click', function () {
@@ -331,10 +413,10 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
   });
   document.getElementById('confirm-go').addEventListener('click', function () {
     confirmEl.style.display = 'none';
-    acquireVsCodeApi().postMessage({ type: 'rebase', actions: collectActions() });
+    vscode.postMessage({ type: 'rebase', actions: collectActions() });
   });
   document.getElementById('confirm-cancel').addEventListener('click', function () { confirmEl.style.display = 'none'; });
-  document.getElementById('cancel-btn').addEventListener('click', function () { acquireVsCodeApi().postMessage({ type: 'cancel' }); });
+  document.getElementById('cancel-btn').addEventListener('click', function () { vscode.postMessage({ type: 'cancel' }); });
 })();
 </script>
 </body>

--- a/src/adapter/webview/rebase-webview.ts
+++ b/src/adapter/webview/rebase-webview.ts
@@ -393,6 +393,18 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
     persist();
   });
 
+  // 键盘重排（WCAG 2.1.1：拖拽须有键盘替代路径）：行内任意控件聚焦时 Alt+↑/↓ 整行移动。
+  tbody.addEventListener('keydown', function (e) {
+    if (!e.altKey || (e.key !== 'ArrowUp' && e.key !== 'ArrowDown')) { return; }
+    var tr = e.target.closest('tr');
+    if (!tr) { return; }
+    var target = e.key === 'ArrowUp' ? tr.previousElementSibling : tr.nextElementSibling;
+    if (!target) { return; }
+    e.preventDefault();
+    if (e.key === 'ArrowUp') { tbody.insertBefore(tr, target); } else { tbody.insertBefore(tr, target.nextSibling); }
+    persist();
+  });
+
   function collectActions() {
     return rows().map(function (row) {
       return { hash: row.dataset.hash, action: row.querySelector('select.action').value, subject: row.querySelector('input.subject').value };
@@ -410,18 +422,39 @@ input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4);
   tbody.addEventListener('input', persist);
 
   // 执行前确认：rebase 改写历史，前置确认防误操作（非阻塞 HTML 覆盖层）。
+  // 对话框语义补全：Escape 关闭、Tab 焦点圈禁（背景表格不可达）、关闭后焦点还原触发按钮。
+  var confirmReturnFocus = null;
+  function closeConfirm() {
+    confirmEl.style.display = 'none';
+    if (confirmReturnFocus && confirmReturnFocus.focus) { confirmReturnFocus.focus(); }
+    confirmReturnFocus = null;
+  }
   document.getElementById('rebase-btn').addEventListener('click', function () {
     var n = rows().length;
     document.getElementById('confirm-count').textContent = 'Rebase ' + n + ' commit' + (n === 1 ? '' : 's') + ' — this rewrites history.';
     document.getElementById('confirm-summary').textContent = document.getElementById('summary').textContent || (n + ' commits');
+    confirmReturnFocus = document.activeElement;
     confirmEl.style.display = 'flex';
     document.getElementById('confirm-go').focus();
   });
+  confirmEl.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeConfirm();
+    } else if (e.key === 'Tab') {
+      var f = Array.prototype.slice.call(confirmEl.querySelectorAll('button'));
+      if (f.length === 0) { return; }
+      var first = f[0], last = f[f.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    }
+  });
   document.getElementById('confirm-go').addEventListener('click', function () {
     confirmEl.style.display = 'none';
+    confirmReturnFocus = null;
     vscode.postMessage({ type: 'rebase', actions: collectActions() });
   });
-  document.getElementById('confirm-cancel').addEventListener('click', function () { confirmEl.style.display = 'none'; });
+  document.getElementById('confirm-cancel').addEventListener('click', closeConfirm);
   document.getElementById('cancel-btn').addEventListener('click', function () { vscode.postMessage({ type: 'cancel' }); });
 })();
 </script>

--- a/src/adapter/webview/rebase-webview.ts
+++ b/src/adapter/webview/rebase-webview.ts
@@ -63,16 +63,15 @@ export class RebaseWebview {
 			void vscode.window.showWarningMessage('No Git repository found');
 			return;
 		}
-		// 选择 base
+		// 选择 base：快捷项与提交列表用 Separator 分段；matchOnDescription 支持按 subject 模糊搜索。
 		const baseOptions = ['HEAD~5', 'HEAD~10', 'HEAD~20', 'HEAD~3', 'HEAD~2'];
 		const commits = await repo.log({ maxEntries: 30 });
-		const basePick = await vscode.window.showQuickPick(
-			[
-				...baseOptions.map((b) => ({ label: b, description: `Rebase from ${b}` })),
-				...commits.slice(1).map((c) => ({ label: c.hash.slice(0, 7), description: (c.message.split('\n', 1)[0] ?? '').slice(0, 60) })),
-			],
-			{ placeHolder: 'Select rebase base' },
-		);
+		const baseItems: Array<{ label: string; description?: string } | { label: string; kind: vscode.QuickPickItemKind.Separator }> = [
+			...baseOptions.map((b) => ({ label: b, description: `Rebase from ${b}` })),
+			{ label: 'Recent Commits', kind: vscode.QuickPickItemKind.Separator },
+			...commits.slice(1).map((c) => ({ label: c.hash.slice(0, 7), description: (c.message.split('\n', 1)[0] ?? '').slice(0, 60) })),
+		];
+		const basePick = await vscode.window.showQuickPick(baseItems, { placeHolder: 'Select rebase base', matchOnDescription: true });
 		if (!basePick) {
 			return;
 		}

--- a/src/adapter/webview/rebase-webview.ts
+++ b/src/adapter/webview/rebase-webview.ts
@@ -264,7 +264,7 @@ p { color: var(--vscode-descriptionForeground); }
 					.join('');
 				return `<tr draggable="true" data-hash="${escapeHtml(r.hash)}">
 <td class="drag" title="Drag to reorder"><svg class="grip" width="10" height="16" viewBox="0 0 10 16" fill="currentColor" aria-hidden="true"><circle cx="2" cy="3" r="1.3"/><circle cx="2" cy="8" r="1.3"/><circle cx="2" cy="13" r="1.3"/><circle cx="7" cy="3" r="1.3"/><circle cx="7" cy="8" r="1.3"/><circle cx="7" cy="13" r="1.3"/></svg></td>
-<td><select class="action">${options}</select></td>
+<td><select class="action hg-select">${options}</select></td>
 <td class="hash">${escapeHtml(r.hash.slice(0, 7))}</td>
 <td><input class="subject" value="${escapeHtml(r.subject)}"${action === 'reword' ? '' : ' disabled'} spellcheck="false"></td>
 </tr>`;
@@ -279,31 +279,31 @@ p { color: var(--vscode-descriptionForeground); }
 ${getBaseStyles()}
 body { margin: 0; padding: 12px 16px; font-family: var(--vscode-font-family); color: var(--vscode-foreground); font-size: var(--vscode-font-size); background: var(--vscode-editor-background); }
 h3 { margin: 0 0 4px; font-weight: 600; }
-.legend { margin: 0 0 8px; font-size: 11px; color: var(--vscode-descriptionForeground); line-height: 1.6; }
+.legend { margin: 0 0 8px; font-size: calc(var(--vscode-font-size) - 2px); color: var(--vscode-descriptionForeground); line-height: 1.6; }
 .legend code { font-family: var(--vscode-editor-font-family); color: var(--vscode-textPreformat-foreground, var(--vscode-foreground)); }
-.summary { margin: 0 0 10px; font-size: 11px; color: var(--vscode-descriptionForeground); font-family: var(--vscode-editor-font-family); }
+.summary { margin: 0 0 10px; font-size: calc(var(--vscode-font-size) - 2px); color: var(--vscode-descriptionForeground); font-family: var(--vscode-editor-font-family); }
 table { width: 100%; border-collapse: collapse; }
 th, td { padding: 4px 6px; border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.2)); text-align: left; vertical-align: middle; }
-th { font-weight: 600; font-size: 12px; color: var(--vscode-descriptionForeground); }
+th { font-weight: 600; font-size: calc(var(--vscode-font-size) - 1px); color: var(--vscode-descriptionForeground); }
 td.drag { color: var(--vscode-descriptionForeground); cursor: grab; user-select: none; width: 18px; }
 td.drag .grip { display: inline-block; pointer-events: none; }
-td.hash { color: var(--vscode-descriptionForeground); font-family: var(--vscode-editor-font-family); font-size: 12px; width: 70px; }
+td.hash { color: var(--vscode-descriptionForeground); font-family: var(--vscode-editor-font-family); font-size: calc(var(--vscode-font-size) - 1px); width: 70px; }
 tr { background: transparent; }
 tr.action-drop { opacity: 0.5; }
 tr.action-drop input.subject { text-decoration: line-through; }
 tr.action-squash, tr.action-fixup { background: var(--vscode-editor-inactiveSelectionBackground, rgba(128,128,128,.12)); }
 tr.dragging { opacity: 0.4; }
 tr.drop-target { border-top: 2px solid var(--vscode-focusBorder, #007fd4); }
-select, input.subject { background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, transparent); padding: 2px 4px; font-size: 12px; font-family: var(--vscode-font-family); }
+input.subject { background: var(--vscode-input-background); color: var(--vscode-input-foreground); border: 1px solid var(--vscode-input-border, transparent); padding: 2px 4px; font-size: calc(var(--vscode-font-size) - 1px); font-family: var(--vscode-font-family); } /* select 视觉走共享 .hg-select（dropdown token） */
 select { width: 92px; }
 input.subject { width: 100%; }
 input.subject:disabled { color: var(--vscode-descriptionForeground); opacity: 0.85; }
 input.subject:not(:disabled) { border-color: var(--vscode-focusBorder, #007fd4); }
 .row-actions { margin-top: 12px; display: flex; gap: 8px; justify-content: flex-end; }
 .confirm-overlay { display: none; position: fixed; inset: 0; background: rgba(0,0,0,.4); align-items: center; justify-content: center; z-index: 100; }
-.confirm-box { background: var(--vscode-editorWidget-background, var(--vscode-editor-background)); color: var(--vscode-editorWidget-foreground, var(--vscode-foreground)); border: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.4)); border-radius: 6px; padding: 16px 20px; max-width: 440px; box-shadow: 0 4px 16px rgba(0,0,0,.4); }
-.confirm-box .confirm-count { font-size: 13px; margin-bottom: 6px; }
-.confirm-box .confirm-summary { font-family: var(--vscode-editor-font-family); font-size: 11px; color: var(--vscode-descriptionForeground); margin-bottom: 14px; }
+.confirm-box { background: var(--vscode-editorWidget-background, var(--vscode-editor-background)); color: var(--vscode-editorWidget-foreground, var(--vscode-foreground)); border: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.4)); border-radius: 6px; padding: 16px 20px; max-width: 440px; box-shadow: 0 4px 16px var(--vscode-widget-shadow, rgba(0,0,0,.4)); }
+.confirm-box .confirm-count { font-size: var(--vscode-font-size); margin-bottom: 6px; }
+.confirm-box .confirm-summary { font-family: var(--vscode-editor-font-family); font-size: calc(var(--vscode-font-size) - 2px); color: var(--vscode-descriptionForeground); margin-bottom: 14px; }
 .confirm-actions { display: flex; gap: 8px; justify-content: flex-end; }
 </style>
 </head>

--- a/src/adapter/webview/shared-styles.ts
+++ b/src/adapter/webview/shared-styles.ts
@@ -24,6 +24,18 @@ export const GRAPH_LANE_W = 14;
 /** 按钮视觉变体。 */
 export type ButtonVariant = 'primary' | 'secondary' | 'sm';
 
+// ── 共享内联 SVG 图标（fill/stroke currentColor 随主题前景色；webview 不引 codicon 字体的替代方案） ──
+
+/** 12px 折叠 chevron（向下；折叠态由 CSS rotate(-90deg) 旋转）。 */
+export const ICON_CHEVRON_DOWN =
+	'<svg width="12" height="12" viewBox="0 0 16 16" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" d="M4 6l4 4 4-4"/></svg>';
+/** 11px 关闭 X。 */
+export const ICON_CLOSE =
+	'<svg width="11" height="11" viewBox="0 0 16 16" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M4 4l8 8M12 4l-8 8"/></svg>';
+/** 12px 水平省略号（⋯ 菜单）。 */
+export const ICON_ELLIPSIS =
+	'<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><circle cx="3" cy="8" r="1.4"/><circle cx="8" cy="8" r="1.4"/><circle cx="13" cy="8" r="1.4"/></svg>';
+
 /**
  * 基础样式：`:root` Token + 通用组件类 + 全局控件基线 + 统一交互态。
  * 返回纯 CSS 字符串，供 Webview 在 `<style>` 首行注入。

--- a/src/adapter/webview/shared-styles.ts
+++ b/src/adapter/webview/shared-styles.ts
@@ -3,33 +3,40 @@
  *
  * 4 个自绘 Webview（Commit / Log / Merge / Rebase）共享同一套：
  * - 设计 Token（spacing/radius，对齐 VS Code 语义）；
- * - 基础组件类（`.hg-btn` / `.hg-btn--secondary` / `.hg-btn--sm` / `.hg-input` / `.hg-row`）
+ * - 基础组件类（`.hg-btn` / `.hg-btn--secondary` / `.hg-btn--sm` / `.hg-input` / `.hg-select`）
  *   统一交互态（hover / active / focus-visible / disabled），消除各 Webview 各自硬编码导致的
- *   「按钮无 hover」「`:last-child` 脆弱选择器」「无 focus ring」等熵增。
+ *   「按钮无 hover」「`:last-child` 脆弱选择器」「无 focus ring」等熵增；
+ * - 全局控件基线：滚动条（`--vscode-scrollbarSlider-*`）、checkbox（accent-color）、
+ *   forced-colors（高对比度/Windows 高对比模式回退系统配色）。
  *
  * 设计原则：纯字符串、零 vscode 依赖（可单测）；每个 Webview 在 `<style>` 首行注入
  * {@link getBaseStyles}，再追加本地视图专属规则。本地规则可在必要时覆盖 token 派生值。
  *
- * 主题策略：颜色一律走 `--vscode-*` 语义令牌（深/浅主题自适应），不硬编码 hex。
+ * 主题策略：颜色一律走 `--vscode-*` 语义令牌（深/浅主题自适应），不硬编码 hex；
+ * 字号以 `var(--vscode-font-size)`（默认 13px，随用户设置缩放）为基准 calc 派生。
  */
+
+/** Graph 虚拟滚动行高（px）：CSS 变量与内联 JS 常量同源注入，消除双源漂移。 */
+export const GRAPH_ROW_H = 24;
+/** Graph 泳道列宽（px）：同上。 */
+export const GRAPH_LANE_W = 14;
 
 /** 按钮视觉变体。 */
 export type ButtonVariant = 'primary' | 'secondary' | 'sm';
 
 /**
- * 基础样式：`:root` Token + 通用组件类 + 统一交互态。
+ * 基础样式：`:root` Token + 通用组件类 + 全局控件基线 + 统一交互态。
  * 返回纯 CSS 字符串，供 Webview 在 `<style>` 首行注入。
  */
 export function getBaseStyles(): string {
 	return `:root {
 	--hg-space-1: 4px;
 	--hg-space-2: 8px;
-	--hg-space-3: 12px;
-	--hg-space-4: 16px;
-	--hg-space-6: 24px;
 	--hg-radius-control: var(--vscode-button-borderRadius, 3px);
-	--hg-radius-panel: 4px;
+	--hg-row: ${GRAPH_ROW_H}px;
+	--hg-lane: ${GRAPH_LANE_W}px;
 }
+body { line-height: 1.4; }
 .hg-btn {
 	padding: 6px 10px;
 	border: none;
@@ -37,7 +44,7 @@ export function getBaseStyles(): string {
 	cursor: pointer;
 	background: var(--vscode-button-background);
 	color: var(--vscode-button-foreground);
-	font-size: 13px;
+	font-size: var(--vscode-font-size);
 	font-family: var(--vscode-font-family);
 	transition: background-color .12s ease, filter .12s ease, opacity .12s ease;
 }
@@ -51,22 +58,43 @@ export function getBaseStyles(): string {
 	border: 1px solid var(--vscode-button-border, transparent);
 }
 .hg-btn--secondary:hover { background: var(--vscode-button-secondaryHoverBackground, var(--vscode-button-secondaryBackground)); }
-.hg-btn--sm { padding: 2px 8px; font-size: 11px; }
+.hg-btn--sm { padding: 2px 8px; font-size: calc(var(--vscode-font-size) - 2px); }
 .hg-input {
 	background: var(--vscode-input-background);
 	color: var(--vscode-input-foreground);
 	border: 1px solid var(--vscode-input-border, transparent);
 	border-radius: var(--hg-radius-control);
 	padding: 6px;
-	font-family: var(--vscode-editor-font-family);
+	font-family: var(--vscode-font-family);
 	font-size: var(--vscode-font-size);
 }
 .hg-input:focus { border-color: var(--vscode-inputOption-activeBorder, var(--vscode-focusBorder)); }
 .hg-input:focus-visible { outline: 2px solid var(--vscode-focusBorder); outline-offset: -1px; }
-.hg-row { display: flex; align-items: center; gap: 6px; padding: 2px 8px; cursor: pointer; }
-.hg-row:hover { background: var(--vscode-list-hoverBackground); }
+.hg-select {
+	background: var(--vscode-dropdown-background);
+	color: var(--vscode-dropdown-foreground);
+	border: 1px solid var(--vscode-dropdown-border, var(--vscode-input-border, transparent));
+	border-radius: var(--hg-radius-control);
+	padding: 2px 4px;
+	font-size: calc(var(--vscode-font-size) - 1px);
+	font-family: var(--vscode-font-family);
+}
+.hg-select:focus { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
+input[type='checkbox'] { accent-color: var(--vscode-checkbox-background, var(--vscode-button-background)); }
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb {
+	background: var(--vscode-scrollbarSlider-background, rgba(121,121,121,.4));
+	border-radius: 0;
+}
+::-webkit-scrollbar-thumb:hover { background: var(--vscode-scrollbarSlider-hoverBackground, rgba(100,100,100,.7)); }
+::-webkit-scrollbar-thumb:active { background: var(--vscode-scrollbarSlider-activeBackground, rgba(191,191,191,.4)); }
+::-webkit-scrollbar-corner { background: transparent; }
 @media (prefers-reduced-motion: reduce) {
 	.hg-btn { transition: none; }
+}
+@media (forced-colors: active) {
+	.hg-btn, .hg-btn--secondary { border: 1px solid ButtonText; }
+	.hg-input, .hg-select { border: 1px solid ButtonText; }
 }`;
 }
 

--- a/src/adapter/worktree-commands.ts
+++ b/src/adapter/worktree-commands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { showGitError } from './notify';
 import type { GitRepositoryService } from './git-repository-service';
 import type { WorktreeNode, WorktreeTreeProvider } from './tree/worktree-tree';
 import { parseWorktreeList } from '../engine/worktree/worktree-list';
@@ -102,9 +103,11 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 			try {
 				await service.execGit(args);
 				worktreeTree.refresh();
+				// 创建后聚焦 Worktrees 视图引导定位。
+				void vscode.commands.executeCommand('hyperGit.worktrees.focus');
 				void vscode.window.showInformationMessage(`Worktree created: ${wtPath.trim()}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to create Worktree: ${errMsg(e)}`);
+				void showGitError(`Failed to create Worktree: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -121,17 +124,31 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 	);
 
 	subs.push(
-		vscode.commands.registerCommand('hyperGit.worktreeRemove', async (node?: WorktreeNode) => {
+		vscode.commands.registerCommand('hyperGit.worktreeRemove', async (node?: WorktreeNode, nodes?: WorktreeNode[]) => {
 			const repo = service.repo;
-			if (!repo || !node || node.kind !== 'worktree') {
+			if (!repo) {
 				return;
 			}
-			if (node.isMain) {
-				void vscode.window.showWarningMessage('The main worktree cannot be deleted');
+			// 多选批量（canSelectMany）：main 与当前打开的工作树剔除后逐个删除。
+			const targets = (nodes?.length ? nodes : node ? [node] : []).filter((n) => n?.kind === 'worktree');
+			if (targets.length === 0) {
 				return;
 			}
-			if (worktreeTree.isCurrent(node)) {
-				void vscode.window.showWarningMessage('The currently open Worktree cannot be deleted; please switch to another window first');
+			const skipped: string[] = [];
+			const deletable: WorktreeNode[] = [];
+			for (const t of targets) {
+				if (t.isMain) {
+					skipped.push(`${t.name} (main worktree)`);
+				} else if (worktreeTree.isCurrent(t)) {
+					skipped.push(`${t.name} (currently open)`);
+				} else {
+					deletable.push(t);
+				}
+			}
+			if (skipped.length > 0) {
+				void vscode.window.showWarningMessage(`Skipped: ${skipped.join(', ')}`);
+			}
+			if (deletable.length === 0) {
 				return;
 			}
 			const forcePick = await vscode.window.showQuickPick(
@@ -139,30 +156,40 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 					{ label: 'Delete', description: 'Fails if there are uncommitted changes', f: false as const },
 					{ label: 'Force delete', description: 'Ignore uncommitted changes (irreversible)', f: true as const },
 				],
-				{ placeHolder: 'Delete Worktree' },
+				{ placeHolder: deletable.length === 1 ? 'Delete Worktree' : `Delete ${deletable.length} Worktrees` },
 			);
 			if (!forcePick) {
 				return;
 			}
+			// 多行明细走 MessageOptions.detail（模态框次要文字载体），标题保持单行。
 			const ok = await vscode.window.showWarningMessage(
-				`Delete Worktree?\n${node.path}\n(${node.ref})`,
-				{ modal: true },
+				deletable.length === 1 ? 'Delete Worktree?' : `Delete ${deletable.length} Worktrees?`,
+				{ modal: true, detail: deletable.map((t) => `${t.path}\n(${t.ref})`).join('\n\n') },
 				'Delete',
 			);
 			if (ok !== 'Delete') {
 				return;
 			}
-			try {
-				const args = ['worktree', 'remove'];
-				if (forcePick.f) {
-					args.push('--force');
+			const failures: string[] = [];
+			for (const t of deletable) {
+				try {
+					const args = ['worktree', 'remove'];
+					if (forcePick.f) {
+						args.push('--force');
+					}
+					args.push(t.path);
+					await service.execGit(args);
+				} catch {
+					failures.push(t.name);
 				}
-				args.push(node.path);
-				await service.execGit(args);
-				worktreeTree.refresh();
-				void vscode.window.showInformationMessage(`Worktree deleted: ${node.name}`);
-			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to delete Worktree: ${errMsg(e)}`);
+			}
+			worktreeTree.refresh();
+			if (failures.length > 0) {
+				void vscode.window.showWarningMessage(`Deleted ${deletable.length - failures.length} worktree(s), ${failures.length} failed: ${failures.join(', ')}`);
+			} else if (deletable.length === 1) {
+				void vscode.window.showInformationMessage(`Worktree deleted: ${deletable[0].name}`);
+			} else {
+				void vscode.window.showInformationMessage(`Deleted ${deletable.length} worktrees`);
 			}
 		}),
 	);
@@ -197,7 +224,7 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 				worktreeTree.refresh();
 				void vscode.window.showInformationMessage(`Worktree locked: ${node.name}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to lock Worktree: ${errMsg(e)}`);
+				void showGitError(`Failed to lock Worktree: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -213,7 +240,7 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 				worktreeTree.refresh();
 				void vscode.window.showInformationMessage(`Worktree unlocked: ${node.name}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to unlock Worktree: ${errMsg(e)}`);
+				void showGitError(`Failed to unlock Worktree: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -240,7 +267,7 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 				worktreeTree.refresh();
 				void vscode.window.showInformationMessage(`Worktree moved → ${dest.trim()}`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to move Worktree: ${errMsg(e)}`);
+				void showGitError(`Failed to move Worktree: ${errMsg(e)}`);
 			}
 		}),
 	);
@@ -259,7 +286,7 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 					.filter((p) => p.prunable)
 					.map((p) => p.path);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to read Worktree list: ${errMsg(e)}`);
+				void showGitError(`Failed to read Worktree list: ${errMsg(e)}`);
 				return;
 			}
 			if (prunablePaths.length === 0) {
@@ -267,8 +294,8 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 				return;
 			}
 			const ok = await vscode.window.showWarningMessage(
-				`Prune metadata for ${prunablePaths.length} stale Worktree(s)?\n${prunablePaths.join('\n')}`,
-				{ modal: true },
+				`Prune metadata for ${prunablePaths.length} stale Worktree(s)?`,
+				{ modal: true, detail: prunablePaths.join('\n') },
 				'Prune',
 			);
 			if (ok !== 'Prune') {
@@ -279,7 +306,7 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 				worktreeTree.refresh();
 				void vscode.window.showInformationMessage(`Pruned ${prunablePaths.length} stale Worktree(s)`);
 			} catch (e) {
-				void vscode.window.showErrorMessage(`Failed to prune Worktrees: ${errMsg(e)}`);
+				void showGitError(`Failed to prune Worktrees: ${errMsg(e)}`);
 			}
 		}),
 	);

--- a/src/adapter/worktree-commands.ts
+++ b/src/adapter/worktree-commands.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { showGitError } from './notify';
+import { validateRefName } from '../engine/ref/ref-name';
 import type { GitRepositoryService } from './git-repository-service';
 import type { WorktreeNode, WorktreeTreeProvider } from './tree/worktree-tree';
 import { parseWorktreeList } from '../engine/worktree/worktree-list';
@@ -44,11 +45,21 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 			let branch: string | undefined;
 			let sourceRef: string | undefined;
 			if (modePick.mode === 'new') {
-				branch = await vscode.window.showInputBox({ prompt: 'New branch name', placeHolder: 'feature/y' });
+				// 多步输入（分支名 → 起点 → 路径）不因失焦丢失（ignoreFocusOut；step/totalSteps 仅 createInputBox 支持）。
+				branch = await vscode.window.showInputBox({
+					prompt: 'New branch name',
+					placeHolder: 'feature/y',
+					validateInput: (v) => validateRefName(v, 'branch'),
+					ignoreFocusOut: true,
+				});
 				if (!branch?.trim()) {
 					return;
 				}
-				const start = await vscode.window.showInputBox({ prompt: 'Start point (leave empty = HEAD)', placeHolder: 'HEAD / main / abc1234' });
+				const start = await vscode.window.showInputBox({
+					prompt: 'Start point (leave empty = HEAD)',
+					placeHolder: 'HEAD / main / abc1234',
+					ignoreFocusOut: true,
+				});
 				if (start === undefined) {
 					return; // Esc 取消；空字符串 = HEAD（允许）
 				}
@@ -81,6 +92,7 @@ export function registerWorktreeCommands(service: GitRepositoryService, worktree
 				prompt: 'Worktree path (relative to repo root / absolute)',
 				value: `../${safeName}-wt`,
 				placeHolder: '../feature-y-wt',
+				ignoreFocusOut: true,
 			});
 			if (!wtPath?.trim()) {
 				return;

--- a/src/engine/commit/conventional-linter.ts
+++ b/src/engine/commit/conventional-linter.ts
@@ -30,18 +30,18 @@ export const ALLOWED_COMMIT_TYPES = ALLOWED_TYPES;
 export function validateConventional(message: string): ConventionalValidation {
 	const trimmed = message.trim();
 	if (!trimmed) {
-		return { severity: 'error', reason: '提交信息不能为空' };
+		return { severity: 'error', reason: 'Commit message cannot be empty' };
 	}
 	const subject = message.split(/\r?\n/, 1)[0] ?? '';
 	if (!subject.trim()) {
-		return { severity: 'error', reason: '主题行（首行）不能为空' };
+		return { severity: 'error', reason: 'The subject line (first line) cannot be empty' };
 	}
 	if (!SUBJECT_RE.test(subject)) {
 		const allowed = ALLOWED_TYPES.join('/');
-		return { severity: 'error', reason: `首行需形如 "type(scope): description"，type ∈ ${allowed}` };
+		return { severity: 'error', reason: `The subject line must look like "type(scope): description", where type is one of ${allowed}` };
 	}
 	if (subject.length > SUBJECT_MAX_LENGTH) {
-		return { severity: 'warning', reason: `主题行 ${subject.length} 字符，建议 ≤ ${SUBJECT_MAX_LENGTH}` };
+		return { severity: 'warning', reason: `Subject line is ${subject.length} characters; keep it within ${SUBJECT_MAX_LENGTH}` };
 	}
 	return { severity: 'ok' };
 }

--- a/src/engine/ref/cleanup.ts
+++ b/src/engine/ref/cleanup.ts
@@ -80,13 +80,13 @@ export function truncateNames(names: readonly string[], max = 8): string {
 	if (names.length <= max) {
 		return names.join(', ');
 	}
-	return `${names.slice(0, max).join(', ')} …还有 ${names.length - max} 个`;
+	return `${names.slice(0, max).join(', ')} … and ${names.length - max} more`;
 }
 
 /**
  * 生成批量删除本地分支的确认文案与确认按钮文本（纯逻辑）。
  * 诚实呈现强制删除风险：混合时分栏列出，确保 force 删除不被隐藏。
- * 单个目标保留原有针对性文案以维持既有体验。
+ * 单个目标保留原有针对性文案以维持既有体验。文案统一英文（对齐全扩展 UI 语言）。
  */
 export function formatBranchDeleteConfirm(
 	merged: readonly string[],
@@ -96,22 +96,22 @@ export function formatBranchDeleteConfirm(
 	if (total === 1) {
 		const name = merged[0] ?? unmerged[0] ?? '';
 		return merged.length === 1
-			? { detail: `分支「${name}」已合并，可安全删除。`, confirmLabel: '删除' }
-			: { detail: `分支「${name}」未合并，强制删除将丢失其独有提交！`, confirmLabel: '强制删除' };
+			? { detail: `Branch "${name}" is fully merged and safe to delete.`, confirmLabel: 'Delete' }
+			: { detail: `Branch "${name}" is NOT merged. Force-deleting will lose its unique commits!`, confirmLabel: 'Force Delete' };
 	}
 	if (unmerged.length === 0) {
-		return { detail: `将删除 ${total} 个已合并的本地分支：${truncateNames(merged)}`, confirmLabel: '删除' };
+		return { detail: `Delete ${total} merged local branch(es): ${truncateNames(merged)}`, confirmLabel: 'Delete' };
 	}
 	if (merged.length === 0) {
 		return {
-			detail: `将强制删除 ${total} 个未合并的本地分支：${truncateNames(unmerged)}（将丢失它们的独有提交！）`,
-			confirmLabel: '强制删除',
+			detail: `Force-delete ${total} unmerged local branch(es): ${truncateNames(unmerged)} (their unique commits will be lost!)`,
+			confirmLabel: 'Force Delete',
 		};
 	}
 	const detail = [
-		`将删除 ${total} 个本地分支：`,
-		`· 已合并（安全删除）：${truncateNames(merged)}`,
-		`· 未合并（强制删除，丢失提交）：${truncateNames(unmerged)}`,
+		`Delete ${total} local branches:`,
+		`· Merged (safe to delete): ${truncateNames(merged)}`,
+		`· Unmerged (force-delete, commits will be lost): ${truncateNames(unmerged)}`,
 	].join('\n');
-	return { detail, confirmLabel: '全部删除' };
+	return { detail, confirmLabel: 'Delete All' };
 }

--- a/src/engine/ref/ref-name.ts
+++ b/src/engine/ref/ref-name.ts
@@ -1,0 +1,56 @@
+/**
+ * Git ref 名（分支/标签）即时校验（纯函数，零 vscode 依赖）。
+ *
+ * 规则取 `git check-ref-format` 的 UI 相关子集：拦截明显非法输入并给出可行动提示，
+ * 不追求与 git 完全一致（最终仲裁仍由 git 本身完成——过严会挡住合法 ref）。
+ */
+
+export type RefKind = 'branch' | 'tag' | 'any';
+
+/** 校验 ref 名：合法返回 null，非法返回用户可读的英文提示（供 InputBox.validateInput 直用）。 */
+export function validateRefName(name: string, kind: RefKind = 'any'): string | null {
+	const v = name;
+	if (!v.trim()) {
+		return 'Name cannot be empty';
+	}
+	if (v !== v.trim()) {
+		return 'Name cannot start or end with whitespace';
+	}
+	if (v.startsWith('-')) {
+		return 'Name cannot start with "-" (it would be parsed as an option)';
+	}
+	if (v.endsWith('.')) {
+		return 'Name cannot end with "."';
+	}
+	if (v.endsWith('.lock')) {
+		return 'Name cannot end with ".lock"';
+	}
+	if (v.includes('..')) {
+		return 'Name cannot contain ".."';
+	}
+	if (v.includes('@{')) {
+		return 'Name cannot contain "@{"';
+	}
+	if (/[\s~^:?*[\\]/.test(v)) {
+		return 'Name cannot contain whitespace or any of ~ ^ : ? * [ \\';
+	}
+	if (kind === 'tag' && v.includes('#')) {
+		return 'Tag names cannot contain "#"';
+	}
+	if (v.startsWith('/') || v.endsWith('/')) {
+		return 'Name cannot start or end with "/"';
+	}
+	if (v.includes('//')) {
+		return 'Name cannot contain "//"';
+	}
+	if (v.split('/').some((part) => part.startsWith('.'))) {
+		return 'Path components cannot start with "."';
+	}
+	if (v === '@') {
+		return 'Name cannot be just "@"';
+	}
+	if (kind === 'branch' && v.toUpperCase() === 'HEAD') {
+		return 'Branch cannot be named "HEAD"';
+	}
+	return null;
+}

--- a/src/engine/ref/remote-ref.ts
+++ b/src/engine/ref/remote-ref.ts
@@ -85,12 +85,12 @@ export function formatRemoteDeleteConfirm(
 	deletable: readonly RemoteBranchTarget[],
 	opts?: { hasUpstreamOfHead?: boolean },
 ): { detail: string; confirmLabel: string } {
-	const head = opts?.hasUpstreamOfHead ? '⚠ 其中包含当前分支的上游，删除后当前分支将失去远程追踪。\n' : '';
-	const irreversible = '此操作作用于远程仓库，不可撤销，并可能影响其他协作者。';
+	const head = opts?.hasUpstreamOfHead ? '⚠ The selection includes the upstream of the current branch; deleting it will leave the current branch untracked.\n' : '';
+	const irreversible = 'This acts on the remote repository, cannot be undone, and may affect other collaborators.';
 	const n = deletable.length;
 	const body =
 		n === 1
-			? `将删除远程分支「${deletable[0].shortName}」（位于远程 ${deletable[0].remote}）。\n${irreversible}`
-			: `将删除 ${n} 个远程分支：${truncateNames(deletable.map((t) => t.shortName))}。\n${irreversible}`;
-	return { detail: `${head}${body}`, confirmLabel: '删除' };
+			? `Delete remote branch "${deletable[0].shortName}" (on remote ${deletable[0].remote})?\n${irreversible}`
+			: `Delete ${n} remote branches: ${truncateNames(deletable.map((t) => t.shortName))}.\n${irreversible}`;
+	return { detail: `${head}${body}`, confirmLabel: 'Delete' };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,7 +30,6 @@ import { registerMiscCommands } from './adapter/misc-commands';
 import { registerClaudeCommands } from './adapter/claude-commands';
 import { registerRepositorySelectionCommand } from './adapter/repository-selection';
 import { getGitApi } from './adapter/git-api';
-import { FileStatus } from './engine/model';
 import { GitRepositoryService } from './adapter/git-repository-service';
 import { GitHubAuth } from './adapter/ci/github-auth';
 import { GitHubCiService } from './adapter/ci/github-ci-service';
@@ -252,10 +251,12 @@ export async function activate(
 		const n = service.getChangeCount();
 		badgeView.badge = n > 0 ? { value: n, tooltip: `${n} uncommitted change(s)` } : undefined;
 		// 冲突存在性 context key：acceptOurs/acceptTheirs 等命令在 commandPalette 的显隐依据（见 package.json）。
+		// 事实源用 vscode.git 的 mergeChanges——7 种 unmerged 状态只进该数组，index/workingTree 变更永不承载
+		// 冲突（getChanges 的 status 映射因此恒判不出冲突，曾致 context key 恒 false、palette 命令永久隐藏）。
 		void vscode.commands.executeCommand(
 			'setContext',
 			'hyperGit.hasConflicts',
-			service.getChanges().some((c) => c.status === FileStatus.Conflict),
+			(service.repo?.state.mergeChanges.length ?? 0) > 0,
 		);
 	};
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -159,6 +159,7 @@ export async function activate(
 		worktreeTree,
 		shelfTree,
 		blame,
+		inlineLens,
 		branchesView,
 		badgeView,
 		vscode.window.registerWebviewViewProvider(CommitWebviewProvider.viewType, commitView),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,7 @@ import { StashTreeProvider } from './adapter/tree/stash-tree';
 import { WorktreeTreeProvider } from './adapter/tree/worktree-tree';
 import { registerWorktreeCommands } from './adapter/worktree-commands';
 import { CommitWebviewProvider } from './adapter/webview/commit-webview';
-import { showGitConsole } from './infra/git-console';
+import { showGitConsole, disposeGitConsole } from './infra/git-console';
 import { InlineCommitCodeLensProvider, registerInlineCommitCommand } from './adapter/editor/inline-commit-codelens';
 import { BlameAnnotationController } from './adapter/editor/blame-annotation';
 import { ShelfService, ShelfTreeProvider, registerShelfCommands } from './adapter/shelf';
@@ -45,6 +45,21 @@ class EmptyTreeProvider implements vscode.TreeDataProvider<never> {
 	}
 }
 
+/** git 扩展不可用时 webview 视图（Commit/Graph）的占位 provider：静态说明页（无脚本，CSP 最小化）。 */
+class UnavailableViewProvider implements vscode.WebviewViewProvider {
+	constructor(private readonly viewName: string) {}
+	resolveWebviewView(view: vscode.WebviewView): void {
+		view.webview.options = { enableScripts: false, localResourceRoots: [] };
+		view.webview.html = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'">
+<style>body { font-family: var(--vscode-font-family); color: var(--vscode-foreground); background: var(--vscode-sideBar-background); padding: 14px 16px; font-size: var(--vscode-font-size); }</style>
+</head>
+<body><strong>${this.viewName}</strong><p style="color: var(--vscode-descriptionForeground)">The built-in Git extension is unavailable, so ${this.viewName} cannot load. Enable the Git extension and reload the window.</p></body>
+</html>`;
+	}
+}
+
 /**
  * 扩展入口。仅做装配（DI 注册），业务逻辑下沉到 engine/adapter 层。
  * 返回 `{ service }` 供集成测试程序化驱动仓库切换（vscode.git 同款导出模式）。
@@ -53,6 +68,8 @@ export async function activate(
 	context: vscode.ExtensionContext,
 ): Promise<{ service: GitRepositoryService } | void> {
 	const logger = createLogger();
+	// LogOutputChannel 随扩展释放（懒创建，无日志的会话零开销）。
+	context.subscriptions.push(logger, new vscode.Disposable(disposeGitConsole));
 	logger.info('Hyper Git activated');
 
 	const llm = new NullLlmProvider();
@@ -68,7 +85,16 @@ export async function activate(
 	if (!api) {
 		logger.warn('vscode.git API 不可用，视图保持空状态');
 		const empty = new EmptyTreeProvider();
-		context.subscriptions.push(vscode.window.registerTreeDataProvider('hyperGit.worktrees', empty));
+		context.subscriptions.push(
+			// 全部声明的树视图注册空 provider：未注册的视图显示 "no tree view registered" 报错而非 viewsWelcome。
+			vscode.window.registerTreeDataProvider('hyperGit.branches', empty),
+			vscode.window.registerTreeDataProvider('hyperGit.stash', empty),
+			vscode.window.registerTreeDataProvider('hyperGit.worktrees', empty),
+			vscode.window.createTreeView('hyperGit.shelf', { treeDataProvider: empty }),
+			// webview 视图渲染静态占位说明页。
+			vscode.window.registerWebviewViewProvider('hyperGit.commit', new UnavailableViewProvider('Commit')),
+			vscode.window.registerWebviewViewProvider('hyperGit.log', new UnavailableViewProvider('Graph')),
+		);
 		return;
 	}
 
@@ -96,10 +122,11 @@ export async function activate(
 		service.repoRoot ?? workspaceRoot,
 	);
 	// Branches 视图启用多选（canSelectMany 仅 createTreeView 支持，registerTreeDataProvider 不支持）；
-	// 多选后批量操作（删除分支/标签、复制引用、收藏）作用于整个选区。
+	// 多选后批量操作（删除分支/标签、复制引用、收藏）作用于整个选区。showCollapseAll 供前缀分组树一键折叠。
 	const branchesView = vscode.window.createTreeView('hyperGit.branches', {
 		treeDataProvider: branchesTree,
 		canSelectMany: true,
+		showCollapseAll: true,
 	});
 	const stashTree = new StashTreeProvider(service);
 	const worktreeTree = new WorktreeTreeProvider(service);
@@ -114,6 +141,22 @@ export async function activate(
 	// 复用占位 EmptyTreeProvider（空树）。
 	const badgeView = vscode.window.createTreeView('hyperGit.changesBadge', {
 		treeDataProvider: new EmptyTreeProvider(),
+	});
+	// Stash/Worktrees 统一 createTreeView（原 registerTreeDataProvider 拿不到 TreeView 句柄）：
+	// canSelectMany 启用批量 Drop/Remove；provider 加载失败经 TreeView.message 以视图内联错误呈现。
+	const stashView = vscode.window.createTreeView('hyperGit.stash', {
+		treeDataProvider: stashTree,
+		canSelectMany: true,
+	});
+	const worktreesView = vscode.window.createTreeView('hyperGit.worktrees', {
+		treeDataProvider: worktreeTree,
+		canSelectMany: true,
+	});
+	stashTree.setViewMessageSink((message) => {
+		stashView.message = message;
+	});
+	worktreeTree.setViewMessageSink((message) => {
+		worktreesView.message = message;
 	});
 	const focusCommitView = (): void => {
 		void vscode.commands.executeCommand('hyperGit.commit.focus');
@@ -164,9 +207,9 @@ export async function activate(
 		badgeView,
 		vscode.window.registerWebviewViewProvider(CommitWebviewProvider.viewType, commitView),
 		vscode.window.registerWebviewViewProvider(LogWebviewProvider.viewType, logTree),
-		vscode.window.registerTreeDataProvider('hyperGit.stash', stashTree),
+		stashView,
 		vscode.window.createTreeView('hyperGit.shelf', { treeDataProvider: shelfTree }),
-		vscode.window.registerTreeDataProvider('hyperGit.worktrees', worktreeTree),
+		worktreesView,
 		...registerChangesCommands(service, registry),
 		...registerHistoryCommands(service, logTree, branchesTree, favorites),
 		...registerGitCliCommands(service, branchesTree, logTree),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,6 +30,7 @@ import { registerMiscCommands } from './adapter/misc-commands';
 import { registerClaudeCommands } from './adapter/claude-commands';
 import { registerRepositorySelectionCommand } from './adapter/repository-selection';
 import { getGitApi } from './adapter/git-api';
+import { FileStatus } from './engine/model';
 import { GitRepositoryService } from './adapter/git-repository-service';
 import { GitHubAuth } from './adapter/ci/github-auth';
 import { GitHubCiService } from './adapter/ci/github-ci-service';
@@ -250,6 +251,12 @@ export async function activate(
 	const updateBadge = (): void => {
 		const n = service.getChangeCount();
 		badgeView.badge = n > 0 ? { value: n, tooltip: `${n} uncommitted change(s)` } : undefined;
+		// 冲突存在性 context key：acceptOurs/acceptTheirs 等命令在 commandPalette 的显隐依据（见 package.json）。
+		void vscode.commands.executeCommand(
+			'setContext',
+			'hyperGit.hasConflicts',
+			service.getChanges().some((c) => c.status === FileStatus.Conflict),
+		);
 	};
 
 	// 角标走独立快路径（~40ms 微防抖）：即便视图未 resolve / Panel 未激活也近实时更新计数（Panel 展开即呈现），

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ import { InlineCommitCodeLensProvider, registerInlineCommitCommand } from './ada
 import { BlameAnnotationController } from './adapter/editor/blame-annotation';
 import { ShelfService, ShelfTreeProvider, registerShelfCommands } from './adapter/shelf';
 import { RebaseWebview } from './adapter/webview/rebase-webview';
-import { registerMergeCommands } from './adapter/webview/merge-editor';
+import { MergeEditorWebview, registerMergeCommands } from './adapter/webview/merge-editor';
 import { registerMiscCommands } from './adapter/misc-commands';
 import { registerClaudeCommands } from './adapter/claude-commands';
 import { registerRepositorySelectionCommand } from './adapter/repository-selection';
@@ -173,6 +173,9 @@ export async function activate(
 		...registerAdvancedCommands(service, branchesTree),
 		...registerRemoteCommands(service, branchesTree, logTree),
 		...registerMergeCommands(service),
+		// 窗口 reload 后 rebase/merge 面板恢复（retainContextWhenHidden 仅保活不跨 reload，serializer 补齐）。
+		RebaseWebview.registerSerializer(service),
+		MergeEditorWebview.registerSerializer(service),
 		...registerMiscCommands(service, branchesTree, logTree),
 		...registerClaudeCommands(),
 		registerRepositorySelectionCommand(service),

--- a/src/infra/git-console.ts
+++ b/src/infra/git-console.ts
@@ -2,13 +2,14 @@ import * as vscode from 'vscode';
 
 /**
  * Hyper Git Console：记录所有经 execGit 执行的 git 命令及其输出。
- * 复用单一 OutputChannel（懒构造）。
+ * 复用单一 LogOutputChannel（懒构造；{log:true} 使其纳入统一日志视图，appendLine
+ * 保持 `$ git …` 誊录形态不加分级别前缀，命令回显可读性优先）。
  */
-let channel: vscode.OutputChannel | undefined;
+let channel: vscode.LogOutputChannel | undefined;
 
-function getChannel(): vscode.OutputChannel {
+function getChannel(): vscode.LogOutputChannel {
 	if (!channel) {
-		channel = vscode.window.createOutputChannel('Hyper Git Console');
+		channel = vscode.window.createOutputChannel('Hyper Git Console', { log: true });
 	}
 	return channel;
 }
@@ -28,4 +29,10 @@ export function logGit(args: readonly string[], output?: string, error?: string)
 /** 显示 Console 面板。 */
 export function showGitConsole(): void {
 	getChannel().show(true);
+}
+
+/** 释放 channel（随扩展 deactivate；extension.ts 订阅调用）。 */
+export function disposeGitConsole(): void {
+	channel?.dispose();
+	channel = undefined;
 }

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,19 +1,31 @@
 import * as vscode from 'vscode';
 
-export interface Logger {
+export interface Logger extends vscode.Disposable {
 	info(message: string): void;
 	warn(message: string): void;
 	error(message: string, err?: unknown): void;
 	show(): void;
 }
 
-/** 创建基于 OutputChannel 的日志器。 */
+/**
+ * 创建基于 LogOutputChannel 的日志器（1.74+：自动时间戳与级别、统一日志视图可过滤，
+ * 取代手写 [info]/[warn] 前缀）。懒创建：首次写入才建 channel，未产生日志的会话零开销。
+ */
 export function createLogger(name = 'Hyper Git'): Logger {
-	const channel = vscode.window.createOutputChannel(name);
+	let channel: vscode.LogOutputChannel | undefined;
+	const getChannel = (): vscode.LogOutputChannel =>
+		(channel ??= vscode.window.createOutputChannel(name, { log: true }));
 	return {
-		info: (message) => channel.appendLine(`[info] ${message}`),
-		warn: (message) => channel.appendLine(`[warn] ${message}`),
-		error: (message, err) => channel.appendLine(`[error] ${message}${err !== undefined ? `: ${String(err)}` : ''}`),
-		show: () => channel.show(),
+		info: (message) => getChannel().info(message),
+		warn: (message) => getChannel().warn(message),
+		error: (message, err) => {
+			if (err === undefined) {
+				getChannel().error(message);
+			} else {
+				getChannel().error(message, err instanceof Error ? err.message : err);
+			}
+		},
+		show: () => getChannel().show(true),
+		dispose: () => channel?.dispose(),
 	};
 }

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -20,6 +20,7 @@ export interface CommitFileItem {
 	readonly label: string; // basename
 	readonly dir: string; // dirname
 	readonly themeColor: string; // gitDecoration.* 主题色 id → webview 用 var(--vscode-...)
+	readonly letter: string; // 状态字母标记（M/A/U/R/D/C/!/I，对齐官方 SCM 字母角标；webview 渲染替代色点）
 }
 
 /**

--- a/tests/unit/menus-guard.test.ts
+++ b/tests/unit/menus-guard.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 清单守护测试：锁定 package.json 贡献点中三类易回归的规范。
+ * 1. `viewItem =~` 正则必须 ^…$ 锚定——未锚定正则会误匹配包含子串的 contextValue
+ *    （如 `hyperGit.branchFolder` 命中 `/hyperGit.branch|…/`，文件夹行出现分支菜单）。
+ * 2. 全部 contributes.settings 必须声明 scope——未声明的设置在 User/Workspace 层级语义不明。
+ * 3. 可见视图必须声明 contextualTitle——视图拖出容器为独立面板时标题不退化为视图名。
+ */
+
+interface PackageJson {
+	contributes: {
+		menus: Record<string, Array<{ when?: string }>>;
+		views: Record<string, Array<{ id: string; contextualTitle?: string; when?: string }>>;
+		configuration: { properties: Record<string, { scope?: string }> };
+	};
+}
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf8')) as PackageJson;
+
+function allWhenClauses(): string[] {
+	const clauses: string[] = [];
+	for (const entries of Object.values(pkg.contributes.menus)) {
+		for (const entry of entries) {
+			if (entry.when) {
+				clauses.push(entry.when);
+			}
+		}
+	}
+	return clauses;
+}
+
+describe('menus-guard（清单守护）', () => {
+	it('所有 viewItem =~ 正则必须 ^…$ 锚定', () => {
+		const offenders: string[] = [];
+		for (const when of allWhenClauses()) {
+			const match = when.match(/viewItem =~ \/([^/]+)\//);
+			if (match && !match[1].startsWith('^')) {
+				offenders.push(when);
+			}
+			if (match && !match[1].endsWith('$')) {
+				offenders.push(when);
+			}
+		}
+		expect(offenders, `未锚定的 viewItem 正则: ${offenders.join(' | ')}`).toEqual([]);
+	});
+
+	it('全部设置项必须声明 scope', () => {
+		const missing = Object.keys(pkg.contributes.configuration.properties).filter(
+			(key) => !pkg.contributes.configuration.properties[key].scope,
+		);
+		expect(missing, `缺 scope 的设置: ${missing.join(', ')}`).toEqual([]);
+	});
+
+	it('可见视图必须声明 contextualTitle', () => {
+		const missing: string[] = [];
+		for (const views of Object.values(pkg.contributes.views)) {
+			for (const view of views) {
+				// when:false 的隐藏承载视图（changesBadge）豁免。
+				if (view.when === 'false') {
+					continue;
+				}
+				if (!view.contextualTitle) {
+					missing.push(view.id);
+				}
+			}
+		}
+		expect(missing, `缺 contextualTitle 的视图: ${missing.join(', ')}`).toEqual([]);
+	});
+
+	it('扩展声明 extensionKind=workspace（依赖本地 git，须跑在工作区侧）', () => {
+		const raw = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf8')) as { extensionKind?: string[] };
+		expect(raw.extensionKind).toEqual(['workspace']);
+	});
+
+	it('非受信工作区显式声明不支持（扩展会执行 commit/push/discard）', () => {
+		const raw = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf8')) as {
+			capabilities: { untrustedWorkspaces?: { supported?: boolean } };
+		};
+		expect(raw.capabilities.untrustedWorkspaces?.supported).toBe(false);
+	});
+});

--- a/tests/unit/ref-cleanup.test.ts
+++ b/tests/unit/ref-cleanup.test.ts
@@ -72,7 +72,7 @@ describe('truncateNames', () => {
 
 	it('超过上限时截断并标注剩余数量', () => {
 		const names = Array.from({ length: 10 }, (_, i) => `b${i}`);
-		expect(truncateNames(names)).toBe('b0, b1, b2, b3, b4, b5, b6, b7 …还有 2 个');
+		expect(truncateNames(names)).toBe('b0, b1, b2, b3, b4, b5, b6, b7 … and 2 more');
 	});
 });
 
@@ -106,31 +106,34 @@ describe('diffPrunedRefs', () => {
 
 describe('formatBranchDeleteConfirm', () => {
 	it('单个已合并 → 安全删除文案', () => {
-		expect(formatBranchDeleteConfirm(['feat'], [])).toEqual({ detail: '分支「feat」已合并，可安全删除。', confirmLabel: '删除' });
+		expect(formatBranchDeleteConfirm(['feat'], [])).toEqual({
+			detail: 'Branch "feat" is fully merged and safe to delete.',
+			confirmLabel: 'Delete',
+		});
 	});
 
 	it('单个未合并 → 强制删除文案', () => {
 		const r = formatBranchDeleteConfirm([], ['feat']);
-		expect(r.confirmLabel).toBe('强制删除');
-		expect(r.detail).toContain('未合并');
+		expect(r.confirmLabel).toBe('Force Delete');
+		expect(r.detail).toContain('NOT merged');
 	});
 
 	it('多个全已合并 → 删除', () => {
 		const r = formatBranchDeleteConfirm(['a', 'b'], []);
-		expect(r.confirmLabel).toBe('删除');
-		expect(r.detail).toContain('将删除 2 个已合并');
+		expect(r.confirmLabel).toBe('Delete');
+		expect(r.detail).toContain('Delete 2 merged local branch');
 	});
 
 	it('多个全未合并 → 强制删除并警示丢失提交', () => {
 		const r = formatBranchDeleteConfirm([], ['a', 'b']);
-		expect(r.confirmLabel).toBe('强制删除');
-		expect(r.detail).toContain('丢失');
+		expect(r.confirmLabel).toBe('Force Delete');
+		expect(r.detail).toContain('lost');
 	});
 
 	it('混合 → 全部删除并分栏诚实呈现', () => {
 		const r = formatBranchDeleteConfirm(['a'], ['b']);
-		expect(r.confirmLabel).toBe('全部删除');
-		expect(r.detail).toContain('已合并');
-		expect(r.detail).toContain('未合并');
+		expect(r.confirmLabel).toBe('Delete All');
+		expect(r.detail).toContain('Merged');
+		expect(r.detail).toContain('Unmerged');
 	});
 });

--- a/tests/unit/ref-name.test.ts
+++ b/tests/unit/ref-name.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { validateRefName } from '../../src/engine/ref/ref-name';
+
+describe('validateRefName', () => {
+	it('合法名称通过（含斜杠分层）', () => {
+		expect(validateRefName('feature/x')).toBeNull();
+		expect(validateRefName('feature/login-page')).toBeNull();
+		expect(validateRefName('v1.0.0', 'tag')).toBeNull();
+		expect(validateRefName('release/1.2.3-beta.1', 'tag')).toBeNull();
+		expect(validateRefName('a.b.c')).toBeNull();
+	});
+
+	it('空与空白', () => {
+		expect(validateRefName('')).toBe('Name cannot be empty');
+		expect(validateRefName('   ')).toBe('Name cannot be empty');
+		expect(validateRefName(' foo')).toContain('whitespace');
+	});
+
+	it('前导 -（会被当作选项）', () => {
+		expect(validateRefName('-x')).toContain('"-"');
+	});
+
+	it('非法字符集', () => {
+		for (const bad of ['a b', 'a~b', 'a^b', 'a:b', 'a?b', 'a*b', 'a[b', 'a\\b']) {
+			expect(validateRefName(bad)).toContain('cannot contain');
+		}
+	});
+
+	it('.. 与 @{ 与孤立 @', () => {
+		expect(validateRefName('a..b')).toContain('..');
+		expect(validateRefName('a@{b')).toContain('@{');
+		expect(validateRefName('@')).toContain('"@"');
+	});
+
+	it('点相关：尾点 / .lock / 组件点开头', () => {
+		expect(validateRefName('a.')).toContain('"."');
+		expect(validateRefName('a.lock')).toContain('.lock');
+		expect(validateRefName('.hidden/x')).toContain('"."');
+		expect(validateRefName('a/.b')).toContain('"."');
+	});
+
+	it('斜杠相关：首尾斜杠与 //', () => {
+		expect(validateRefName('/a')).toContain('"/"');
+		expect(validateRefName('a/')).toContain('"/"');
+		expect(validateRefName('a//b')).toContain('"//"');
+	});
+
+	it('branch 禁 HEAD（大小写不敏感），tag 禁 #', () => {
+		expect(validateRefName('HEAD', 'branch')).toContain('HEAD');
+		expect(validateRefName('head', 'branch')).toContain('HEAD');
+		expect(validateRefName('HEAD')).toBeNull(); // any 不受限
+		expect(validateRefName('rel#1', 'tag')).toContain('"#"');
+	});
+
+	it('组件级点规则不误伤常规点号名', () => {
+		expect(validateRefName('v1.0')).toBeNull();
+		expect(validateRefName('a.b/c.d')).toBeNull();
+	});
+});

--- a/tests/unit/ref-remote.test.ts
+++ b/tests/unit/ref-remote.test.ts
@@ -77,10 +77,10 @@ describe('formatRemoteDeleteConfirm', () => {
 
 	it('单条 → 删除 + 不可撤销 + 协作者', () => {
 		const r = formatRemoteDeleteConfirm([t('origin/foo', 'origin', 'foo')]);
-		expect(r.confirmLabel).toBe('删除');
+		expect(r.confirmLabel).toBe('Delete');
 		expect(r.detail).toContain('origin/foo');
-		expect(r.detail).toContain('不可撤销');
-		expect(r.detail).toContain('协作者');
+		expect(r.detail).toContain('cannot be undone');
+		expect(r.detail).toContain('collaborators');
 	});
 
 	it('多条 → 含数量与截断名', () => {
@@ -89,18 +89,18 @@ describe('formatRemoteDeleteConfirm', () => {
 			t('origin/b1', 'origin', 'b1'),
 			t('origin/b2', 'origin', 'b2'),
 		]);
-		expect(r.confirmLabel).toBe('删除');
-		expect(r.detail).toContain('3 个');
+		expect(r.confirmLabel).toBe('Delete');
+		expect(r.detail).toContain('3 remote');
 	});
 
-	it('多条超上限 → truncateNames 截断（…还有）', () => {
+	it('多条超上限 → truncateNames 截断（… and N more）', () => {
 		const ts = Array.from({ length: 12 }, (_, i) => t(`origin/b${i}`, 'origin', `b${i}`));
-		expect(formatRemoteDeleteConfirm(ts).detail).toContain('…还有');
+		expect(formatRemoteDeleteConfirm(ts).detail).toContain('… and 4 more');
 	});
 
 	it('含当前 HEAD 上游 → ⚠ 软警示', () => {
 		const r = formatRemoteDeleteConfirm([t('origin/foo', 'origin', 'foo')], { hasUpstreamOfHead: true });
-		expect(r.detail).toContain('上游');
+		expect(r.detail).toContain('upstream');
 		expect(r.detail).toContain('⚠');
 	});
 

--- a/tests/unit/shared-styles.test.ts
+++ b/tests/unit/shared-styles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getBaseStyles, getButtonClass } from '../../src/adapter/webview/shared-styles';
+import { getBaseStyles, getButtonClass, GRAPH_ROW_H, GRAPH_LANE_W } from '../../src/adapter/webview/shared-styles';
 
 describe('shared-styles', () => {
 	it('getBaseStyles 暴露 spacing/radius token 与全部基础组件类', () => {
@@ -13,22 +13,47 @@ describe('shared-styles', () => {
 		expect(css).toContain('.hg-btn--secondary');
 		expect(css).toContain('.hg-btn--sm');
 		expect(css).toContain('.hg-input');
-		expect(css).toContain('.hg-row');
+		expect(css).toContain('.hg-select');
 	});
 
-	it('getBaseStyles 统一交互态：hover / focus-visible / disabled / reduced-motion', () => {
+	it('GRAPH 行高/列宽常量与 CSS 变量同源注入（消除 CSS/JS 双源漂移）', () => {
+		const css = getBaseStyles();
+		expect(css).toContain(`--hg-row: ${GRAPH_ROW_H}px`);
+		expect(css).toContain(`--hg-lane: ${GRAPH_LANE_W}px`);
+		expect(GRAPH_ROW_H).toBeGreaterThan(0);
+		expect(GRAPH_LANE_W).toBeGreaterThan(0);
+	});
+
+	it('getBaseStyles 统一交互态：hover / focus-visible / disabled / reduced-motion / forced-colors', () => {
 		const css = getBaseStyles();
 		expect(css).toContain(':hover');
 		expect(css).toContain(':focus-visible');
 		expect(css).toContain(':disabled');
 		expect(css).toContain('prefers-reduced-motion');
+		expect(css).toContain('forced-colors');
+	});
+
+	it('全局控件基线：滚动条与 checkbox 走主题令牌', () => {
+		const css = getBaseStyles();
+		expect(css).toContain('::-webkit-scrollbar');
+		expect(css).toContain('--vscode-scrollbarSlider-background');
+		expect(css).toContain('accent-color');
+		expect(css).toContain('--vscode-checkbox-background');
 	});
 
 	it('getBaseStyles 颜色一律走 --vscode-* 语义令牌（不硬编码裸 hex 作主色）', () => {
 		const css = getBaseStyles();
 		expect(css).toContain('var(--vscode-button-background)');
 		expect(css).toContain('var(--vscode-focusBorder)');
-		expect(css).toContain('var(--vscode-list-hoverBackground)');
+		expect(css).toContain('var(--vscode-input-background)');
+		expect(css).toContain('var(--vscode-dropdown-background)');
+	});
+
+	it('字号以 --vscode-font-size 为基准（随用户字号设置缩放，无裸 px 主字号）', () => {
+		const css = getBaseStyles();
+		expect(css).toContain('font-size: var(--vscode-font-size)');
+		expect(css).toContain('calc(var(--vscode-font-size) - 2px)');
+		expect(css).not.toMatch(/font-size: 1[0-9]px/);
 	});
 
 	it('getButtonClass 按变体拼出正确的 class 串', () => {


### PR DESCRIPTION
## 概述

对系统 UI 做全方位审计（Webview UI / 原生 API / 清单集成三路并行）后，基于最新版 VS Code（1.136，2026-09）最佳实践完成的系统性适配：**12 个提交、46+ 文件、+1500/−460**，涵盖 9 项缺陷修复、进度反馈/入门导览/批量操作/输入校验等新能力、控件全面令牌化与无障碍加固。

## 审计基线

- 最新稳定版 VS Code **1.136**（集成测试即在该版本真实宿主上全绿）；官方已废弃 Webview UI Toolkit（2025-01），推荐纯 `--vscode-*` CSS 变量方案——本项目路线正确，本 PR 补齐其执行深度。
- `engines.vscode` 维持 `^1.85`（审计确认所有待用 API ≤1.85，无需抬基线）。

## 修复的缺陷（Fixed）

| # | 缺陷 | 影响 |
|---|------|------|
| 1 | webview 回调内重复调用 `acquireVsCodeApi()` | Merge「保存→拒绝→取消」取消失效（第二次调用抛异常） |
| 2 | Commit 草稿随视图销毁丢失 | message/amend/signoff/skipHooks 全丢且模板重灌覆盖 |
| 3 | 深浅主题切换后 Graph 泳道色停留旧主题 | JS 快照无 MutationObserver 监听 |
| 4 | 分支树文件夹节点出现分支级菜单 | 11 处 `viewItem =~` 正则未锚定误匹配 `branchFolder` |
| 5 | CLI 通道失败不可诊断 | `execFile` 丢弃 stderr |
| 6 | 交互 rebase 的 reword 可能拉起新 VS Code 窗口 | `GIT_EDITOR` 未设 `ELECTRON_RUN_AS_NODE` |
| 7 | 窗口 reload 后 Rebase/Merge 面板空白 | 缺 `registerWebviewPanelSerializer` |
| 8 | git 扩展不可用时多视图报 "no tree view registered" | 缺空 provider 兜底 |
| 9 | Blame 注解悬浮换行折叠 / split 编辑器无注解 / 泄漏 | MarkdownString + 可见编辑器订阅 |

另有对抗性验证工作流确认并已修复的 2 项次生问题：草稿跨仓泄漏（切到无草稿仓库时旧仓 amend 标志残留并持久化污染）、`hyperGit.hasConflicts` 恒 false（vscode.git 的 unmerged 只在 `mergeChanges`，原 `getChanges()` 谓词不可达，Accept Ours/Theirs 在面板永久隐藏）。

## 新能力（Added）

- **长时操作进度反馈**：pull/push/fetch/merge/rebase/cherry-pick/reset/updateProject 全部 `withProgress`（默认标题栏非阻塞）；失败通知附 "Show Output" 直达 Console
- **入门导览**：`walkthroughs` 5 步导览 + 2 条无冲突默认键位（Alt+B Blame、Alt+G Graph 过滤）
- **Stash/Worktrees 多选批量操作**（降序 drop 防位移）、新建后视图定位、provider 失败 `TreeView.message` 内联呈现
- **分支/标签名即时校验**：`engine/ref/ref-name` 纯函数（check-ref-format UI 子集，9 组单测）挂接全部 8 处输入框
- **QuickPick**：提交选择器 hash 可搜（matchOn*）、Separator 分段、codicon 图标统一
- **键盘可达性**：Commit 文件列表方向键/Enter/Escape 导航、Rebase Alt+↑/↓ 键盘重排 + 确认层焦点圈禁

## 控件与主题（Changed）

- 滚动条/checkbox/下拉/阴影全面走主题令牌；字号以 `--vscode-font-size` calc 派生（随用户设置缩放）；高对比度主题下彩色胶囊改描边；Graph 行高/列宽常量单源化
- 文件状态点 `●` → **M/A/U/R/D/C 字母标记**（色盲可辨，对齐官方 SCM）；8 处 Unicode 字符图标 SVG 化
- 日志通道迁 `LogOutputChannel`（自动时间戳/级别，懒创建）；确认框多行正文迁 `MessageOptions.detail`；用户可见文案统一英文
- **清单治理**：`extensionKind: workspace`、`untrustedWorkspaces: unsupported`、11 项设置补 `scope`、5 个预留设置中性化（默认值清除个人化内容，**默认值变更**）、palette 补 when 限定
- 同步 IO 清理（Shelf 全量 `fs.promises`、worktree realpath 记忆化）

## 验证

- ✅ 420 单测通过（新增 `ref-name` 9 组、`menus-guard` 5 组守护测试）
- ✅ 集成测试在真实 **VS Code 1.136.2** 宿主全绿（单仓 8/8 + 多根 4/4）
- ✅ 四维对抗性验证工作流（webview 内联 JS 语法/XSS、host 正确性、清单一致性、回归风险）：确认 2 项真实问题均已修复并复验
- 每批次独立 commit（12 个），逐批 `compile + lint + test:unit`

## 明确不做（后续立项）

l10n、codicon 字体引入、webview 拆分打包、README/图片优化、engines 提升、CI 最低版本矩阵档、withProgress 真取消。

🤖 Generated with [Claude Code](https://claude.com/claude-code), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>