### PR TITLE
feat(UI): Commit 视图头部两行 UI 上移标题栏——Active Changelist 选择器与 List/Tree 切换;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Commit 视图头部两行 UI 上移 VS Code 标题栏（省两行竖直空间）**：① 「Active Changelist」下拉与 `⋯` 管理菜单合并为标题栏 Refresh 图标左侧的 `$(checklist)` 图标按钮——点击弹出 QuickPick：各列表带文件计数、当前活动项预选，分隔线后并入 New / Rename / Delete Changelist… 操作（默认列表不可改名/删除）；活动 changelist 名常驻视图副标题（标题「Commit」同行右侧）。② 文件列表 List ⇄ Tree 段控改为标题栏 `$(list-tree)`/`$(list-flat)` 互斥图标（交互同 Graph/Branches 切换范式），偏好移交 host `workspaceState` 按仓库持久化（`hyperGit.commit.dmode:<repo>`）——**原 webview state 中的旧 List/Tree 偏好一次性重置为默认 flat**（勾选集、目录折叠与提交草稿不受影响）。③ Select All 复选框吸顶于文件列表容器内首行（列表为空时随空态隐藏），原 `.cl-bar` 与 files-header 两行整体移除。
+
 ## [0.0.17] - 2026-09-09 — Log 提交详情常驻面板 · VS Code 1.136 最佳实践对齐 · 稳定性与体验修复
 
 自 v0.0.16 以来的积累（PR #115 / #116）。核心变更：**Log 提交详情由悬停浮层改为右侧常驻面板**（三区可拖拽分割线、窄视图自适应堆叠），并全面对齐 VS Code 1.136 控件 / 交互 / API 最佳实践（修复 9 项缺陷、Webview 控件全面主题化、能力声明与设置治理）；新增长时 git 操作进度反馈、入门导览与默认键位、Stash / Worktrees 批量操作、分支 / 标签名即时校验等体验增强。完整用户视角叙述见 [Release Note v0.0.17](./docs/releases/v0.0.17.md)。

--- a/docs/features/commit-view-consolidation.md
+++ b/docs/features/commit-view-consolidation.md
@@ -8,7 +8,7 @@
 |---|---|
 | 文件单击看 Diff | 文件行单击（勾选框除外）→ `commit/openFile` → 复用 `hyperGit.openDiff` |
 | 单文件右键菜单 | 文件行右键 → `commit/fileMenu` → 原生 `showQuickPick`：Open Diff / Move to Changelist… / Show History / Stage·Unstage Hunks… / Add to .gitignore / Discard Changes（复用既有命令，含 discard 确认框） |
-| Changelist 管理 | 头部 `<select>` 切换活动列表（`commit/setActive`）+ `⋯` 菜单（`commit/changelistMenu` → 新建 / 重命名 / 删除） |
+| Changelist 管理 | 标题栏 `$(checklist)` 图标（Refresh 左侧）→ `hyperGit.setActiveChangelist` QuickPick：各列表带文件计数、当前活动项 `picked` 预选，分隔线后并入 New / Rename / Delete…（默认列表不可改名删除）；活动列表名常驻 `view.description` 副标题（原头部 `<select>` + `⋯` 菜单行已上移，省一行竖直空间） |
 | Git 操作工具栏 | 标题栏（`view/title`）承接 refresh / push / pull / fetch / pushDialog / updateProject / createPatch / applyPatch；去掉与 webview 内 Commit·Commit&Push 按钮重复的两项 |
 | 活动栏未提交数角标 | 迁至 Commit `WebviewView.badge`（容器图标角标 = 各视图 badge 之和，总数不变） |
 
@@ -22,16 +22,16 @@
 
 ## 交互范围取舍
 
-Commit 视图文件区以**活动 Changelist** 为提交目标（勾选集即提交范围）；非活动 Changelist 通过头部下拉切换查看。相较旧树「同屏并列多 changelist」少了一处低频便利，换取窄侧栏下更聚焦的提交工作流。
+Commit 视图文件区以**活动 Changelist** 为提交目标（勾选集即提交范围）；非活动 Changelist 通过标题栏 `$(checklist)` 图标弹 QuickPick 切换，活动列表名常驻 `view.description` 副标题。相较旧树「同屏并列多 changelist」少了一处低频便利，换取窄侧栏下更聚焦的提交工作流。
 
 ## 实现
 
 - 视图与菜单：[`package.json`](../../package.json)（删 `hyperGit.changes` 视图 / viewsWelcome / 全部 `view == hyperGit.changes` 菜单；`view/title` 迁至 `view == hyperGit.commit`）。
-- 视图主体：[`adapter/webview/commit-webview.ts`](../../src/adapter/webview/commit-webview.ts)（groups/switcher/文件交互/菜单/角标/目录树）。
-- 命令：[`adapter/commands.ts`](../../src/adapter/commands.ts)（`resolveChange` + 签名重构）。
+- 视图主体：[`adapter/webview/commit-webview.ts`](../../src/adapter/webview/commit-webview.ts)（groups/文件交互/菜单/角标/目录树；changelist 切换与管理、List/Tree 切换已上移标题栏，mode 以 host 为事实源按仓库持久化）。
+- 命令：[`adapter/commands.ts`](../../src/adapter/commands.ts)（`resolveChange` + 签名重构；`setActiveChangelist` QuickPick 承载切换与管理）。
 - 装配：[`extension.ts`](../../src/extension.ts)（移除 tree/changesView，角标改由 `commitView.updateBadge`）。
-- 协议：[`shared/protocol.ts`](../../src/shared/protocol.ts)（`CommitChangelistItem`、`commit/openFile|fileMenu|setActive|changelistMenu`）。
+- 协议：[`shared/protocol.ts`](../../src/shared/protocol.ts)（`commit/openFile|fileMenu`；changelist 操作消息已随标题栏上移移除）。
 
 ## 验证
 
-`pnpm run check-types && pnpm run lint && pnpm run test:unit` 全绿；Extension Development Host（F5）：无 CHANGES 视图；Commit 顶部可切换/管理 changelist；文件单击开 Diff、右键出菜单（含 discard 确认）；标题栏 Git 动作可用；活动栏角标随未提交数增减；无 Git 仓库时降级不崩溃。
+`pnpm run check-types && pnpm run lint && pnpm run test:unit` 全绿；Extension Development Host（F5）：无 CHANGES 视图；标题栏 `$(checklist)` 图标可切换/管理 changelist、副标题显示活动列表名；文件单击开 Diff、右键出菜单（含 discard 确认）；标题栏 Git 动作可用；活动栏角标随未提交数增减；无 Git 仓库时降级不崩溃。

--- a/docs/features/file-list-group-by-directory.md
+++ b/docs/features/file-list-group-by-directory.md
@@ -29,14 +29,14 @@ flowchart LR
 | 建树路径 | 条目 `path`（仓库相对） | `CommitFileChange.path`（干净新路径，重命名归位到新目录） |
 | 复选框 | 有：叶子勾选 + **目录三态**级联；Select All 基于全量文件 | 无（只读浏览） |
 | 叶子单击 | 打开 Diff（`commit/openFile`） | 打开单文件 Diff（`log/openFile`，`data-path` 保持展示串不变） |
-| 偏好持久化 | `setState({mode, collapsed, checked})` | host `workspaceState`（`hyperGit.log.dmode:<repo>`）+ webview `dcollapsed` 按仓库记忆 |
-| 切换控件 | webview 内 List/Tree 段控 | Graph 标题栏 `$(list-tree)`/`$(list-flat)` 互斥图标（同 Branches 分组切换范式） |
+| 偏好持久化 | host `workspaceState`（`hyperGit.commit.dmode:<repo>`）+ webview `setState` 按仓库记 `collapsed`/`checked` | host `workspaceState`（`hyperGit.log.dmode:<repo>`）+ webview `dcollapsed` 按仓库记忆 |
+| 切换控件 | Commit 标题栏 `$(list-tree)`/`$(list-flat)` 互斥图标（context key `hyperGit.commit.tree`） | Graph 标题栏 `$(list-tree)`/`$(list-flat)` 互斥图标（同 Branches 分组切换范式） |
 
 ## 实现
 
 - 引擎：[`engine/tree/file-tree.ts`](../../src/engine/tree/file-tree.ts)（+ [`tests/unit/file-tree.test.ts`](../../tests/unit/file-tree.test.ts)，15 用例）。
 - 协议：[`shared/protocol.ts`](../../src/shared/protocol.ts)（`FileTreeNode`；`CommitViewState.tree`；`log/commitFiles` payload `tree`）。
-- 渲染：[`commit-webview.ts`](../../src/adapter/webview/commit-webview.ts)（List/Tree 段控、`renderFlat`/`renderTree`、`makeLeafRow`、目录三态 `updateDirStates`）、[`log-webview.ts`](../../src/adapter/webview/log-webview.ts)（`renderDetails` 分派、`renderDetailNode`；Log 侧切换控件为 Graph 标题栏 `hyperGit.log.detailTree/detailFlat` 命令图标，模式经 `log/detailMode` 定向下发免整图重拉）。
+- 渲染：[`commit-webview.ts`](../../src/adapter/webview/commit-webview.ts)（`renderFlat`/`renderTree`、`makeLeafRow`、目录三态 `updateDirStates`；切换控件为 Commit 标题栏 `hyperGit.commit.detailTree/detailFlat` 命令图标，mode 以 host 为事实源随 `state` 整态下发）、[`log-webview.ts`](../../src/adapter/webview/log-webview.ts)（`renderDetails` 分派、`renderDetailNode`；Log 侧切换控件为 Graph 标题栏 `hyperGit.log.detailTree/detailFlat` 命令图标，模式经 `log/detailMode` 定向下发免整图重拉）。
 
 ## 验证
 

--- a/package.json
+++ b/package.json
@@ -204,8 +204,9 @@
 			},
 			{
 				"command": "hyperGit.setActiveChangelist",
-				"title": "Set Active Changelist",
-				"category": "Hyper Git"
+				"title": "Set Active Changelist…",
+				"category": "Hyper Git",
+				"icon": "$(checklist)"
 			},
 			{
 				"command": "hyperGit.renameChangelist",
@@ -268,6 +269,18 @@
 			},
 			{
 				"command": "hyperGit.log.detailFlat",
+				"title": "Show Changed Files as Flat List",
+				"category": "Hyper Git",
+				"icon": "$(list-flat)"
+			},
+			{
+				"command": "hyperGit.commit.detailTree",
+				"title": "Group Changed Files by Directory",
+				"category": "Hyper Git",
+				"icon": "$(list-tree)"
+			},
+			{
+				"command": "hyperGit.commit.detailFlat",
 				"title": "Show Changed Files as Flat List",
 				"category": "Hyper Git",
 				"icon": "$(list-flat)"
@@ -817,6 +830,21 @@
 			],
 			"view/title": [
 				{
+					"command": "hyperGit.setActiveChangelist",
+					"when": "view == hyperGit.commit",
+					"group": "navigation@0.5"
+				},
+				{
+					"command": "hyperGit.commit.detailTree",
+					"when": "view == hyperGit.commit && !hyperGit.commit.tree",
+					"group": "navigation@0.75"
+				},
+				{
+					"command": "hyperGit.commit.detailFlat",
+					"when": "view == hyperGit.commit && hyperGit.commit.tree",
+					"group": "navigation@0.75"
+				},
+				{
 					"command": "hyperGit.refresh",
 					"when": "view == hyperGit.commit",
 					"group": "navigation@1"
@@ -1153,7 +1181,7 @@
 				},
 				{
 					"command": "hyperGit.setActiveChangelist",
-					"when": "false"
+					"when": "view == hyperGit.commit"
 				},
 				{
 					"command": "hyperGit.renameChangelist",
@@ -1374,6 +1402,14 @@
 				{
 					"command": "hyperGit.log.detailFlat",
 					"when": "view == hyperGit.log"
+				},
+				{
+					"command": "hyperGit.commit.detailTree",
+					"when": "view == hyperGit.commit"
+				},
+				{
+					"command": "hyperGit.commit.detailFlat",
+					"when": "view == hyperGit.commit"
 				},
 				{
 					"command": "hyperGit.acceptOurs",

--- a/src/adapter/commands.ts
+++ b/src/adapter/commands.ts
@@ -21,7 +21,8 @@ function asId(arg: unknown): string | undefined {
  * 注册 Changes / Commit 相关命令（M1；原 Changes 树移除后由 Commit webview 复用）。
  *
  * 文件级命令统一接受 `ChangeItem | 路径字符串`：webview 传路径，host 经 {@link resolveChange}
- * 回落到 `service.getChanges()` 解析为 ChangeItem（单一事实源）。视图刷新由 registry/service
+ * 回落到 `service.getChanges()` 解析为 ChangeItem（单一事实源）。changelist 切换与管理由
+ * 标题栏 $(checklist) 图标进入 setActiveChangelist QuickPick 承载。视图刷新由 registry/service
  * 的 onDidChange → extension.refreshAll → commitView.refresh() 驱动，命令内不再直接刷新视图。
  */
 export function registerChangesCommands(
@@ -57,10 +58,48 @@ export function registerChangesCommands(
 	);
 
 	subs.push(
-		vscode.commands.registerCommand('hyperGit.setActiveChangelist', (arg: unknown) => {
+		vscode.commands.registerCommand('hyperGit.setActiveChangelist', async (arg?: unknown) => {
+			// 带参 = 程序化切换；无参 = QuickPick（标题栏 $(checklist) 图标与命令面板共用入口）。
 			const id = asId(arg);
 			if (id) {
 				registry.setActive(id);
+				return;
+			}
+			const active = registry.activeChangelistId;
+			// 计数取 getGroups（含空列表，未显式分配项归活动列表——见 engine/changelist/grouper）。
+			const groups = registry.getGroups(service.getChanges(), (c) => c.relativePath);
+			type SetActiveItem =
+				| { label: string; description: string; picked: boolean; setId: string }
+				| { label: string; kind: vscode.QuickPickItemKind }
+				| { label: string; op: 'new' | 'rename' | 'delete'; targetId?: string };
+			const items: SetActiveItem[] = groups.map((g) => ({
+				label: g.name,
+				description: `${g.items.length} file${g.items.length === 1 ? '' : 's'}`,
+				picked: g.id === active, // 预选当前活动项（对齐 selectRepository 的 picked 范式）
+				setId: g.id,
+			}));
+			// 分隔线后并入原 webview「⋯」菜单管理操作（default 不可改名/删除，镜像原 handleChangelistMenu 语义）。
+			items.push({ label: 'Actions', kind: vscode.QuickPickItemKind.Separator });
+			items.push({ label: '$(add) New Changelist…', op: 'new' });
+			const def = active !== 'default' ? registry.getDef(active) : undefined;
+			if (def) {
+				items.push({ label: `$(edit) Rename "${def.name}"…`, op: 'rename', targetId: active });
+				items.push({ label: `$(trash) Delete "${def.name}"…`, op: 'delete', targetId: active });
+			}
+			const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Select Active Changelist' });
+			if (!pick) {
+				return;
+			}
+			if ('setId' in pick) {
+				registry.setActive(pick.setId); // 视图刷新经 registry.onDidChange → refreshAll 驱动
+			} else if ('op' in pick) {
+				if (pick.op === 'new') {
+					await vscode.commands.executeCommand('hyperGit.newChangelist');
+				} else if (pick.op === 'rename') {
+					await vscode.commands.executeCommand('hyperGit.renameChangelist', pick.targetId);
+				} else {
+					await vscode.commands.executeCommand('hyperGit.deleteChangelist', pick.targetId);
+				}
 			}
 		}),
 	);

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -272,11 +272,11 @@ details.advanced[open] summary { margin-bottom: 4px; }
 </style>
 </head>
 <body>
-<div class="files" id="files" tabindex="0">
-  <div class="files-selectall" id="files-selectall" style="display:none">
+<div class="files" id="files" tabindex="0" role="tree" aria-label="Changed files">
+  <div class="files-selectall" id="files-selectall" role="presentation" style="display:none">
     <label class="opt" style="margin:0"><input type="checkbox" id="select-all"> Select All</label>
   </div>
-  <div id="files-rows" role="tree" aria-label="Changed files"></div>
+  <div id="files-rows" role="presentation"></div>
 </div>
 <textarea id="message" class="hg-input" rows="4" placeholder="Commit message (Conventional Commits: type(scope): description)" spellcheck="false"></textarea>
 <div id="validation" class="validation" role="status" aria-live="polite"></div>

--- a/src/adapter/webview/commit-webview.ts
+++ b/src/adapter/webview/commit-webview.ts
@@ -6,35 +6,88 @@ import type { CommitRequest } from '../commit/commit-service';
 import type { ChangelistRegistry } from '../changelist-registry';
 import type { ChangeItem, GitRepositoryService } from '../git-repository-service';
 import type {
-	CommitChangelistItem,
 	CommitFileItem,
 	CommitViewState,
 	HostToWebviewMessage,
 	WebviewToHostMessage,
 } from '../../shared/protocol';
 import type { CommitService } from '../commit/commit-service';
-import { getBaseStyles, ICON_CHEVRON_DOWN, ICON_ELLIPSIS } from './shared-styles';
+import { getBaseStyles, ICON_CHEVRON_DOWN } from './shared-styles';
 import { getNonce } from './nonce';
 
 /**
  * Commit 提交窗口（WebviewView，自绘提交面板）。
  *
- * 承载活动 changelist 文件列表（平铺 / 目录树两态可切）+ 文件单击看 diff + 单文件右键操作 +
- * changelist 切换与管理（由原 Changes 视图平移而来）+ 多行 Commit Message 编辑器 +
- * Amend/sign-off/skip-hooks 选项 + Commit/Commit and Push 按钮 + Conventional Commits 实时校验 +
- * 最近消息复用。选中态由 webview 端管理（host 不回写，避免覆盖用户操作）。
+ * 承载活动 changelist 文件列表（平铺 / 目录树两态，切换上移标题栏互斥图标）+ 文件单击看 diff +
+ * 单文件右键操作 + 多行 Commit Message 编辑器 + Amend/sign-off/skip-hooks 选项 +
+ * Commit/Commit and Push 按钮 + Conventional Commits 实时校验 + 最近消息复用。
+ * changelist 切换与管理（New/Rename/Delete）由标题栏 $(checklist) 图标 → setActiveChangelist
+ * QuickPick 承载，活动列表名常驻 view.description 副标题；Select All 吸顶于文件列表容器内首行。
+ * 选中态由 webview 端管理（host 不回写，避免覆盖用户操作）。
  * 注：活动栏未提交数角标已迁至隐藏的 hyperGit.changesBadge TreeView 承载（见 extension.ts）。
  */
-export class CommitWebviewProvider implements vscode.WebviewViewProvider {
+export class CommitWebviewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
 	public static readonly viewType = 'hyperGit.commit';
 	private view?: vscode.WebviewView;
 	private currentMessage = '';
+	/** 文件列表展示模式（List/Tree，标题栏图标切换）：host 为事实源，随 state 整态下发。 */
+	private detailMode: 'flat' | 'tree' = 'flat';
+	private readonly disposables: vscode.Disposable[] = [];
+
+	/** List/Tree 偏好按仓库持久化 key（issue #107 同 log.dmode 范式；第三视图复用时提炼共享 helper）。 */
+	private static dmodeKey(root: string): string {
+		return `hyperGit.commit.dmode:${root}`;
+	}
+	/** context key 同步（标题栏互斥按钮显隐由 when 子句驱动）。 */
+	private static setCtx(key: string, value: string | boolean): void {
+		void vscode.commands.executeCommand('setContext', key, value);
+	}
 
 	constructor(
 		private readonly service: GitRepositoryService,
 		private readonly registry: ChangelistRegistry,
 		private readonly commit: CommitService,
-	) {}
+		private readonly workspaceState: vscode.Memento,
+	) {
+		// 激活即恢复当前仓库的 List/Tree 记忆并同步 context key（标题栏控件先于视图解析渲染）；
+		// 活跃仓库切换（issue #107）：恢复该仓库的记忆值（无记忆回退 'flat'），
+		// 文件列表刷新由 extension 的 onDidChange → refreshAll 驱动。
+		this.loadRepoScopedPrefs();
+		this.disposables.push(
+			service.onDidChangeRepository(() => {
+				this.loadRepoScopedPrefs();
+			}),
+		);
+	}
+
+	dispose(): void {
+		for (const d of this.disposables) {
+			d.dispose();
+		}
+		this.disposables.length = 0;
+	}
+
+	/** 装载当前仓库的 List/Tree 偏好（memento → 内存 + context key）。 */
+	private loadRepoScopedPrefs(): void {
+		const root = this.service.repoRoot;
+		this.detailMode =
+			(root ? this.workspaceState.get<'flat' | 'tree'>(CommitWebviewProvider.dmodeKey(root)) : undefined) ?? 'flat';
+		CommitWebviewProvider.setCtx('hyperGit.commit.tree', this.detailMode === 'tree');
+	}
+
+	/** 标题栏 List/Tree 互斥图标切换（同 Graph/Branches 范式）：pushState 全同步且幂等，整态重发即达。 */
+	setDetailMode(mode: 'flat' | 'tree'): void {
+		if (this.detailMode === mode) {
+			return;
+		}
+		const root = this.service.repoRoot;
+		if (root) {
+			void this.workspaceState.update(CommitWebviewProvider.dmodeKey(root), mode);
+		}
+		this.detailMode = mode;
+		CommitWebviewProvider.setCtx('hyperGit.commit.tree', mode === 'tree');
+		this.pushState();
+	}
 
 	resolveWebviewView(view: vscode.WebviewView): void {
 		this.view = view;
@@ -74,12 +127,6 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 			case 'commit/fileMenu':
 				void this.handleFileMenu(msg.payload.path);
 				break;
-			case 'commit/setActive':
-				void vscode.commands.executeCommand('hyperGit.setActiveChangelist', msg.payload.id);
-				break;
-			case 'commit/changelistMenu':
-				void this.handleChangelistMenu(msg.payload.id);
-				break;
 		}
 	}
 
@@ -93,7 +140,7 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 		if (!change) {
 			return;
 		}
-		// QuickPick label 支持 $(codicon) 内联图标（与 changelist 菜单对齐）。
+		// QuickPick label 支持 $(codicon) 内联图标（与 changelist 标题栏 QuickPick 对齐）。
 		const actions: ReadonlyArray<{ readonly label: string; readonly command: string }> = [
 			{ label: '$(diff) Open Diff', command: 'hyperGit.openDiff' },
 			{ label: '$(symbol-enum) Move to Changelist…', command: 'hyperGit.moveChangelist' },
@@ -108,30 +155,6 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 			return;
 		}
 		await vscode.commands.executeCommand(pick.command, change);
-	}
-
-	/** changelist 头部 ⋯ 菜单：新建 / 重命名 / 删除（默认列表不可改名删除，复用既有命令）。 */
-	private async handleChangelistMenu(id: string): Promise<void> {
-		const def = this.registry.getDef(id);
-		const canModify = Boolean(def) && id !== 'default';
-		const items: Array<{ label: string; op: 'new' | 'rename' | 'delete' }> = [
-			{ label: '$(add) New Changelist…', op: 'new' },
-		];
-		if (canModify && def) {
-			items.push({ label: `$(edit) Rename "${def.name}"…`, op: 'rename' });
-			items.push({ label: `$(trash) Delete "${def.name}"…`, op: 'delete' });
-		}
-		const pick = await vscode.window.showQuickPick(items, { placeHolder: 'Changelist actions' });
-		if (!pick) {
-			return;
-		}
-		if (pick.op === 'new') {
-			await vscode.commands.executeCommand('hyperGit.newChangelist');
-		} else if (pick.op === 'rename') {
-			await vscode.commands.executeCommand('hyperGit.renameChangelist', id);
-		} else {
-			await vscode.commands.executeCommand('hyperGit.deleteChangelist', id);
-		}
 	}
 
 	private sendValidation(): void {
@@ -169,21 +192,20 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 		const changes = this.service.getChanges();
 		const groups = this.registry.getGroups(changes, (c) => c.relativePath);
 		const activeId = this.registry.activeChangelistId;
-		const changelists: CommitChangelistItem[] = groups.map((g) => ({ id: g.id, name: g.name, count: g.items.length }));
 		const activeGroup = groups.find((g) => g.id === activeId) ?? groups.find((g) => g.active) ?? groups[0];
 		const files = (activeGroup?.items ?? []).map((c) => this.toFileItem(c));
 		const state: CommitViewState = {
 			template: this.commit.getTemplate(),
 			recentMessages: this.commit.getRecentMessages(),
-			activeChangelistName: this.registry.getDef(activeId)?.name ?? 'Default',
-			activeChangelistId: activeId,
-			changelists,
+			mode: this.detailMode,
 			files,
 			tree: buildFileTree(files.map((f) => f.path)),
 			conventionalEnabled: this.commit.conventionalEnabled(),
 			busy: false,
 			repoRoot: this.service.repoRoot ?? '',
 		};
+		// 标题栏副标题 = 活动 changelist 名（原 webview 头部切换行上移，省一行竖直空间）。
+		this.view.description = this.registry.getDef(activeId)?.name ?? 'Default';
 		this.post({ type: 'state', payload: state });
 		this.sendValidation();
 	}
@@ -204,14 +226,9 @@ export class CommitWebviewProvider implements vscode.WebviewViewProvider {
 <style>
 ${getBaseStyles()}
 body { margin: 0; padding: var(--hg-space-2); font-family: var(--vscode-font-family); color: var(--vscode-foreground); font-size: var(--vscode-font-size); background: var(--vscode-sideBar-background); }
-.cl-bar { display: flex; align-items: center; gap: 6px; margin-bottom: var(--hg-space-1); }
-.cl-bar .cl-label { flex: 0 0 auto; font-weight: 600; }
-#cl-switch { flex: 1 1 auto; min-width: 0; } /* 视觉走共享 .hg-select（dropdown token 单一事实源） */
-.cl-menu-btn { flex: 0 0 auto; padding: 1px 7px; }
-.seg { display: inline-flex; border: 1px solid var(--vscode-input-border, transparent); border-radius: 3px; overflow: hidden; }
-.seg button { background: transparent; color: var(--vscode-foreground); border: none; padding: 2px 8px; font-size: calc(var(--vscode-font-size) - 2px); cursor: pointer; opacity: 0.7; }
-.seg button.active { background: var(--vscode-button-background); color: var(--vscode-button-foreground); opacity: 1; }
-.seg button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
+/* Select All 吸顶行（List/Tree 切换上移标题栏后由 files-header 行迁入列表容器）：背景必须不透明（防行内容透出）。 */
+.files-selectall { position: sticky; top: 0; z-index: 1; background: var(--vscode-sideBar-background); border-bottom: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.3)); padding: 1px 6px; }
+.file, .tree-dir { scroll-margin-top: 22px; } /* 键盘导航 scrollIntoView 补偿：防止首行被吸顶行遮挡 */
 .files { max-height: 260px; overflow-y: auto; border: 1px solid var(--vscode-editorWidget-border, rgba(128,128,128,.3)); border-radius: var(--hg-radius-control); margin-bottom: var(--hg-space-2); }
 .files:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
 .file.kb-focus, .tree-dir.kb-focus { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
@@ -239,7 +256,6 @@ textarea { width: 100%; box-sizing: border-box; resize: vertical; }
 .opt { display: block; font-size: calc(var(--vscode-font-size) - 1px); margin: 3px 2px; }
 .buttons { display: flex; gap: 6px; margin-top: var(--hg-space-2); }
 .buttons .hg-btn { flex: 1; }
-.files-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; min-height: 18px; padding: 0 6px; color: var(--vscode-descriptionForeground); }
 .files-empty { padding: 14px 8px; text-align: center; color: var(--vscode-descriptionForeground); font-size: calc(var(--vscode-font-size) - 1px); }
 .spinner { display: inline-block; width: 12px; height: 12px; border: 1.5px solid currentColor; border-top-color: transparent; border-radius: 50%; animation: hg-spin 0.8s linear infinite; vertical-align: -2px; margin-right: 5px; }
 @keyframes hg-spin { to { transform: rotate(360deg); } }
@@ -256,19 +272,12 @@ details.advanced[open] summary { margin-bottom: 4px; }
 </style>
 </head>
 <body>
-<div class="cl-bar">
-  <span class="cl-label">Active Changelist:</span>
-  <select id="cl-switch" class="hg-select" title="Switch active changelist"></select>
-  <button id="cl-menu" class="hg-btn hg-btn--secondary hg-btn--sm cl-menu-btn" title="Changelist actions" aria-label="Changelist actions">${ICON_ELLIPSIS}</button>
+<div class="files" id="files" tabindex="0">
+  <div class="files-selectall" id="files-selectall" style="display:none">
+    <label class="opt" style="margin:0"><input type="checkbox" id="select-all"> Select All</label>
+  </div>
+  <div id="files-rows" role="tree" aria-label="Changed files"></div>
 </div>
-<div class="files-header" id="files-header" style="display:none">
-  <label class="opt" style="margin:0"><input type="checkbox" id="select-all"> Select All</label>
-  <span class="seg" role="group" aria-label="File view mode">
-    <button id="mode-flat" class="active" aria-pressed="true" title="Flat list">List</button>
-    <button id="mode-tree" aria-pressed="false" title="Group by directory">Tree</button>
-  </span>
-</div>
-<div class="files" id="files" tabindex="0" role="tree" aria-label="Changed files"></div>
 <textarea id="message" class="hg-input" rows="4" placeholder="Commit message (Conventional Commits: type(scope): description)" spellcheck="false"></textarea>
 <div id="validation" class="validation" role="status" aria-live="polite"></div>
 <div class="recent" id="recent"></div>
@@ -286,20 +295,21 @@ details.advanced[open] summary { margin-bottom: 4px; }
 
 <script nonce="${nonce}">
 const vscode = acquireVsCodeApi();
-// ── 勾选集/视图模式/提交草稿按仓库分区（v3，issue #107）：勾选是相对路径集合，跨仓库本就错位；
+// ── 勾选集/折叠集/提交草稿按仓库分区（v3，issue #107）：勾选是相对路径集合，跨仓库本就错位；
 // 切换仓库换装载互不串扰；v3 起 draft（message + amend/signoff/skipHooks）一并入 state——
 // 视图隐藏销毁 / 窗口 reload 后草稿可恢复（对齐内置 SCM 输入框草稿语义），提交成功即清空。
-// 旧版 state（v2 byRepo / v1 平铺）无感升级，draft 缺省为空。──
+// 旧版 state（v2 byRepo / v1 平铺）无感升级，draft 缺省为空；
+// mode 自标题栏迁移（host workspaceState 持久化）后废弃，webview 不再读写。──
 const persistedRaw = vscode.getState() || {};
 let persistedRepo = '';
 let persistedByRepo = {};
 if ((persistedRaw.v === 2 || persistedRaw.v === 3) && persistedRaw.byRepo) {
   persistedByRepo = persistedRaw.byRepo;
-} else if (persistedRaw.checked || persistedRaw.mode || persistedRaw.collapsed) {
-  persistedByRepo = { '': { checked: persistedRaw.checked, mode: persistedRaw.mode, collapsed: persistedRaw.collapsed } };
+} else if (persistedRaw.checked || persistedRaw.collapsed) {
+  persistedByRepo = { '': { checked: persistedRaw.checked, collapsed: persistedRaw.collapsed } };
 }
 let checked = new Set();
-let mode = 'flat';
+let mode = 'flat'; // 渲染模式：host 经 state 下发（标题栏 List/Tree 图标切换），webview 不再持久化
 let collapsed = new Set();
 let draft = null; // 当前仓库的草稿快照（loadPersistedFor 装载；仅 webview 重建/切仓库时回灌 DOM）
 let stateV3Written = false; // 本会话是否已落盘 v3 state：true 后 '' 兜底关闭（见 loadPersistedFor）
@@ -312,7 +322,6 @@ function loadPersistedFor(repoRoot) {
   const fallback = persistedRaw.v === 3 || stateV3Written ? undefined : persistedByRepo[''];
   const s = persistedByRepo[repoRoot] || fallback || {};
   checked = new Set(s.checked || []);
-  mode = s.mode === 'tree' ? 'tree' : 'flat';
   collapsed = new Set(s.collapsed || []);
   draft = s.draft || null;
 }
@@ -320,7 +329,6 @@ function loadPersistedFor(repoRoot) {
 function saveState() {
   persistedByRepo[persistedRepo] = {
     checked: Array.from(checked),
-    mode: mode,
     collapsed: Array.from(collapsed),
     draft: { message: msgEl.value, amend: amendEl.checked, signoff: signoffEl.checked, skipHooks: skipHooksEl.checked }
   };
@@ -346,11 +354,8 @@ const signoffEl = document.getElementById('signoff');
 const skipHooksEl = document.getElementById('skipHooks');
 const toastEl = document.getElementById('toast');
 const selectAllEl = document.getElementById('select-all');
-const filesHeaderEl = document.getElementById('files-header');
-const clSwitchEl = document.getElementById('cl-switch');
-const clMenuEl = document.getElementById('cl-menu');
-const modeFlatEl = document.getElementById('mode-flat');
-const modeTreeEl = document.getElementById('mode-tree');
+const filesSelectAllEl = document.getElementById('files-selectall');
+const filesRowsEl = document.getElementById('files-rows');
 
 let msgTimer = null;
 msgEl.addEventListener('input', function () {
@@ -455,13 +460,13 @@ function makeLeafRow(f, depth) {
 function renderFlat(files) {
   const frag = document.createDocumentFragment();
   files.forEach(function (f) { frag.appendChild(makeLeafRow(f, 0)); });
-  filesEl.appendChild(frag);
+  filesRowsEl.appendChild(frag);
 }
 
 function renderTree(tree, files) {
   const frag = document.createDocumentFragment();
   tree.forEach(function (n) { renderNode(n, 0, frag, files); });
-  filesEl.appendChild(frag);
+  filesRowsEl.appendChild(frag);
   updateDirStates();
 }
 
@@ -533,13 +538,13 @@ function toggleCollapse(p) {
 
 function renderList() {
   kbIdx = -1;
-  filesEl.innerHTML = '';
+  filesRowsEl.innerHTML = '';
   if (!curFiles || curFiles.length === 0) {
-    filesHeaderEl.style.display = 'none';
-    filesEl.innerHTML = EMPTY_HTML;
+    filesSelectAllEl.style.display = 'none';
+    filesRowsEl.innerHTML = EMPTY_HTML;
     return;
   }
-  filesHeaderEl.style.display = '';
+  filesSelectAllEl.style.display = '';
   if (mode === 'tree') { renderTree(curTree, curFiles); } else { renderFlat(curFiles); }
   syncSelectAll();
 }
@@ -577,35 +582,12 @@ filesEl.addEventListener('keydown', function (e) {
 });
 filesEl.addEventListener('focus', function () { if (kbIdx < 0) { kbApply(0); } });
 
-function updateModeButtons() {
-  modeFlatEl.classList.toggle('active', mode === 'flat');
-  modeTreeEl.classList.toggle('active', mode === 'tree');
-  modeFlatEl.setAttribute('aria-pressed', String(mode === 'flat'));
-  modeTreeEl.setAttribute('aria-pressed', String(mode === 'tree'));
-}
-function setMode(m) { if (mode === m) return; mode = m; saveState(); updateModeButtons(); renderList(); }
-modeFlatEl.addEventListener('click', function () { setMode('flat'); });
-modeTreeEl.addEventListener('click', function () { setMode('tree'); });
-
 selectAllEl.addEventListener('change', function () {
   const want = selectAllEl.checked;
   curFiles.forEach(function (f) { if (want) checked.add(f.path); else checked.delete(f.path); });
   filesEl.querySelectorAll('.file-cb').forEach(function (cb) { cb.checked = want; });
   saveState(); updateDirStates();
 });
-
-function renderChangelists(list, activeId) {
-  clSwitchEl.innerHTML = '';
-  (list || []).forEach(function (c) {
-    const opt = document.createElement('option');
-    opt.value = c.id;
-    opt.textContent = c.name + ' (' + c.count + ')';
-    if (c.id === activeId) opt.selected = true;
-    clSwitchEl.appendChild(opt);
-  });
-}
-clSwitchEl.addEventListener('change', function () { vscode.postMessage({ type: 'commit/setActive', payload: { id: clSwitchEl.value } }); });
-clMenuEl.addEventListener('click', function () { vscode.postMessage({ type: 'commit/changelistMenu', payload: { id: clSwitchEl.value } }); });
 
 function renderRecent(messages) {
   recentEl.innerHTML = '';
@@ -674,10 +656,9 @@ window.addEventListener('message', function (e) {
     draftRestored = true;
     curFiles = p.files || [];
     curTree = p.tree || [];
+    mode = p.mode === 'tree' ? 'tree' : 'flat';
     reconcileChecked(curFiles);
     pruneCollapsed(curTree);
-    renderChangelists(p.changelists, p.activeChangelistId);
-    updateModeButtons();
     renderList();
     renderRecent(p.recentMessages);
     conventionalEnabled = p.conventionalEnabled;

--- a/src/adapter/webview/shared-styles.ts
+++ b/src/adapter/webview/shared-styles.ts
@@ -32,9 +32,6 @@ export const ICON_CHEVRON_DOWN =
 /** 11px 关闭 X。 */
 export const ICON_CLOSE =
 	'<svg width="11" height="11" viewBox="0 0 16 16" aria-hidden="true"><path fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" d="M4 4l8 8M12 4l-8 8"/></svg>';
-/** 12px 水平省略号（⋯ 菜单）。 */
-export const ICON_ELLIPSIS =
-	'<svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><circle cx="3" cy="8" r="1.4"/><circle cx="8" cy="8" r="1.4"/><circle cx="13" cy="8" r="1.4"/></svg>';
 
 /**
  * 基础样式：`:root` Token + 通用组件类 + 全局控件基线 + 统一交互态。

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ export async function activate(
 		grouper: new NullChangelistGrouper(),
 		conflict: new NullConflictResolver(),
 	});
-	const commitView = new CommitWebviewProvider(service, registry, commit);
+	const commitView = new CommitWebviewProvider(service, registry, commit, context.workspaceState);
 	const logTree = new LogWebviewProvider(service, ciService, context.workspaceState);
 	const branchesTree = new BranchesTreeProvider(
 		service,
@@ -196,6 +196,7 @@ export async function activate(
 		favorites,
 		commit,
 		ciService,
+		commitView,
 		logTree,
 		branchesTree,
 		stashTree,
@@ -238,6 +239,10 @@ export async function activate(
 		vscode.commands.registerCommand('hyperGit.log.scopeCheckpointer', () => logTree.setScope('checkpointer')),
 		vscode.commands.registerCommand('hyperGit.log.detailTree', () => logTree.setDetailMode('tree')),
 		vscode.commands.registerCommand('hyperGit.log.detailFlat', () => logTree.setDetailMode('flat')),
+		// Commit 标题栏 List/Tree 互斥图标切换（镜像 Graph 范式，context key hyperGit.commit.tree 驱动显隐；
+		// commitView 的 onDidChangeRepository 订阅先于 refreshAll 注册，切库时 dmode 重载先于视图刷新）。
+		vscode.commands.registerCommand('hyperGit.commit.detailTree', () => commitView.setDetailMode('tree')),
+		vscode.commands.registerCommand('hyperGit.commit.detailFlat', () => commitView.setDetailMode('flat')),
 		vscode.commands.registerCommand('hyperGit.showConsole', () => showGitConsole()),
 		vscode.commands.registerCommand('hyperGit.startRebase', () => RebaseWebview.open(service)),
 		vscode.languages.registerCodeLensProvider({ scheme: 'file' }, inlineLens),

--- a/src/shared/protocol.ts
+++ b/src/shared/protocol.ts
@@ -39,27 +39,18 @@ export interface FileTreeNode {
 	readonly children?: readonly FileTreeNode[]; // 仅目录
 }
 
-/** Commit 头部切换下拉的 changelist 条目（含文件计数，空列表也在内以便切换）。 */
-export interface CommitChangelistItem {
-	readonly id: string;
-	readonly name: string;
-	readonly count: number;
-}
-
 export interface CommitViewState {
 	readonly template: string;
 	readonly recentMessages: readonly string[];
-	readonly activeChangelistName: string;
-	readonly activeChangelistId: string;
-	/** 全部 changelist（含空列表，供头部切换下拉 / 展示计数）。 */
-	readonly changelists: readonly CommitChangelistItem[];
+	/** 文件列表展示模式（host 为事实源，标题栏 List/Tree 图标切换；镜像 LogGraphState.dmode）。 */
+	readonly mode: 'flat' | 'tree';
 	/** 活动 changelist 的文件（提交目标；平铺形态直接渲染）。 */
 	readonly files: readonly CommitFileItem[];
 	/** 活动 changelist 文件的目录树（host 侧构建，供 Group By Directory 形态渲染）。 */
 	readonly tree: readonly FileTreeNode[];
 	readonly conventionalEnabled: boolean;
 	readonly busy: boolean;
-	/** 当前活跃仓库根（issue #107）：webview 勾选集/视图模式按仓库分区记忆。 */
+	/** 当前活跃仓库根（issue #107）：webview 勾选集/折叠集按仓库分区记忆（mode 已上移 host）。 */
 	readonly repoRoot: string;
 }
 
@@ -84,11 +75,10 @@ export type WebviewToHostMessage =
 			readonly push: boolean;
 		};
 	}
-	// ── 由旧 Changes 树平移而来的文件 / changelist 操作（webview 右键/点击 → host 复用既有命令）── //
+	// ── 由旧 Changes 树平移而来的文件操作（webview 点击/右键 → host 复用既有命令）；
+	// changelist 切换与管理已上移标题栏（hyperGit.setActiveChangelist QuickPick）── //
 	| { readonly type: 'commit/openFile'; readonly payload: { readonly path: string } }
-	| { readonly type: 'commit/fileMenu'; readonly payload: { readonly path: string } }
-	| { readonly type: 'commit/setActive'; readonly payload: { readonly id: string } }
-	| { readonly type: 'commit/changelistMenu'; readonly payload: { readonly id: string } };
+	| { readonly type: 'commit/fileMenu'; readonly payload: { readonly path: string } };
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Log Graph 视图（hyperGit.log，Webview）↔ Extension Host 消息契约。

--- a/tests/suite/extension.test.js
+++ b/tests/suite/extension.test.js
@@ -20,6 +20,8 @@ suite('扩展冒烟测试', function () {
 			'hyperGit.refresh',
 			'hyperGit.newChangelist',
 			'hyperGit.setActiveChangelist',
+			'hyperGit.commit.detailTree',
+			'hyperGit.commit.detailFlat',
 			'hyperGit.renameChangelist',
 			'hyperGit.deleteChangelist',
 			'hyperGit.moveChangelist',

--- a/tests/unit/commit-titlebar.test.ts
+++ b/tests/unit/commit-titlebar.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Commit 视图标题栏控件护栏：changelist 选择（$(checklist) 图标 → QuickPick）与
+ * List/Tree 互斥图标（context key hyperGit.commit.tree 驱动显隐）纯由 package.json
+ * 贡献点声明，一旦拼写漂移（context key 名、`!` 互斥、槽位排序、palette when），
+ * 标题栏按钮即静默消失或常驻双显。此处锁定声明基线，风格对齐 views-layout / menus-guard。
+ */
+
+interface CommandDef {
+	command: string;
+	title?: string;
+	icon?: string;
+}
+interface MenuEntry {
+	command?: string;
+	when?: string;
+	group?: string;
+}
+interface PackageJson {
+	contributes: {
+		commands: CommandDef[];
+		menus: { 'view/title': MenuEntry[]; commandPalette: MenuEntry[] };
+	};
+}
+
+const pkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8')) as PackageJson;
+const commandById = new Map(pkg.contributes.commands.map((c) => [c.command, c]));
+const titleEntries = pkg.contributes.menus['view/title'];
+const paletteEntries = pkg.contributes.menus.commandPalette;
+
+describe('commit-titlebar（Commit 视图标题栏控件声明护栏）', () => {
+	it('三个命令定义齐备：changelist 选择器带 … 与 $(checklist)，List/Tree 图标与 Graph 版一致', () => {
+		expect(commandById.get('hyperGit.setActiveChangelist')).toMatchObject({
+			title: 'Set Active Changelist…',
+			icon: '$(checklist)',
+		});
+		expect(commandById.get('hyperGit.commit.detailTree')).toMatchObject({
+			title: 'Group Changed Files by Directory',
+			icon: '$(list-tree)',
+		});
+		expect(commandById.get('hyperGit.commit.detailFlat')).toMatchObject({
+			title: 'Show Changed Files as Flat List',
+			icon: '$(list-flat)',
+		});
+	});
+
+	it('view/title 挂载于 Refresh 左侧且 List/Tree 以 hyperGit.commit.tree 互斥', () => {
+		const pick = (command: string): MenuEntry => {
+			const hit = titleEntries.find(
+				(e) => e.command === command && (e.when ?? '').includes('hyperGit.commit'),
+			);
+			expect(hit, `view/title 缺 ${command}`).toBeDefined();
+			return hit!;
+		};
+		expect(pick('hyperGit.setActiveChangelist')).toEqual({
+			command: 'hyperGit.setActiveChangelist',
+			when: 'view == hyperGit.commit',
+			group: 'navigation@0.5',
+		});
+		expect(pick('hyperGit.commit.detailTree')).toEqual({
+			command: 'hyperGit.commit.detailTree',
+			when: 'view == hyperGit.commit && !hyperGit.commit.tree',
+			group: 'navigation@0.75',
+		});
+		expect(pick('hyperGit.commit.detailFlat')).toEqual({
+			command: 'hyperGit.commit.detailFlat',
+			when: 'view == hyperGit.commit && hyperGit.commit.tree',
+			group: 'navigation@0.75',
+		});
+	});
+
+	it('commandPalette 三条均限定 Commit 视图聚焦（不全局泄漏）', () => {
+		for (const command of [
+			'hyperGit.setActiveChangelist',
+			'hyperGit.commit.detailTree',
+			'hyperGit.commit.detailFlat',
+		]) {
+			expect(
+				paletteEntries.find((e) => e.command === command),
+				`commandPalette 缺 ${command}`,
+			).toEqual({ command, when: 'view == hyperGit.commit' });
+		}
+	});
+});


### PR DESCRIPTION
## 变更内容

延续 v0.0.17「Graph 视图工具栏上移 VS Code 标题栏」的范式，将 Commit 视图（WebviewView）内两行行内 UI 上移至视图标题栏 Refresh 按钮左侧，**净省两行纵向空间**，并消除 Commit 与 Graph/Branches 视图在切换控件交互上的不一致：

1. **Active Changelist 选择器**（原 `.cl-bar` 行的下拉 + `⋯` 管理菜单）→ 标题栏 `$(checklist)` 图标按钮（`navigation@0.5`），点击弹出 QuickPick：各 changelist 带文件计数、当前活动项 `picked` 预选，分隔线后并入 New / Rename / Delete Changelist… 管理操作（默认列表不可改名/删除）。changelist 为动态数据，静态 submenu 不可行，故采用 `hyperGit.selectRepository`（`$(repo)`）的 QuickPick 范式承载。
2. **List / Tree 段控**（原 files-header 行内）→ 标题栏 `$(list-tree)`/`$(list-flat)` 互斥图标（`navigation@0.75`，context key `hyperGit.commit.tree` 驱动显隐翻转），完全镜像 Graph 视窗 `hyperGit.log.detailTree/detailFlat` 与 Branches 分组切换的交互。
3. **Select All** 复选框随段控同行的头部行一并移除，改为**文件列表容器内 sticky 吸顶首行**（空态隐藏，键盘导航经 `scroll-margin-top` 补偿防遮挡）。
4. 活动 changelist 名常驻 `view.description` 副标题（标题「Commit」同行右侧，镜像 Graph 的仓库路径副标题），保证一眼可见当前提交目标。

## 实现要点

- **mode 事实源上移 host**：`CommitWebviewProvider` 镜像 `log-webview` 范式——构造注入 `workspaceState`，按仓库持久化 `hyperGit.commit.dmode:<repo>`（无记忆回退 flat），激活期 `loadRepoScopedPrefs()` 同步 context key（标题栏按钮先于视图解析渲染），`onDidChangeRepository` 保证多根切库时按钮态与记忆正确重载；切换经 `setDetailMode` → 整态 `pushState` 下发（Commit 的 pushState 全同步幂等，无需 Graph 的定向消息）。
- **协议收缩**：删 `commit/setActive` / `commit/changelistMenu` 消息与 `CommitChangelistItem` 接口及 state 三字段，`CommitViewState` 增 `mode` 字段；清理全仓零引用的 `ICON_ELLIPSIS`。
- **偏好迁移**：旧 webview state（v3）中的 List/Tree 偏好一次性重置为默认 flat（对齐 Graph 迁移先例，CHANGELOG 已注明）；勾选集、目录折叠与提交草稿不受影响。
- **QuickPick 管理链复用**：New/Rename/Delete 经 `executeCommand` 转发既有命令（与原 webview `⋯` 菜单逐字一致），视图刷新经 `registry.onDidChange → refreshAll` 自然驱动。

## 测试与验证

- 新增 `tests/unit/commit-titlebar.test.ts` 清单护栏（锁 context key 拼写、互斥 when 子句、槽位排序与 palette 限定）；集成命令注册清单补 `commit.detailTree/detailFlat`。
- `pnpm run check-types` / `lint` / `test:unit`（44 文件 423 用例）/ `test:integration`（单仓 8 + 多根 4）全绿。
- 文档同步：CHANGELOG [Unreleased]、`commit-view-consolidation.md`、`file-list-group-by-directory.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)